### PR TITLE
Fixed error with i18n url patterns using Django trunk

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -34,14 +34,14 @@ class DebugToolbarMiddleware(object):
     on outgoing response.
     """
     debug_toolbars = {}
-    
+
     @classmethod
     def get_current(cls):
         return cls.debug_toolbars.get(thread.get_ident())
 
     def __init__(self):
         self._urlconfs = {}
-        
+
         # Set method to use to decide to show toolbar
         self.show_toolbar = self._show_toolbar # default
 
@@ -78,22 +78,20 @@ class DebugToolbarMiddleware(object):
             urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)
             if isinstance(urlconf, basestring):
                 urlconf = import_module(getattr(request, 'urlconf', settings.ROOT_URLCONF))
-                
+
             if urlconf not in self._urlconfs:
                 new_urlconf = imp.new_module('urlconf')
                 new_urlconf.urlpatterns = debug_toolbar.urls.urlpatterns + \
-                    patterns('',
-                        ('', include(urlconf)),
-                    )
-                
+                        urlconf.urlpatterns
+
                 if hasattr(urlconf, 'handler404'):
                     new_urlconf.handler404 = urlconf.handler404
                 if hasattr(urlconf, 'handler500'):
                     new_urlconf.handler500 = urlconf.handler500
 
                 self._urlconfs[urlconf] = new_urlconf
-            
-            request.urlconf = self._urlconfs[urlconf] 
+
+            request.urlconf = self._urlconfs[urlconf]
 
             toolbar = DebugToolbar(request)
             for panel in toolbar.panels:
@@ -130,7 +128,7 @@ class DebugToolbarMiddleware(object):
             for panel in toolbar.panels:
                 panel.process_response(request, response)
             response.content = replace_insensitive(
-                smart_unicode(response.content), 
+                smart_unicode(response.content),
                 self.tag,
                 smart_unicode(toolbar.render_toolbar() + self.tag))
             if response.get('Content-Length', None):


### PR DESCRIPTION
It is forbidden to include a i18n pattern. This pull request is a fix for this. 

Thank you!
## 

Jeffrey Gelens
