### PR TITLE
Convert settings.INSTALLED_APPS to list before concatenating django.

### DIFF
--- a/debug_toolbar/panels/version.py
+++ b/debug_toolbar/panels/version.py
@@ -30,7 +30,7 @@ class VersionDebugPanel(DebugPanel):
     def process_response(self, request, response):
         versions = {}
         versions['Python'] = '%d.%d.%d' % sys.version_info[:3]
-        for app in settings.INSTALLED_APPS + ['django']:
+        for app in list(settings.INSTALLED_APPS) + ['django']:
             name = app.split('.')[-1].replace('_', ' ').capitalize()
             __import__(app)
             app = sys.modules[app]


### PR DESCRIPTION
According to the Django documentation settings.INSTALLED_APPS is a
tuple. To go for sure that only list + list are concatenated,
settings.INSTALLED_APPS is converted to list type before adding
['django'].
