### PR TITLE
Do not intercept redirects for ajax requests

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -115,7 +115,7 @@ class DebugToolbarMiddleware(object):
         if not toolbar:
             return response
         if isinstance(response, HttpResponseRedirect):
-            if not toolbar.config['INTERCEPT_REDIRECTS']:
+            if not toolbar.config['INTERCEPT_REDIRECTS'] or request.is_ajax():
                 return response
             redirect_to = response.get('Location', None)
             if redirect_to:


### PR DESCRIPTION
Debug toolbar should never intercept redirects for ajax requests.
