### PR TITLE
Added constraint for None parameters.

### DIFF
--- a/debug_toolbar/utils/tracking/db.py
+++ b/debug_toolbar/utils/tracking/db.py
@@ -80,6 +80,9 @@ class NormalCursorWrapper(object):
         if isinstance(params, dict):
             return dict((key, self._quote_expr(value))
                             for key, value in params.iteritems())
+        elif params is None:
+            return []
+
         return map(self._quote_expr, params)
 
     def execute(self, sql, params=()):


### PR DESCRIPTION
`Execute` methods accept `None` as params and that wasn't supported
by the tracking module, that was passing into to a map function.
