### PR TITLE
Caught AttributeError while rendering: 'Template' object has no attribute 'origin'

### DIFF
--- a/debug_toolbar/panels/template.py
+++ b/debug_toolbar/panels/template.py
@@ -78,7 +78,7 @@ class TemplateDebugPanel(DebugPanel):
             # Skip templates that we are generating through the debug toolbar.
             if template.name and template.name.startswith('debug_toolbar/'):
                 continue
-            if template.name == "<Unknown Template>":
+            if not hasattr(template, 'origin'):
                 continue
             if template.origin and template.origin.name:
                 template.origin_name = template.origin.name


### PR DESCRIPTION
Fixes TemplateDebugPanel iterating over an unknown template without origin or name

Some applications render Templates that are dynamically generated using `Template` object, those don't have origin or name, so I guess the best is to skip them as they are usually used for small things. Somebody reported this here: 
http://code.google.com/p/django-endless-pagination/issues/detail?id=7#c2

It breaks with current django-uni-form master too.

I was willing to add a test for this bug, but the middleware is broken in current master branch (test_middleware fails) and it turned out to be a nightmare. I think testing should be more isolated. Panels get loaded with the information of the project within you run tests. Maybe having test_settings and a small test_project would help.

Regards,
Miguel
