### PR TITLE
Debug page looks broken in RTL pages

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -4,7 +4,7 @@
 {{ css }}
 </style>
 <script type="text/javascript">{{ js }}</script>
-<div id="djDebug" style="display:none;">
+<div id="djDebug" style="display:none;" dir="ltr">
 	<div style="display:none;" id="djDebugToolbar">
 		<ul id="djDebugPanelList">
 			{% if panels %}


### PR DESCRIPTION
Adding dir=ltr on #djDebug fixes this.
