### PR TITLE
Don't run context processors for redirect template.

### DIFF
--- a/debug_toolbar/panels/redirects.py
+++ b/debug_toolbar/panels/redirects.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.core.handlers.wsgi import STATUS_CODE_TEXT
-from django.shortcuts import render
+from django.shortcuts import render_to_response
 from django.utils.translation import ugettext_lazy as _
 
 from debug_toolbar.panels import Panel
@@ -28,6 +28,6 @@ class RedirectsPanel(Panel):
                 status_line = '%s %s' % (response.status_code, reason_phrase)
                 cookies = response.cookies
                 context = {'redirect_to': redirect_to, 'status_line': status_line}
-                response = render(request, 'debug_toolbar/redirect.html', context)
+                response = render_to_response('debug_toolbar/redirect.html', context)
                 response.cookies = cookies
         return response


### PR DESCRIPTION
In certain configurations, applying the context processors when rendering the redirect template can cause exceptions.  For example, assume the folllowing Django settings:

```
APPEND_SLASH = True

MIDDLEWARE_CLASSES = (
    'debug_panel.middleware.DebugPanelMiddleware',
    'django.middleware.common.CommonMiddleware',
    ...
    'custom.middleware.CustomMiddleware'
)

TEMPLATE_CONTEXT_PROCESSORS = (
    ...
    'custom.context_processors.custom',
    ....
)
```

Further, assume that `custom.middleware.CustomMiddleware` sets an attribute on the request that `custom.context_processors.custom` tries to access.  If `django.middleware.common.CommonMiddleware` causes a redirect, (e.g. as a result of the `APPEND_SLASH` setting), the attribute that `custom.context_processors.custom` needs will never get set on the request.  Then when initializing the `RequestContext` in order to render  `debug_toolbar/redirect.html`,an exception will occur when `custom.context_processors.custom` tries to access the missing attribute.

Since no context processors are needed to render the `debug_toolbar/redirect.html` template, avoid this problem by replacing `render` with `render_to_response`, which does not apply context processors to the template context.
