### PR TITLE
Allow profiler max depth to be set in settings

### DIFF
--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, unicode_literals
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 from debug_toolbar.panels import Panel
+from debug_toolbar import settings as dt_settings
 
 import cProfile
 from pstats import Stats
@@ -152,6 +153,7 @@ class ProfilingPanel(Panel):
         root = FunctionCall(self.stats, self.stats.get_root_func(), depth=0)
 
         func_list = []
-        self.add_node(func_list, root, 10, root.stats[3] / 8)
+        max_depth = dt_settings.CONFIG.get('PROFILER_MAX_DEPTH', 10)
+        self.add_node(func_list, root, max_depth, root.stats[3] / 8)
 
         self.record_stats({'func_list': func_list})


### PR DESCRIPTION
Sometimes it's helpful to have a max depth of more than 10, which is currently hard-coded in the profiling panel.
