### PR TITLE
Remove support for logbook.

### DIFF
--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -68,40 +68,13 @@ class ThreadTrackingHandler(logging.Handler):
         self.collector.add_record(record)
 
 
+# We don't use enable/disable_instrumentation because logging is global.
+# We can't add thread-local logging handlers. Hopefully logging is cheap.
+
 collector = LogCollector()
 logging_handler = ThreadTrackingHandler(collector)
 logging.root.setLevel(logging.NOTSET)
-logging.root.addHandler(logging_handler)  # register with logging
-
-# We don't use enable/disable_instrumentation because we can't make these
-# functions thread-safe and (hopefully) logging isn't too expensive.
-
-try:
-    import logbook
-    logbook_supported = True
-except ImportError:
-    # logbook support is optional, so fail silently
-    logbook_supported = False
-
-if logbook_supported:
-    class LogbookThreadTrackingHandler(logbook.handlers.Handler):
-        def __init__(self, collector):
-            logbook.handlers.Handler.__init__(self, bubble=True)
-            self.collector = collector
-
-        def emit(self, record):
-            record = {
-                'message': record.message,
-                'time': record.time,
-                'level': record.level_name,
-                'file': record.filename,
-                'line': record.lineno,
-                'channel': record.channel,
-            }
-            self.collector.add_record(record)
-
-    logbook_handler = LogbookThreadTrackingHandler(collector)
-    logbook_handler.push_application()  # register with logbook
+logging.root.addHandler(logging_handler)
 
 
 class LoggingPanel(Panel):

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -82,7 +82,7 @@ Logging
 
 Path: ``debug_toolbar.panels.logging.LoggingPanel``
 
-Logging output via Python's built-in :mod:`logging`, or via the `logbook <http://logbook.pocoo.org>`_ module.
+Logging output via Python's built-in :mod:`logging` module.
 
 Redirects
 ~~~~~~~~~


### PR DESCRIPTION
If you were relying on this feature, it should be quite easy to
implement it in a third-party panel, and we'll reference it in the
documentation.

Fix #478.
