### PR TITLE
Temporary solution for problems with dual View call for ProfilingDebugPanel

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -105,8 +105,12 @@ class DebugToolbarMiddleware(object):
         toolbar = self.__class__.debug_toolbars.get(thread.get_ident())
         if not toolbar:
             return
+        result = None
         for panel in toolbar.panels:
-            panel.process_view(request, view_func, view_args, view_kwargs)
+            response = panel.process_view(request, view_func, view_args, view_kwargs)
+            if response:
+                result = response
+        return result
 
     def process_response(self, request, response):
         __traceback_hide__ = True


### PR DESCRIPTION
Related issues and pull requests:
https://github.com/django-debug-toolbar/django-debug-toolbar/pull/204
https://github.com/django-debug-toolbar/django-debug-toolbar/issues/267
https://github.com/django-debug-toolbar/django-debug-toolbar/issues/209

Soon I will finish the panel that will gather all the statistics on calls, not only for the View.
It will start in process_request and will stop in process_response, as well as will drawing a graph and will provide a file "*.profile" to download.
