### PR TITLE
Fix: query.engine can be 'MySQLdb' for mysql.

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -49,9 +49,9 @@
 								<button formaction="{% url 'djdt:sql_select' %}" class="remoteCall">Sel</button>
 								<button formaction="{% url 'djdt:sql_explain' %}" class="remoteCall">Expl</button>
 
-								{% ifequal query.engine 'mysql' %}
+								{% if query.engine == 'mysql' or query.engine == 'MySQLdb' %}
 									<button formaction="{% url 'djdt:sql_profile' %}" class="remoteCall">Prof</button>
-								{% endifequal %}
+								{% endif %}
 							</form>
 						{% endif %}
 					{% endif %}


### PR DESCRIPTION
query.engine could be 'mysql' or 'MySQLdb' for mysql driver.
