### PR TITLE
First bunch of fixes to make debug-toolbar work with Python 3

### DIFF
--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -3,5 +3,5 @@ __all__ = ('VERSION',)
 try:
     VERSION = __import__('pkg_resources') \
         .get_distribution('django-debug-toolbar').version
-except Exception, e:
+except Exception as e:
     VERSION = 'unknown'

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -2,12 +2,18 @@
 Debug Toolbar middleware
 """
 import imp
-import thread
-
+try: # python 3 compat
+    import thread
+except ImportError:
+    import threading as thread
+import sys
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render_to_response
-from django.utils.encoding import smart_unicode
+try: # python 3 compat
+    from django.utils.encoding import smart_unicode
+except ImportError:
+    from django.utils.encoding import smart_text as smart_unicode
 from django.utils.importlib import import_module
 
 import debug_toolbar.urls
@@ -76,7 +82,8 @@ class DebugToolbarMiddleware(object):
         __traceback_hide__ = True
         if self.show_toolbar(request):
             urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)
-            if isinstance(urlconf, basestring):
+            # the below condition is for python 3 compat
+            if isinstance(urlconf, basestring if sys.version_info[0] < 3 else str):
                 urlconf = import_module(getattr(request, 'urlconf', settings.ROOT_URLCONF))
 
             if urlconf not in self._urlconfs:

--- a/debug_toolbar/panels/sql.py
+++ b/debug_toolbar/panels/sql.py
@@ -25,7 +25,6 @@ def cursor(func, self):
 
     return CursorWrapper(result, self, logger=logger)
 
-
 def get_isolation_level_display(engine, level):
     if engine == 'psycopg2':
         import psycopg2.extensions

--- a/debug_toolbar/toolbar/loader.py
+++ b/debug_toolbar/toolbar/loader.py
@@ -93,7 +93,7 @@ def load_panel_classes():
         panel_module, panel_classname = panel_path[:dot], panel_path[dot + 1:]
         try:
             mod = import_module(panel_module)
-        except ImportError, e:
+        except ImportError as e:
             raise ImproperlyConfigured(
                 'Error importing debug panel %s: "%s"' %
                 (panel_module, e))

--- a/debug_toolbar/utils/__init__.py
+++ b/debug_toolbar/utils/__init__.py
@@ -1,7 +1,10 @@
 import inspect
 import os.path
 import django
-import SocketServer
+try: # python 3 compat
+    import SocketServer
+except ImportError:
+    import socketserver as SocketServer
 import sys
 
 from django.conf import settings

--- a/debug_toolbar/utils/sqlparse/lexer.py
+++ b/debug_toolbar/utils/sqlparse/lexer.py
@@ -79,7 +79,7 @@ class LexerMeta(type):
 
             try:
                 rex = re.compile(tdef[0], rflags).match
-            except Exception, err:
+            except Exception as err:
                 raise ValueError(("uncompilable regex %r in state"
                                   " %r of %r: %s"
                                   % (tdef[0], state, cls, err)))

--- a/debug_toolbar/utils/sqlparse/sql.py
+++ b/debug_toolbar/utils/sqlparse/sql.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """This module contains classes representing syntactical elements of SQL."""
+from __future__ import print_function
 
 import re
 
@@ -152,9 +153,9 @@ class TokenList(Token):
                 pre = ' +-'
             else:
                 pre = ' | '
-            print '%s%s%d %s \'%s\'' % (indent, pre, idx,
+            print('%s%s%d %s \'%s\'' % (indent, pre, idx,
                                         token._get_repr_name(),
-                                        token._get_repr_value())
+                                        token._get_repr_value()))
             if (token.is_group() and (max_depth is None or depth < max_depth)):
                 token._pprint_tree(max_depth, depth + 1)
 

--- a/debug_toolbar/utils/tracking/db.py
+++ b/debug_toolbar/utils/tracking/db.py
@@ -5,7 +5,10 @@ from threading import local
 
 from django.conf import settings
 from django.template import Node
-from django.utils.encoding import force_unicode, smart_str
+try: # python 3 compat
+    from django.utils.encoding import force_unicode, smart_str
+except ImportError:
+    from django.utils.encoding import force_text as force_unicode, smart_bytes as smart_str
 
 from debug_toolbar.utils import ms_from_timedelta, tidy_stacktrace, \
                                 get_template_info, get_stack


### PR DESCRIPTION
Hi,
I made these initial fixes to start porting debug-toolbar to Python 3. These are the "easy" ones.
The big problem will be the replace_call decorator from utils.tracking, cause you can no longer get the defining class from method (although you can get its name by **qualname**). So I'd advise changing the signature of replace_call to replace_call(klass, func), where klass will be the defining class(/module) itself and func will be string name of function. I'll do the work, but I want to make sure you'd accept such a change.

Thanks!
