### PR TITLE
Don't blow up if INSTALLED_APPS is a tuple

### DIFF
--- a/debug_toolbar/panels/version.py
+++ b/debug_toolbar/panels/version.py
@@ -30,7 +30,7 @@ class VersionDebugPanel(DebugPanel):
     def process_response(self, request, response):
         versions = {}
         versions['Python'] = '%d.%d.%d' % sys.version_info[:3]
-        for app in settings.INSTALLED_APPS + ['django']:
+        for app in list(settings.INSTALLED_APPS) + ['django']:
             name = app.split('.')[-1].replace('_', ' ').capitalize()
             __import__(app)
             app = sys.modules[app]


### PR DESCRIPTION
Since r17158 in Django trunk, INSTALLED_APPS is now not always co-erced to
a list. In my projects I prefer to have INSTALLED_APPS as a tuple as it
reinforces that it is not modifiable at runtime. However, this blows up
in the VersionDebugPanel as it currently assumes it is a list.

Signed-off-by: Chris Lamb lamby@debian.org
