### PR TITLE
Avoid importing `django.conf.urls.defaults` on django 1.4+

### DIFF
--- a/debug_toolbar/urls.py
+++ b/debug_toolbar/urls.py
@@ -4,7 +4,10 @@ URLpatterns for the debug toolbar.
 These should not be loaded explicitly; the debug toolbar middleware will patch
 this into the urlconf for the request.
 """
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import patterns, url
+except ImportError: # django < 1.4
+    from django.conf.urls.defaults import patterns, url
 
 _PREFIX = '__debug__'
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,14 +4,17 @@ URLpatterns for the debug toolbar.
 These should not be loaded explicitly; the debug toolbar middleware will patch
 this into the urlconf for the request.
 """
-from django.conf.urls.defaults import *
 from django.contrib import admin
+try:
+    from django.conf.urls import patterns, url
+except ImportError: # django < 1.4
+    from django.conf.urls.defaults import patterns, url
 
 admin.autodiscover()
 
 urlpatterns = patterns('',
     # This pattern should be last to ensure tests still work
-    url(r'^resolving1/(.+)/(.+)/$', 'tests.views.resolving_view', name = 'positional-resolving'),
+    url(r'^resolving1/(.+)/(.+)/$', 'tests.views.resolving_view', name='positional-resolving'),
     url(r'^resolving2/(?P<arg1>.+)/(?P<arg2>.+)/$', 'tests.views.resolving_view'),
     url(r'^resolving3/(.+)/$', 'tests.views.resolving_view', { 'arg2' : 'default' }),
     url(r'^execute_sql/$', 'tests.views.execute_sql'),


### PR DESCRIPTION
`django.conf.urls.defaults` is deprecated since django 1.4+ and completely removed as of 1.6.
