### PR TITLE
#151 -- Logging panel fails on invalid string representations

### DIFF
--- a/debug_toolbar/panels/logger.py
+++ b/debug_toolbar/panels/logger.py
@@ -9,6 +9,8 @@ except ImportError:
 from django.utils.translation import ungettext, ugettext_lazy as _
 from debug_toolbar.panels import DebugPanel
 
+MESSAGE_IF_STRING_REPRESENTATION_INVALID = '[Could not get log message]'
+
 
 class LogCollector(object):
     def __init__(self):
@@ -49,8 +51,13 @@ class ThreadTrackingHandler(logging.Handler):
         self.collector = collector
 
     def emit(self, record):
+        try:
+            message = record.getMessage()
+        except Exception:
+            message = MESSAGE_IF_STRING_REPRESENTATION_INVALID
+
         record = {
-            'message': record.getMessage(),
+            'message': message,
             'time': datetime.datetime.fromtimestamp(record.created),
             'level': record.levelname,
             'file': record.pathname,


### PR DESCRIPTION
Fixes issue #151. I haven't tested this in a real-life situation, but have attached unit tests which should cover this.
