### PR TITLE
Re-fix #535 fix reversed noConflict in DjDT jQuery include

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -5,9 +5,9 @@
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
 {% if toolbar.config.JQUERY_URL %}
 <script src="{{ toolbar.config.JQUERY_URL }}"></script>
-<script>var djdt = {jQuery: jQuery.noConflict(true)};</script>
-{% else %}
 <script>var djdt = {jQuery: jQuery};</script>
+{% else %}
+<script>var djdt = {jQuery: jQuery.noConflict(true)};</script>
 {% endif %}
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
 <div id="djDebug" style="display:none;" dir="ltr"


### PR DESCRIPTION
Per my comment at https://github.com/django-debug-toolbar/django-debug-toolbar/commit/727b4e05f59c15904f7b08388220b7bfc76d59b2#diff-4f4a91c0e3639b7eb74d3dc23799f72dR8

I believe the noConflict call is swapped; using your own JQUERY_URL should _not_ use noConflict, while using the "bundled" one of DjDT _should_ use noConflict. The code as currently written does the reverse, and both break in my app that uses both require.js and other jQuery plugins, with the jQuery plugins unable to find the jQuery "$" object.

This pull request reverses those, fixing that.

If this pull request is accepted, an expedited 1.2.1 release would be appreciated! Thanks!
