### PR TITLE
SQL panel collapses query with multiple SELECT...FROM wrong

### DIFF
--- a/debug_toolbar/panels/sql.py
+++ b/debug_toolbar/panels/sql.py
@@ -225,7 +225,7 @@ class BoldKeywordFilter(sqlparse.filters.Filter):
 
 
 def swap_fields(sql):
-    return re.sub('SELECT</strong> (.*) <strong>FROM', 'SELECT</strong> <a class="djDebugUncollapsed djDebugToggle" href="#">&bull;&bull;&bull;</a> ' +
+    return re.sub('SELECT</strong> (.*?) <strong>FROM', 'SELECT</strong> <a class="djDebugUncollapsed djDebugToggle" href="#">&bull;&bull;&bull;</a> ' +
         '<a class="djDebugCollapsed djDebugToggle" href="#">\g<1></a> <strong>FROM', sql)
 
 


### PR DESCRIPTION
The regex should not match greedy, otherwise a query with multiple "SELECT... FROM" statements is going to get unreadable. This patch fixes it and works nice with longer, nested SQL statements.
