### PR TITLE
AttributeError in RequestVarsPanel when using FallbackMiddleware

### DIFF
--- a/debug_toolbar/panels/request_vars.py
+++ b/debug_toolbar/panels/request_vars.py
@@ -32,10 +32,14 @@ class RequestVarsDebugPanel(DebugPanel):
             'get': [(k, self.request.GET.getlist(k)) for k in self.request.GET],
             'post': [(k, self.request.POST.getlist(k)) for k in self.request.POST],
             'cookies': [(k, self.request.COOKIES.get(k)) for k in self.request.COOKIES],
-            'view_func': '%s.%s' % (self.view_func.__module__, self.view_func.__name__),
-            'view_args': self.view_args,
-            'view_kwargs': self.view_kwargs
         })
+        if hasattr(self, 'view_func'):
+            context.update({
+                'view_func': '%s.%s' % (self.view_func.__module__, self.view_func.__name__),
+                'view_args': self.view_args,
+                'view_kwargs': self.view_kwargs
+            })
+
         if hasattr(self.request, 'session'):
             context.update({
                 'session': [(k, self.request.session.get(k)) for k in self.request.session.iterkeys()]


### PR DESCRIPTION
Dear Rob,

Just now I ran into a bug in a situation where `process_view` was not called on the debug panels, as the response was actually returned by a middleware which caught an exception. The code I ran into this with is very similar to Django's own FallbackMiddleware in the static contrib module. The result was an `AttributeError` in `request_vars.py` as you're assuming some of `view_func`'s attributes to be present.

So I made a simple patch checking for the existence of `view_func` in this particular panel and updating the context consequently.

Kinds regards,
Mathijs

PS. The error was spotted in a setup running Django 1.3 from SVN.
