### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,9 @@ The debug toolbar has two settings that can be set in `settings.py`:
 	    'ENABLE_STACKTRACES' : True,
 	}
 
+#. note: HTML page (your templates) must contain closed body tag, meta tag with content="text/html.
+   toolbar wont display itself in other pages
+
 `debugsqlshell`
 ===============
 The following is sample output from running the `debugsqlshell` management


### PR DESCRIPTION
adding a note about templates that debug_toolbar can display it self on
