### PR TITLE
prevent crash due to UnicodeDecodeError in the TemplatePanel

### DIFF
--- a/debug_toolbar/panels/template.py
+++ b/debug_toolbar/panels/template.py
@@ -112,10 +112,17 @@ class TemplateDebugPanel(DebugPanel):
         self.request = request
 
     def process_response(self, request, response):
+
+        def format(item):
+            try:
+                return pformat(item)
+            except UnicodeDecodeError:
+                return ""
+
         context_processors = dict(
             [
                 ("%s.%s" % (k.__module__, k.__name__),
-                    pformat(k(self.request))) for k in get_standard_processors()
+                    format(k(self.request))) for k in get_standard_processors()
             ]
         )
         template_context = []


### PR DESCRIPTION
Hi, please accept my pull request - this hotfix prevent crash when TemplatePanel used on windows cyrillic locale. In fact, this is a bug in PrettyPrint/Python 2, and it will be not relevant in Python 3.
Tnx.
