### PR TITLE
Remove upper limit from django version in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='BSD',
     packages=find_packages(exclude=('tests', 'example')),
     install_requires=[
-        'django>=1.4.2,<1.7',
+        'django>=1.4.2',
         'sqlparse',
     ],
     include_package_data=True,


### PR DESCRIPTION
The docs say Django 1.7 is supported, but setup.py still requires < 1.7. When pip sees this it downloads and installs Django 1.6 even if 1.7 or master are already installed.
