### PR TITLE
Prevent PendingDeprecationWarning on Django 1.4

### DIFF
--- a/debug_toolbar/urls.py
+++ b/debug_toolbar/urls.py
@@ -4,7 +4,10 @@ URLpatterns for the debug toolbar.
 These should not be loaded explicitly; the debug toolbar middleware will patch
 this into the urlconf for the request.
 """
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 
 _PREFIX = '__debug__'
 


### PR DESCRIPTION
When using tests with Django 1.4 there's a PendingDeprecationWarning due to changes in django.conf.urls
