### PR TITLE
Fix params is None issue

### DIFF
--- a/debug_toolbar/utils/tracking/db.py
+++ b/debug_toolbar/utils/tracking/db.py
@@ -89,7 +89,7 @@ class NormalCursorWrapper(object):
         if isinstance(params, dict):
             return dict((key, self._quote_expr(value))
                             for key, value in params.iteritems())
-        return map(self._quote_expr, params)
+        return map(self._quote_expr, params) if params else None
 
     def _decode(self, param):
         try:


### PR DESCRIPTION
When user call `cursor.execute('sql statement', None)` directly, `return map(self._quote_expr, params)` would crash. See screenshot below.
![screen shot 2013-05-07 at 6 02 57 pm](https://f.cloud.github.com/assets/1174439/470614/db64992e-b6fd-11e2-9623-d874c3a5d390.png)
