### PR TITLE
Put debug_toolbar's url patterns first

### DIFF
--- a/debug_toolbar/models.py
+++ b/debug_toolbar/models.py
@@ -51,9 +51,9 @@ def patch_root_urlconf():
         reverse('djdt:render_panel')
     except NoReverseMatch:
         urlconf_module = import_module(settings.ROOT_URLCONF)
-        urlconf_module.urlpatterns += patterns('',                      # noqa
+        urlconf_module.urlpatterns = patterns('',                      # noqa
             url(r'^__debug__/', include(debug_toolbar.urls)),
-        )
+        ) + urlconf_module.urlpatterns
         clear_url_caches()
 
 


### PR DESCRIPTION
Some applications require using a catch-all urlpattern that must come last in the list of urlpatterns. If the `__debug__` urls come after it, they'll never be hit.

Putting the debug_toolbar urls first fixes this, but could possibly shadow an existing url, but the old version of debug toolbar did the same thing.
