### PR TITLE
Make stacktraces optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,10 @@ The debug toolbar has two settings that can be set in `settings.py`:
    * `TAG`: If set, this will be the tag to which debug_toolbar will attach the 
      debug toolbar. Defaults to 'body'.
 
+   * `ENABLE_STACKTRACES`: If set, this will show stacktraces for SQL queries.
+     Enabling stacktraces can increase the CPU time used when executing
+     queries. Defaults to True.
+
    Example configuration::
 
 	def custom_show_toolbar(request):
@@ -135,6 +139,7 @@ The debug toolbar has two settings that can be set in `settings.py`:
 	    'EXTRA_SIGNALS': ['myproject.signals.MySignal'],
 	    'HIDE_DJANGO_SQL': False,
 	    'TAG': 'div',
+	    'ENABLE_STACKTRACES' : True,
 	}
 
 `debugsqlshell`

--- a/debug_toolbar/utils/tracking/db.py
+++ b/debug_toolbar/utils/tracking/db.py
@@ -71,7 +71,12 @@ class NormalCursorWrapper(object):
         finally:
             stop = datetime.now()
             duration = ms_from_timedelta(stop - start)
-            stacktrace = tidy_stacktrace(reversed(inspect.stack()))
+            enable_stacktraces = getattr(settings, 'DEBUG_TOOLBAR_CONFIG', {}) \
+                                    .get('ENABLE_STACKTRACES', True)
+            if enable_stacktraces:
+                stacktrace = tidy_stacktrace(reversed(inspect.stack()))
+            else:
+                stacktrace = []
             _params = ''
             try:
                 _params = simplejson.dumps([force_unicode(x, strings_only=True) for x in params])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -204,6 +204,28 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertTrue('duration' in query[1])
         self.assertTrue('stacktrace' in query[1])
 
+        # ensure the stacktrace is populated
+        self.assertTrue(len(query[1]['stacktrace']) > 0)
+
+    def test_disable_stacktraces(self):
+        panel = self.toolbar.get_panel(SQLDebugPanel)
+        self.assertEquals(len(panel._queries), 0)
+       
+        with Settings(DEBUG_TOOLBAR_CONFIG={ 'ENABLE_STACKTRACES' : False }):
+            list(User.objects.all())
+        
+        # ensure query was logged
+        self.assertEquals(len(panel._queries), 1)
+        query = panel._queries[0]
+        self.assertEquals(query[0], 'default')
+        self.assertTrue('sql' in query[1])
+        self.assertTrue('duration' in query[1])
+        self.assertTrue('stacktrace' in query[1])
+
+        # ensure the stacktrace is empty
+        self.assertEquals([], query[1]['stacktrace'])
+
+
 class TemplatePanelTestCase(BaseTestCase):
     def test_queryset_hook(self):
         template_panel = self.toolbar.get_panel(TemplateDebugPanel)


### PR DESCRIPTION
Fixes issue #218

Stacktraces can now be enabled / disabled via ENABLE_STACKTRACES in DEBUG_TOOLBAR_CONFIG
