### PR TITLE
Fix for missing __name__ attribute when using class based views (i.e. FormWizard)

### DIFF
--- a/debug_toolbar/panels/request_vars.py
+++ b/debug_toolbar/panels/request_vars.py
@@ -28,11 +28,19 @@ class RequestVarsDebugPanel(DebugPanel):
 
     def content(self):
         context = self.context.copy()
+
+        if hasattr(self.view_func, '__name__'):
+            view_name = self.view_func.__name__
+        elif hasattr(self.view_func, '__class__'):
+            view_name = self.view_func.__class__.__name__
+        else:
+            view_name = '<unknown>'
+
         context.update({
             'get': [(k, self.request.GET.getlist(k)) for k in self.request.GET],
             'post': [(k, self.request.POST.getlist(k)) for k in self.request.POST],
             'cookies': [(k, self.request.COOKIES.get(k)) for k in self.request.COOKIES],
-            'view_func': '%s.%s' % (self.view_func.__module__, self.view_func.__name__),
+            'view_func': '%s.%s' % (self.view_func.__module__, view_name),
             'view_args': self.view_args,
             'view_kwargs': self.view_kwargs
         })


### PR DESCRIPTION
A small change to the `content` method in the **RequestVarsDebugPanel**, so that if the `view_func` doesn't have a `__name__` attribute, the `__class__.__name__` will be tried instead.

Otherwise, `<unknown>` is used to save an `AttributeError` being raised if neither exist.

This issue became apparent when using a form wizard, though I think Django 1.3's class-based views should be safe due to the way they are instantiated (`ViewClass.as_view()`).
