### PR TITLE
Fix doc for show_toolbar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ The debug toolbar has two settings that can be set in ``settings.py``:
      If not set or set to None, the debug_toolbar
      middleware will use its built-in show_toolbar method for determining whether
      the toolbar should show or not. The default checks are that DEBUG must be
-     set to True or the IP of the request must be in INTERNAL_IPS. You can
+     set to True and the IP of the request must be in INTERNAL_IPS. You can
      provide your own method for displaying the toolbar which contains your
      custom logic. This method should return True or False.
 


### PR DESCRIPTION
In the code, the default is that DEBUG must be set **and** IP must be in INTERAL_IPS.
