### PR TITLE
Propagate mouseup events when not dragging toolbar

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -160,8 +160,8 @@
                     setTimeout(function () {
                         djdt.handleDragged = false;
                     }, 10);
+                    return false;
                 }
-                return false;
             });
             $(document).bind('close.djDebug', function() {
                 // If a sub-panel is open, close that


### PR DESCRIPTION
In Chrome (this does not affect Firefox) onchange events on multi-selects are not fired all of the time e.g. with the following template:

``` html
<body>
    <select multiple="multiple" onchange="console.log('clicked');">
        <option  value="1">1</option>
    </select>
</body>
```

Ctrl click on the option and view the js log. many of the events will not register. Therefore stop propagation and prevent default action only when handle is dragged.
