### PR TITLE
Display execution time after query

### DIFF
--- a/debug_toolbar/management/commands/debugsqlshell.py
+++ b/debug_toolbar/management/commands/debugsqlshell.py
@@ -9,12 +9,12 @@ from debug_toolbar.utils import sqlparse
 
 class PrintQueryWrapper(util.CursorDebugWrapper):
     def execute(self, sql, params=()):
-        starttime = datetime.today()
+        starttime = datetime.now()
         try:
             return self.cursor.execute(sql, params)
         finally:
             raw_sql = self.db.ops.last_executed_query(self.cursor, sql, params)
-            execution_time = datetime.today() - starttime
+            execution_time = datetime.now() - starttime
             print sqlparse.format(raw_sql, reindent=True)
             print
             print 'Execution time: %fs' % execution_time.total_seconds()


### PR DESCRIPTION
I found the debugsqlshell really useful to compare different queries, but I also wanted to be able to time them, in order to tell which one will execute faster.

So I added a simple timing mechanism that uses a timedelta. I don't know whether there is a cleaner way, e.g. by retrieving the execution time directly from the query/database, but it seems to work pretty well this way.
