### PR TITLE
Improve the redirect context processor test.

### DIFF
--- a/tests/context_processors.py
+++ b/tests/context_processors.py
@@ -1,2 +1,2 @@
-def custom(request):
+def broken(request):
     request.non_existing_attribute

--- a/tests/middlewares.py
+++ b/tests/middlewares.py
@@ -1,5 +1,0 @@
-
-
-class CustomMiddleware(object):
-    def process_request(request):
-        request.myattr = 'test attribute'

--- a/tests/panels/test_redirects.py
+++ b/tests/panels/test_redirects.py
@@ -33,16 +33,12 @@ class RedirectsPanelTestCase(BaseTestCase):
         self.assertContains(response, '302 FOUND')
         self.assertContains(response, 'http://somewhere/else/')
 
-    def test_redirect_breaks_procesor(self):
-        middlewares = settings.MIDDLEWARE_CLASSES + [
-            'tests.middlewares.CustomMiddleware',
-        ]
+    def test_redirect_with_broken_context_processor(self):
         context_processors = settings.TEMPLATE_CONTEXT_PROCESSORS + (
-            'tests.context_processors.custom',
+            'tests.context_processors.broken',
         )
 
-        with self.settings(MIDDLEWARE_CLASSES=middlewares,
-                           TEMPLATE_CONTEXT_PROCESSORS=context_processors):
+        with self.settings(TEMPLATE_CONTEXT_PROCESSORS=context_processors):
             redirect = HttpResponse(status=302)
             redirect['Location'] = 'http://somewhere/else/'
             response = self.panel.process_response(self.request, redirect)


### PR DESCRIPTION
- rename the context processor used from 'custom' to 'broken'
- remove the custom middleware, because it is not used in the context of
  the test
- rename the test to better identify what it is testing
