### PR TITLE
Fixing UnicodeEncodeError in sql panel

### DIFF
--- a/debug_toolbar/panels/sql.py
+++ b/debug_toolbar/panels/sql.py
@@ -194,7 +194,7 @@ class SQLDebugPanel(DebugPanel):
                 stacktrace = []
                 for frame in query['stacktrace']:
                     params = map(escape, frame[0].rsplit('/', 1) + list(frame[1:]))
-                    stacktrace.append('<span class="path">{0}/</span><span class="file">{1}</span> in <span class="func">{3}</span>(<span class="lineno">{2}</span>)\n  <span class="code">{4}</span>'.format(*params))
+                    stacktrace.append(u'<span class="path">{0}/</span><span class="file">{1}</span> in <span class="func">{3}</span>(<span class="lineno">{2}</span>)\n  <span class="code">{4}</span>'.format(*params))
                 query['stacktrace'] = mark_safe('\n'.join(stacktrace))
                 i += 1
 


### PR DESCRIPTION
Error was detonated by this statement:

<pre>
messages.add_message(request, messages.INFO, u'Su opinión ha sido guardada, gracias')
</pre>


This is the error thrown:

<pre>
Caught UnicodeEncodeError while rendering: ('ascii', u'messages.add_message(request, messages.INFO, u&#39;Su opini\xf3n ha sido guardada, gracias.&#39;)', 59, 60, 'ordinal not in range(128)')
</pre>


This little patch fixes the problem, regards
Miguel
