### PR TITLE
Fix for View template links get "Template Does Not Exist" for django >= 1.2

### DIFF
--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -165,6 +165,7 @@ def template_source(request):
             try:
                 source, display_name = loader.load_template_source(template_name)
                 origin = make_origin(display_name, loader, template_name, settings.TEMPLATE_DIRS)
+                break
             except TemplateDoesNotExist:
                 source = "Template Does Not Exist: %s" % (template_name,)
     except ImportError: # Django 1.1 ...


### PR DESCRIPTION
http://github.com/robhudson/django-debug-toolbar/issues/issue/95

just adds a "break" after an exception-less template retrieval.

Cheers,
Tom
