### PR TITLE
restore the pages $ function if necessary

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -4,6 +4,7 @@
 </style>
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
 <script>//<![CDATA[
+if(!!window.$) window.__$_orig = window.$;
 if(!window.jQuery) document.write('<scr'+'ipt src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></scr'+'ipt>');
 //]]></script>
 <script src="{% static 'debug_toolbar/js/jquery.cookie.js' %}"></script>
@@ -61,3 +62,6 @@ if(!window.jQuery) document.write('<scr'+'ipt src="//ajax.googleapis.com/ajax/li
 	{% endfor %}
 	<div id="djDebugWindow" class="panelContent"></div>
 </div>
+<script>//<![CDATA[
+if(!!window.__$_orig) window.$ = window.__$_orig;
+//]]></script>


### PR DESCRIPTION
My web application uses MooTools as JS Framework, which comes with a $ function. This function gets overwritten by django-debug-toolbar. This little change should make django-debug-toolbar more compatible in such cases by restoring the original $ function.
