### PR TITLE
Add tox.ini. Fix #407.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist =
+    py26-django14,
+    py27-django14,
+    py26-django15,
+    py27-django15
+
+[testenv]
+commands = python runtests.py
+
+[testenv:py26-django14]
+basepython = python2.6
+deps = Django>=1.4,<1.5
+
+[testenv:py27-django14]
+basepython = python2.7
+deps = Django>=1.4,<1.5
+
+[testenv:py26-django15]
+basepython = python2.6
+deps = Django>=1.5,<1.6
+
+[testenv:py27-django15]
+basepython = python2.7
+deps = Django>=1.5,<1.6


### PR DESCRIPTION
Currently this targets Django 1.4 & 1.5 on Python 2.6 & 2.7 as we'll
drop support for Django 1.3 and Python 2.5 in the next release.

Python 3.2 & 3.3 isn't supported yet.
