### PR TITLE
prevent debug toolbar from inserting itself into a partial template

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -116,9 +116,7 @@ class DebugToolbarMiddleware(object):
         __traceback_hide__ = True
         ident = thread.get_ident()
         toolbar = self.__class__.debug_toolbars.get(ident)
-        if not toolbar:
-            return response
-        if 'XMLHttpRequest' in request.META.get('HTTP_X_REQUESTED_WITH', ''):
+        if not toolbar or request.is_ajax():
             return response
         if isinstance(response, HttpResponseRedirect):
             if not toolbar.config['INTERCEPT_REDIRECTS']:


### PR DESCRIPTION
called via ajax. This also prevents overwriting the current toolbar on the page and rendering the event listeners on toolbar panel buttons useless.
