### PR TITLE
Fixed unhandled UnicodeDecodeError in utils.sqlparse.lexer

### DIFF
--- a/debug_toolbar/utils/sqlparse/lexer.py
+++ b/debug_toolbar/utils/sqlparse/lexer.py
@@ -243,7 +243,7 @@ class Lexer(object):
                 try:
                     text = text.decode(self.encoding)
                 except UnicodeDecodeError:
-                    text = u'[UnicodeDecodeError]'
+                    text = text.decode('unicode-escape')
         if self.stripall:
             text = text.strip()
         elif self.stripnl:


### PR DESCRIPTION
This fixes an UnicodeDecodeError exception when the query contains a value for a mysql BINARY field. As I don't care about the value in de debug toolbar context I've replaced the text with u'[UnicodeDecodeError]'
