### PR TITLE
Don't explode if a project uses tuple'd urlpatterns

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -82,7 +82,7 @@ class DebugToolbarMiddleware(object):
             if urlconf not in self._urlconfs:
                 new_urlconf = imp.new_module('urlconf')
                 new_urlconf.urlpatterns = debug_toolbar.urls.urlpatterns + \
-                        urlconf.urlpatterns
+                        list(urlconf.urlpatterns)
 
                 if hasattr(urlconf, 'handler404'):
                     new_urlconf.handler404 = urlconf.handler404


### PR DESCRIPTION
This fixes https://github.com/django-debug-toolbar/django-debug-toolbar/issues/235. The toolbar will now work correctly if the Django project's urlpatterns are a tuple, rather than a list.

(We do this because we have lots of apps that re-use another app's URLConf - we tuple-ise the urlpatterns to avoid those apps accidentally mutating the base app's URLs.)
