### PR TITLE
Fix for error 'Settings' object has no attribute 'DATABASE_ENGINE' (#208)

### DIFF
--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -82,7 +82,10 @@ def sql_explain(request):
         params = simplejson.loads(params)
         cursor = connections[alias].cursor()
 
-        if settings.DATABASE_ENGINE == "sqlite3":
+        conn = connections[alias].connection
+        engine = conn.__class__.__module__.split('.', 1)[0]
+
+        if engine == "sqlite3":
             # SQLite's EXPLAIN dumps the low-level opcodes generated for a query;
             # EXPLAIN QUERY PLAN dumps a more human-readable summary
             # See http://www.sqlite.org/lang_explain.html for details

--- a/runtests.py
+++ b/runtests.py
@@ -7,10 +7,11 @@ from django.conf import settings, global_settings
 
 if not settings.configured:
     settings.configure(
-        DATABASE_ENGINE='sqlite3',
-        # HACK: this fixes our threaded runserver remote tests
-        # DATABASE_NAME='test_sentry',
-        # TEST_DATABASE_NAME='test_sentry',
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+            }
+        },
         INSTALLED_APPS=[
             'django.contrib.auth',
             'django.contrib.admin',
@@ -30,7 +31,7 @@ if not settings.configured:
         SITE_ID=1,
     )
 
-from django.test.simple import run_tests
+from django.test.simple import DjangoTestSuiteRunner
 
 def runtests(*test_args, **kwargs):
     if 'south' in settings.INSTALLED_APPS:
@@ -41,7 +42,8 @@ def runtests(*test_args, **kwargs):
         test_args = ['tests']
     parent = dirname(abspath(__file__))
     sys.path.insert(0, parent)
-    failures = run_tests(test_args, verbosity=kwargs.get('verbosity', 1), interactive=kwargs.get('interactive', False), failfast=kwargs.get('failfast'))
+    test_runner = DjangoTestSuiteRunner(verbosity=kwargs.get('verbosity', 1), interactive=kwargs.get('interactive', False), failfast=kwargs.get('failfast'))
+    failures = test_runner.run_tests(test_args)
     sys.exit(failures)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Error on fresh installed master while trying to view query explain:

<pre>
lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  111.                         response = callback(request, *callback_args, **callback_kwargs)
File "lib/python2.7/site-packages/debug_toolbar/views.py" in sql_explain
  85.         if settings.DATABASE_ENGINE == "sqlite3":
File "lib/python2.7/site-packages/django/utils/functional.py" in inner
  173.         return func(self._wrapped, *args)

Exception Type: AttributeError at /__debug__/sql_explain/
Exception Value: 'Settings' object has no attribute 'DATABASE_ENGINE'
</pre>
