### PR TITLE
Exempt SQL Detail Views from CSRF Middleware

### DIFF
--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -145,6 +145,7 @@ def sql_profile(request):
         return render_to_response('debug_toolbar/panels/sql_profile.html', context)
     raise InvalidSQLError("Only 'select' queries are allowed.")
 
+@csrf_exempt
 def template_source(request):
     """
     Return the source of a template, syntax-highlighted by Pygments if


### PR DESCRIPTION
Since the Django 1.2.5 security release (http://www.djangoproject.com/weblog/2011/feb/08/security/), CSRF tokens are also required for AJAX requests. This patch exempts those views from the CSRF checking - safe, considering that the toolbar will only be run when debugging. 
