### PR TITLE
Indentation for logging message when the dump is an object

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/logger.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/logger.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load debug_toolbar_utils %}
 {% if records %}
 	<table>
 		<thead>
@@ -16,7 +17,7 @@
 					<td>{{ record.level }}</td>
 					<td>{{ record.time|date:"h:i:s m/d/Y" }}</td>
 					<td>{{ record.channel|default:"-" }}</td>
-					<td>{{ record.message|linebreaksbr }}</td>
+					<td>{{ record.message|linebreaksbr|nbspindent }}</td>
 					<td>{{ record.file }}:{{ record.line }}</td>
 				</tr>
 			{% endfor %}

--- a/debug_toolbar/templatetags/debug_toolbar_utils.py
+++ b/debug_toolbar/templatetags/debug_toolbar_utils.py
@@ -1,4 +1,5 @@
 
+import re
 from django import template
 from django.utils.numberformat import format
 
@@ -10,3 +11,7 @@ def dotted_number(number):
     number = float(number)
     return format(number, '.', 6)
 
+
+@register.filter(is_safe=True)
+def nbspindent(obj):
+    return re.sub(r'(?<=<br />)(\s+)[^ ]', lambda m: re.sub(r'\s', '&nbsp;', m.group(0)), obj)


### PR DESCRIPTION
When you want to pretty print your object, instead of doing logging.debug(myobj) you can do
logging.debug(pprint.pformat(myobj)). One problem, pprint uses a space char to indent and that won't work in html, so i added a filter called nbspindent that replaces the spaces created by pprint with &nbsp; so it's proper indented.
