### PR TITLE
Fix for RequireJS

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/jquery.cookie.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery.cookie.js
@@ -8,7 +8,7 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as anonymous module.
-        define(['jquery'], factory);
+        define('jquery.cookie', ['jquery'], factory);
     } else {
         // Browser globals.
         factory(jQuery);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -1,7 +1,7 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as anonymous module.
-        define(['jquery', 'jquery.cookie'], factory);
+        define('django-debug-toolbar', ['jquery', 'jquery.cookie'], factory);
     } else {
         // Browser globals.
         window.djdt = factory(jQuery);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.profiling.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.profiling.js
@@ -1,6 +1,6 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['jquery'], factory);
+        define('django-debug-toolbar-profiling', ['jquery'], factory);
     } else {
         factory(jQuery);
     }

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.sql.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.sql.js
@@ -1,6 +1,6 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['jquery'], factory);
+        define('django-debug-sql', ['jquery'], factory);
     } else {
         factory(jQuery);
     }

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.template.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.template.js
@@ -1,6 +1,6 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['jquery'], factory);
+        define('django-debug-template', ['jquery'], factory);
     } else {
         factory(jQuery);
     }

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
@@ -1,6 +1,6 @@
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['jquery'], factory);
+        define('django-debug-timer', ['jquery'], factory);
     } else {
         factory(jQuery);
     }

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -61,3 +61,6 @@ if(!window.jQuery) document.write('<scr'+'ipt src="//ajax.googleapis.com/ajax/li
 	{% endfor %}
 	<div id="djDebugWindow" class="panelContent"></div>
 </div>
+<script>//<![CDATA[
+if (require) require(['django-debug-toolbar']);
+//]]></script>


### PR DESCRIPTION
There are two problems with the current support of AMD modules in DDT when it comes to RequireJs (and probably other module loaders as well). First all modules that are imported through script tags from an html page have to be named and second is that the code never run, its only added to modules.

One possible solution is to name each module (first parameter in define()) and to call the code (the require() in base.html). But this would only work for RequireJS and no other AMD loaders (to my knowledge at least).

Perhaps the best solution is just be to go back to browser global's? DDT is only used during development anyways.
