### PR TITLE
Ensure that toolbar templates get the injected urlconf.

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -127,7 +127,8 @@ class DebugToolbarMiddleware(object):
            response.get('Content-Type', '').split(';')[0] in _HTML_TYPES:
             for panel in toolbar.panels:
                 panel.process_response(request, response)
-            set_urlconf(request.urlconf)
+            if getattr(request, 'urlconf', None):
+                set_urlconf(request.urlconf)
             response.content = replace_insensitive(
                 smart_unicode(response.content),
                 self.tag,


### PR DESCRIPTION
This change allows one to use [django-debug-toolbar-user-panel](https://github.com/playfire/django-debug-toolbar-user-panel) without needing to modify the root urlconf.  Django resets the default urlconf before the response middleware is run, so there is no default urlconf for reverse to lookup view names in.  This is normally fine, but django-debug-toolbar does some template rendering in the response middleware.  Also, with this change django-debug-toolbar may now use {% url viewname %} instead of hardcoded url paths.
