### PR TITLE
Set browser focus on redirect link 

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/redirect.html
+++ b/debug_toolbar/templates/debug_toolbar/redirect.html
@@ -4,9 +4,12 @@
 </head>
 <body>
 <h1>HttpResponseRedirect</h1>
-<p>{% trans 'Location' %}: <a href="{{ redirect_to }}">{{ redirect_to }}</a></p>
+<p>{% trans 'Location' %}: <a id="redirect_to" href="{{ redirect_to }}">{{ redirect_to }}</a></p>
 <p class="notice">
 	{% trans "The Django Debug Toolbar has intercepted a redirect to the above URL for debug viewing purposes.  You can click the above link to continue with the redirect as normal.  If you'd like to disable this feature, set the <code>DEBUG_TOOLBAR_CONFIG</code> dictionary's key <code>INTERCEPT_REDIRECTS</code> to <code>False</code>." %}
 </p>
+<script type="text/javascript">
+    document.getElementById('redirect_to').focus();
+</script>
 </body>
 </html>


### PR DESCRIPTION
This commit sets the browser focus on the redirect link so you can hit enter to quickly continue through redirect pages.

Thanks,
Alex
