### PR TITLE
Be more explicit about function signature of toolbar callback

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -113,8 +113,8 @@ Toolbar options
   This is the dotted path to a function used for determining whether the
   toolbar should show or not. The default checks are that ``DEBUG`` must be
   set to ``True``, the IP of the request must be in ``INTERNAL_IPS``, and the
-  request must no be an AJAX request. You can provide your own function that
-  accepts a request in argument and returns ``True`` or ``False``.
+  request must no be an AJAX request. You can provide your own function 
+  ``callback(request)`` which returns ``True`` or ``False``.
 
 Panel options
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This is not a big change, but it the function signature is more readable this way.
