### PR TITLE
Correct the dotted path to TemplatesPanel

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -18,7 +18,7 @@ setting. The default value is::
         'debug_toolbar.panels.headers.HeadersPanel',
         'debug_toolbar.panels.request.RequestPanel',
         'debug_toolbar.panels.sql.SQLPanel',
-        'debug_toolbar.panels.template.TemplatesPanel',
+        'debug_toolbar.panels.templates.TemplatesPanel',
         'debug_toolbar.panels.cache.CachePanel',
         'debug_toolbar.panels.signals.SignalsPanel',
         'debug_toolbar.panels.logging.LoggingPanel',


### PR DESCRIPTION
Useful to have the paths right if you want something to copy/paste from
