### PR TITLE
Make NormalCursorWrapper a context manager

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -185,3 +185,9 @@ class NormalCursorWrapper(object):
 
     def __iter__(self):
         return iter(self.cursor)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()


### PR DESCRIPTION
 -- like `django.db.backends.utils.CursorWrapper` since Django #17671

Otherwise `django.db.backends.BaseDatabaseWrapper._savepoint` methods result in `AttributeError` exceptions.
