### PR TITLE
Avoided importing `django.conf.urls.defaults` in example project

### DIFF
--- a/example/urls.py
+++ b/example/urls.py
@@ -1,5 +1,8 @@
 from django.conf import settings
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import patterns, url
+except ImportError: # django < 1.4
+    from django.conf.urls.defaults import patterns, url
 from django.contrib import admin
 from django.views.generic import TemplateView
 


### PR DESCRIPTION
Use same approach as 39088e7cab
