### PR TITLE
Disable Logging panel when DEBUG is set to False to prevent memory leaks

### DIFF
--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -45,12 +45,12 @@ class ThreadTrackingHandler(logging.Handler):
         }
         self.collector.collect(record)
 
+collector = LogCollector()
 
 # Check to make sure DEBUG is enabled to prevent silent memory leaks.
 if settings.DEBUG:
     # We don't use enable/disable_instrumentation because logging is global.
     # We can't add thread-local logging handlers. Hopefully logging is cheap.
-    collector = LogCollector()
     logging_handler = ThreadTrackingHandler(collector)
     logging.root.setLevel(logging.NOTSET)
     logging.root.addHandler(logging_handler)

--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -89,8 +89,6 @@ class LoggingPanel(Panel):
     title = _("Log messages")
 
     def process_request(self, request):
-        # The state of DEBUG can be changed after the app is first initialized; ensure
-        # that the collector is in the right state.
         collector.clear_collection()
 
     def process_response(self, request, response):

--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -6,6 +6,7 @@ try:
     import threading
 except ImportError:
     threading = None
+from django.conf import settings
 from django.utils.translation import ungettext, ugettext_lazy as _
 from debug_toolbar.panels import Panel
 from debug_toolbar.utils import ThreadCollector
@@ -45,13 +46,14 @@ class ThreadTrackingHandler(logging.Handler):
         self.collector.collect(record)
 
 
-# We don't use enable/disable_instrumentation because logging is global.
-# We can't add thread-local logging handlers. Hopefully logging is cheap.
-
-collector = LogCollector()
-logging_handler = ThreadTrackingHandler(collector)
-logging.root.setLevel(logging.NOTSET)
-logging.root.addHandler(logging_handler)
+# Check to make sure DEBUG is enabled to prevent silent memory leaks.
+if settings.DEBUG:
+    # We don't use enable/disable_instrumentation because logging is global.
+    # We can't add thread-local logging handlers. Hopefully logging is cheap.
+    collector = LogCollector()
+    logging_handler = ThreadTrackingHandler(collector)
+    logging.root.setLevel(logging.NOTSET)
+    logging.root.addHandler(logging_handler)
 
 
 class LoggingPanel(Panel):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ New features
 
 * The SQL panel colors queries depending on the stack level.
 * The Profiler panel allows configuring the maximum depth.
+* The Logging panel will not attempt to collect data when DEBUG is False.
 
 Bugfixes
 ~~~~~~~~

--- a/tests/panels/test_logging.py
+++ b/tests/panels/test_logging.py
@@ -16,6 +16,9 @@ class LoggingPanelTestCase(BaseTestCase):
         super(LoggingPanelTestCase, self).setUp()
         self.panel = self.toolbar.get_panel_by_id('LoggingPanel')
         self.logger = logging.getLogger(__name__)
+        # DEBUG may be set to False initially, preventing the default tracking
+        # from executing. Force an enable here to ensure that logging is activated.
+        collector.enable_logging()
         collector.clear_collection()
 
     def test_happy_case(self):

--- a/tests/panels/test_logging.py
+++ b/tests/panels/test_logging.py
@@ -4,10 +4,12 @@ import logging
 
 from debug_toolbar.panels.logging import (
     collector, MESSAGE_IF_STRING_REPRESENTATION_INVALID)
+from django.test.utils import override_settings
 
 from ..base import BaseTestCase
 
 
+@override_settings(DEBUG=True)
 class LoggingPanelTestCase(BaseTestCase):
 
     def setUp(self):


### PR DESCRIPTION
I upgraded django-debug-toolbar from 0.9.4. to 1.0.1, and I noticed my application was quickly leaking memory even when settings.DEBUG was set to False. Once I removed debug_toolbar from the list of applications, the problem disappeared.

Upon further investigation, I found that LoggingPanel was quietly collecting all my log messages and never releasing them.

This problem only occurs if the Django application is fully initialized (e.g. using runserver), since this causes the LoggingPanel to register its handlers. Here is a simple application that illustrates the problem:

``` python
from django.core.management import ManagementUtility
import logging

utility = ManagementUtility()
command = utility.fetch_command('runserver')
command.validate()

logger = logging.getLogger('test')

while True:
    logger.info('This logger will leak memory')
```

Run this application with the default debug_toolbar settings, and then use 'top' to watch the memory grow without bound. The problem appears that the LoggingPanel does not use the enable_instrumentation() function normally called by the middleware, which does the DEBUG check beforehand.

I think the simplest fix is to check if DEBUG is enabled before initializing the LogCollector. This pull request does just that, and it appears to fix the issue.

In addition, I think we should consider a few other things:

1) Warn the user that under DEBUG mode, memory used for log messages can grow without bounds (this might be true for other panels already).

2) Limit the number/age of messages stored (perhaps as a configuration option).
