### PR TITLE
Enabling html-formatting in logger panel

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/logger.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/logger.html
@@ -16,7 +16,7 @@
 					<td>{{ record.level }}</td>
 					<td>{{ record.time|date:"h:i:s m/d/Y" }}</td>
 					<td>{{ record.channel|default:"-" }}</td>
-					<td>{{ record.message }}</td>
+					<td>{{ record.message|linebreaksbr }}</td>
 					<td>{{ record.file }}:{{ record.line }}</td>
 				</tr>
 			{% endfor %}


### PR DESCRIPTION
Sometimes I need log something like that:
`logging.debug('Result is:\n%s' % pformat({'one': 1, 'two': 2}))`
