### PR TITLE
Fix static assets

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -3,7 +3,7 @@
 @media print { #djDebug {display:none;}}
 </style>
 <link rel="stylesheet" href="{{ STATIC_URL }}debug_toolbar/css/toolbar.min.css" type="text/css">
-<script type="text/javascript" src="{{ STATIC_URL }}debug_toolbar/css/toolbar.min.js"></script>
+<script type="text/javascript" src="{{ STATIC_URL }}debug_toolbar/js/toolbar.min.js"></script>
 <div id="djDebug" style="display:none;" dir="ltr">
 	<div style="display:none;" id="djDebugToolbar">
 		<ul id="djDebugPanelList">

--- a/debug_toolbar/toolbar/loader.py
+++ b/debug_toolbar/toolbar/loader.py
@@ -26,6 +26,7 @@ class DebugToolbar(object):
         self.template_context = {
             'BASE_URL': base_url,  # for backwards compatibility
             'DEBUG_TOOLBAR_MEDIA_URL': self.config.get('MEDIA_URL'),
+            'STATIC_URL': settings.STATIC_URL,
         }
 
         self.load_panels()
@@ -55,8 +56,6 @@ class DebugToolbar(object):
         """
         Renders the overall Toolbar with panels inside.
         """
-        media_path = os.path.join(os.path.dirname(__file__), os.pardir, 'media', 'debug_toolbar')
-
         context = self.template_context.copy()
         context.update({
             'panels': self.panels,


### PR DESCRIPTION
Should be pretty obvious.
- `STATIC_URL` wasn't accessible from within the template since it's not using a `RequestContext`
- Referenced the wrong path for the js file
