### PR TITLE
Fix for blocktrans syntax change breaking debug_toolbar in Django 1.2

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<h4>{% blocktrans count template_count=template_dirs|length %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
+<h4>{% blocktrans count template_dirs|length as template_count %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
 {% if template_dirs %}
 	<ol>
 	{% for template in template_dirs %}
@@ -10,7 +10,7 @@
 	<p>{% trans "None" %}</p>
 {% endif %}
 
-<h4>{% blocktrans count template_count=templates|length %}Template{% plural %}Templates{% endblocktrans %}</h4>
+<h4>{% blocktrans count templates|length as template_count %}Template{% plural %}Templates{% endblocktrans %}</h4>
 {% if templates %}
 <dl>
 {% for template in templates %}
@@ -28,7 +28,7 @@
 	<p>{% trans 'None' %}</p>
 {% endif %}
 
-<h4>{% blocktrans count context_processors_count=context_processors|length %}Context processor{% plural %}Context processors{% endblocktrans %}</h4>
+<h4>{% blocktrans count context_processors|length as context_processors_count %}Context processor{% plural %}Context processors{% endblocktrans %}</h4>
 {% if context_processors %}
 <dl>
 {% for key, value in context_processors.iteritems %}


### PR DESCRIPTION
Commit 2870dcdf320a7b0864cd59e775111a2618d3f1ec changed blocktrans in templates/debug_toolbar/panels/templates.htm to use the compact syntax introduced in Django 1.3.  This commit changes it back so blocktrans works in Django 1.2 as well as 1.3 and 1.4
