### PR TITLE
Django debug toolbar was throwing an exception getting the model app name, slightly more defensive approach to getting this value

### DIFF
--- a/debug_toolbar/panels/template.py
+++ b/debug_toolbar/panels/template.py
@@ -78,7 +78,7 @@ class TemplateDebugPanel(DebugPanel):
                     # QuerySet would trigger the database: user can run the query from SQL Panel
                     elif isinstance(value, (QuerySet, RawQuerySet)):
                         model_meta = getattr(value.model, "_meta", "")
-                        app_level = getattr(model_meta, "app_label", "")
+                        app_label = getattr(model_meta, "app_label", "")
                         model_name = "%s.%s" % (app_label, value.model.__name__)
                         temp_layer[key] = '<<%s of %s>>' % (value.__class__.__name__.lower(), model_name)
                     else:


### PR DESCRIPTION
```
Traceback (most recent call last):
File "newrelic-1.10.0.28/newrelic/hooks/framework_django.py", line 475, in wrapper return wrapped(*args, **kwargs)
File "views/credit.py", line\ 64, in credit_button "count_class": 'ct-disabled' if got_credit else 'ct-active'
File "django/shortcuts/__init__.py", line 44, in render return HttpResponse(loader.render_to_string(*args, **kwargs),
File "django/template/loader.py", line 176, in render_to_string return t.render(context_instance)
File "django/template/base.py", line 140, in render return self._render(context)
File "django/test/utils.py", line 61, in instrumented_test_render template_rendered.send(sender=self,\ template=self, context=context)
File "django/dispatch/dispatcher.py", line 172, in send response = receiver(signal=self, sender=sender, **named)
File "debug_toolbar/panels/template.py", line 80, in _store_template_info model_name = "%s.%s" % (value.model._meta.app_label,\ value.model.__name__)
AttributeError: 'NoneType' object has no attribute '_meta'
```

This has been showing up in my logs for the past few days. I patched the part of the code that was trying to access _meta from a None variable, not sure why it was a None to begin with but this will print an empty string instead of throwing an exception.
