### PR TITLE
Fix: sql panel sql uncollapse

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n %}{% load static from staticfiles %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href="">{% trans "Back" %}</a>
 	<h3>{% trans "SQL explained" %}</h3>
@@ -33,3 +33,5 @@
 		</table>
 	</div>
 </div>
+
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n %}{% load static from staticfiles %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href="">{% trans "Back" %}</a>
 	<h3>{% trans "SQL profiled" %}</h3>
@@ -40,3 +40,5 @@
 		{% endif %}
 	</div>
 </div>
+
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n %}{% load static from staticfiles %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href="">{% trans "Back" %}</a>
 	<h3>{% trans "SQL selected" %}</h3>
@@ -37,3 +37,5 @@
 		{% endif %}
 	</div>
 </div>
+
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>


### PR DESCRIPTION
sql_select.html, sql_explain.html, sql_profile.html
These three templates all need toolbar.sql.js, otherwise
the `select ...` cannot be uncollapsed.
