### PR TITLE
map() returns an iterator on Python 3

### DIFF
--- a/debug_toolbar/utils/tracking/db.py
+++ b/debug_toolbar/utils/tracking/db.py
@@ -98,7 +98,7 @@ class NormalCursorWrapper(object):
                 stacktrace = []
             _params = ''
             try:
-                _params = json.dumps(map(self._decode, params))
+                _params = json.dumps(list(map(self._decode, params)))
             except Exception:
                 pass  # object not JSON serializable
 


### PR DESCRIPTION
In python3.X, we need to convert map object to list, to be able serialize it.

Issue #431
