### PR TITLE
prevent crash due to SQLDebugPanel when transaction is in error state

### DIFF
--- a/debug_toolbar/utils/tracking/db.py
+++ b/debug_toolbar/utils/tracking/db.py
@@ -146,10 +146,11 @@ class NormalCursorWrapper(object):
             }
 
             if engine == 'psycopg2':
+                from psycopg2.extensions import TRANSACTION_STATUS_INERROR
                 params.update({
                     'trans_id': self.logger.get_transaction_id(alias),
                     'trans_status': conn.get_transaction_status(),
-                    'iso_level': conn.isolation_level,
+                    'iso_level': conn.isolation_level if not conn.get_transaction_status() == TRANSACTION_STATUS_INERROR else "",
                     'encoding': conn.encoding,
                 })
 


### PR DESCRIPTION
fix for https://github.com/django-debug-toolbar/django-debug-toolbar/issues/230

if isolation_level is looked up while transaction is in an error state, an exception is thrown, which eats up the original exception that is never shown
