### PR TITLE
fix STATIC_URL for toolbar templates, fix toolbar.min.js url

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -3,7 +3,7 @@
 @media print { #djDebug {display:none;}}
 </style>
 <link rel="stylesheet" href="{{ STATIC_URL }}debug_toolbar/css/toolbar.min.css" type="text/css">
-<script type="text/javascript" src="{{ STATIC_URL }}debug_toolbar/css/toolbar.min.js"></script>
+<script type="text/javascript" src="{{ STATIC_URL }}debug_toolbar/js/toolbar.min.js"></script>
 <div id="djDebug" style="display:none;" dir="ltr">
 	<div style="display:none;" id="djDebugToolbar">
 		<ul id="djDebugPanelList">

--- a/debug_toolbar/toolbar/loader.py
+++ b/debug_toolbar/toolbar/loader.py
@@ -26,6 +26,7 @@ class DebugToolbar(object):
         self.template_context = {
             'BASE_URL': base_url,  # for backwards compatibility
             'DEBUG_TOOLBAR_MEDIA_URL': self.config.get('MEDIA_URL'),
+            'STATIC_URL': getattr(settings, 'STATIC_URL'),
         }
 
         self.load_panels()


### PR DESCRIPTION
Fix two problems with static files.
1. toolbar.min.js relative path at base.html
2. STATIC_URL var at toolbar templates doesn't exists
