### PR TITLE
Save a clone of template context instead of the original

### DIFF
--- a/debug_toolbar/panels/template.py
+++ b/debug_toolbar/panels/template.py
@@ -47,6 +47,7 @@ class TemplateDebugPanel(DebugPanel):
         template_rendered.connect(self._store_template_info)
 
     def _store_template_info(self, sender, **kwargs):
+        kwargs['context'] = kwargs['context'].__copy__()
         self.templates.append(kwargs)
 
     def nav_title(self):


### PR DESCRIPTION
Django 1.3 seems to alter templates' rendering contexts after the fact, so just make our saved context a clone of the original to be sure we keep all of it. Fixes #159.
