### PR TITLE
System encoding might not be utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from setuptools import setup, find_packages
+from io import open
 
 setup(
     name='django-debug-toolbar',
     version='1.1',
     description='A configurable set of panels that display various debug '
                 'information about the current request/response.',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', encoding='utf-8').read(),
     author='Rob Hudson',
     author_email='rob@cogit8.org',
     url='https://github.com/django-debug-toolbar/django-debug-toolbar',


### PR DESCRIPTION
Eliminates UnicodeDecodeError when opening README.rst if system encoding is not utf-8. Works in both Python >= 2.6 and 3.
