### PR TITLE
psycopg2: Avoid causing a 2nd error in an aborted transaction

### DIFF
--- a/debug_toolbar/utils/tracking/db.py
+++ b/debug_toolbar/utils/tracking/db.py
@@ -149,9 +149,15 @@ class NormalCursorWrapper(object):
                 params.update({
                     'trans_id': self.logger.get_transaction_id(alias),
                     'trans_status': conn.get_transaction_status(),
-                    'iso_level': conn.isolation_level,
                     'encoding': conn.encoding,
                 })
+
+                # This fails when a query aborted the transaction. Avoid
+                # causing a 2nd exception and hiding the real error
+                try:
+                    params['iso_level'] = conn.isolation_level
+                except Exception:
+                    pass
 
             # We keep `sql` to maintain backwards compatibility
             self.logger.record(**params)


### PR DESCRIPTION
Asking for connection isolation_level results in a query executed by
psycopg2. However, all queries ran in an aborted transaction will result
in a new error.

This is my biggest annoyance with the debug toolbar -- whenever a query
causes an aborted transaction, the original error is hidden and a new
exception is thrown:

```
InternalError: current transaction is aborted, commands ignored until
end of transaction block
```
