### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,16 +23,12 @@ Quick setup
 
 Make sure that ``'django.contrib.staticfiles'`` is `set up properly
 <https://docs.djangoproject.com/en/stable/howto/static-files/>`_ and add
-``'debug_toolbar.apps.DebugToolbarConfig'`` (Django ≥ 1.7) or
-``'debug_toolbar'`` (Django < 1.7) to your ``INSTALLED_APPS`` setting::
+``'debug_toolbar'`` to your ``INSTALLED_APPS`` setting::
 
     INSTALLED_APPS = (
         # ...
         'django.contrib.staticfiles',
         # ...
-        # If you're using Django 1.7.x or later
-        'debug_toolbar.apps.DebugToolbarConfig',
-        # If you're using Django 1.6.x or earlier
         'debug_toolbar',
     )
 


### PR DESCRIPTION
I tried using django-debug-toolbar with Django 1.7b1.

At first, I configured just like documentation (add `'debug_toolbar.apps.DebugToolbarConfig'` to `INSTALLED_APPS`) and I failed to runserver because 

```
ImportError: No module named DebugToolbarConfig
```

Next, I configured as before 1.6 (add `'debug_toolbar'` to `INSTALLED_APPS`) and I succeeded in runserver.
