### PR TITLE
Fix UnicodeDecodeError on getting template context representations for templates panel.

### DIFF
--- a/debug_toolbar/panels/template.py
+++ b/debug_toolbar/panels/template.py
@@ -83,6 +83,8 @@ class TemplateDebugPanel(DebugPanel):
                             pformat(value)  # this MAY trigger a db query
                         except SQLQueryTriggered:
                             temp_layer[key] = '<<triggers database query>>'
+                        except UnicodeEncodeError:
+                            temp_layer[key] = '<<unicode encode error>>'
                         else:
                             temp_layer[key] = value
                         finally:


### PR DESCRIPTION
Found this error after debug toolbar was upgraded. I understand that it's my fault in **str**/**unicode** declaration for models, but debug toolbar was created to help fix out mistakes except produce new one :)
