### PR TITLE
Fix python 2.5 compatibility (no named tuple and Traceback)

### DIFF
--- a/debug_toolbar/utils/__init__.py
+++ b/debug_toolbar/utils/__init__.py
@@ -129,7 +129,10 @@ def getframeinfo(frame, context=1):
     else:
         lines = index = None
 
-    return inspect.Traceback(filename, lineno, frame.f_code.co_name, lines, index)
+    if hasattr(inspect, 'Traceback'):
+        return inspect.Traceback(filename, lineno, frame.f_code.co_name, lines, index)
+    else:
+        return (filename, lineno, frame.f_code.co_name, lines, index)
 
 def get_stack(context=1):
     """


### PR DESCRIPTION
To fix an issue https://github.com/django-debug-toolbar/django-debug-toolbar/issues/248
