### PR TITLE
Fixes KeyError when Content-Type is forcibly removed from the HttpResponse.

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -99,7 +99,7 @@ class DebugToolbarMiddleware(object):
         if response.status_code == 200:
             for panel in self.debug_toolbars[request].panels:
                 panel.process_response(request, response)
-            if response['Content-Type'].split(';')[0] in _HTML_TYPES:
+            if response.get('Content-Type', None) and response['Content-Type'].split(';')[0] in _HTML_TYPES:
                 response.content = replace_insensitive(
                     smart_unicode(response.content), 
                     self.tag,


### PR DESCRIPTION
Admittedly this is an edge case since django set's a content-type by default if you don't provide it, but it is possible, and sometimes desirable to remove it after the fact (When returning X-Accel-Redirect or similar headers).  When it is removed, debug_toolbar throws a KeyError when attempting to check for an html content-type.
