### PR TITLE
Clarified in README that package can be installed via pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,10 @@ If you have ideas for other panels please let us know.
 Installation
 ============
 
+#. Clone the repo locally and link/copy the debug-toolbar folder into your Django project folder. Or install via pip::
+    
+        pip install django-debug-toolbar
+    
 #. Add the ``debug_toolbar`` directory to your Python path.
 
 #. Add the following middleware to your project's ``settings.py`` file::


### PR DESCRIPTION
I just found the repo and was a little confused by the install instructions. Seems easier to start by installing from pip rather than cloning the repo (which is what the current language implies is the best option.)
