### PR TITLE
Propagate handler403 value when wrapping urlconf

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -85,7 +85,7 @@ class DebugToolbarMiddleware(object):
                         list(urlconf.urlpatterns)
 
                 if hasattr(urlconf, 'handler403'):
-                    new_urlconf.handler404 = urlconf.handler403
+                    new_urlconf.handler403 = urlconf.handler403
                 if hasattr(urlconf, 'handler404'):
                     new_urlconf.handler404 = urlconf.handler404
                 if hasattr(urlconf, 'handler500'):


### PR DESCRIPTION
This is just a minor patch to allow overriding handler403 value while using the toolbar.
