### PR TITLE
UnicodeDecode Exception

### DIFF
--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -80,7 +80,7 @@ class SQLSelectForm(forms.Form):
         items = [settings.SECRET_KEY, data['sql'], data['params']]
         # Replace lines endings with spaces to preserve the hash value
         # even when the browser normalizes \r\n to \n in inputs.
-        items = [force_text(' '.join(item.splitlines())) for item in items]
+        items = [' '.join(force_text(item).splitlines()) for item in items]
         return hashlib.sha1(''.join(items).encode('utf-8')).hexdigest()
 
     @property


### PR DESCRIPTION
Environment:

Request Method: GET
Request URL: http://localhost:8000/events/events/ed/

Django Version: 1.4.3
Python Version: 2.7.4

Traceback:
File "/home/a_homza/env/ui/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
1.                 response = middleware_method(request, response)
   File "/home/a_homza/env/ui/local/lib/python2.7/site-packages/debug_toolbar/middleware.py" in process_response
2.             new_response = panel.process_response(request, response)
   File "/home/a_homza/env/ui/local/lib/python2.7/site-packages/debug_toolbar/panels/sql/panel.py" in process_response
3.                 query['form'] = SQLSelectForm(auto_id=None, initial=copy(query))
   File "/home/a_homza/env/ui/local/lib/python2.7/site-packages/debug_toolbar/panels/sql/forms.py" in **init**
4.             initial['hash'] = self.make_hash(initial)
   File "/home/a_homza/env/ui/local/lib/python2.7/site-packages/debug_toolbar/panels/sql/forms.py" in make_hash
5.         items = [force_text(' '.join(item.splitlines())) for item in items]

Exception Type: UnicodeDecodeError at /events/events/ed/
Exception Value: 'ascii' codec can't decode byte 0xd0 in position 36: ordinal not in range(128)

The string that could not be encoded/decoded was: ` = '������
