### PR TITLE
Untitled

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -104,7 +104,7 @@ class DebugToolbarMiddleware(object):
                     smart_unicode(response.content), 
                     self.tag,
                     smart_unicode(self.debug_toolbars[request].render_toolbar() + self.tag))
-            if response.get('Content-Length', None):
+            if not response.get('Content-Length', None):
                 response['Content-Length'] = len(response.content)
         del self.debug_toolbars[request]
         return response


### PR DESCRIPTION
tracked down as the cause of a problem in one of my views which was setting a Content-Length -- changed it so django-debug-toolbar only sets content-length if it's not present instead of when it is present.
