### PR TITLE
undefine "define" to avoid requirejs conflict

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -3,12 +3,19 @@
 @media print { #djDebug {display:none;}}
 </style>
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
+<script>
+	var _define = window.define;
+	window.define = undefined;
+</script>
 {% if toolbar.config.JQUERY_URL %}
 <script src="{{ toolbar.config.JQUERY_URL }}"></script>
 <script>var djdt = {jQuery: jQuery.noConflict(true)};</script>
 {% else %}
 <script>var djdt = {jQuery: jQuery};</script>
 {% endif %}
+<script>
+	window.define = _define;
+</script>
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
 <div id="djDebug" style="display:none;" dir="ltr"
      data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}"


### PR DESCRIPTION
Even with the vendored RequireJS and the call to noConflict(), we are still having problems using Django Debug Toolbar.

Even though the function noConflict removes jquery from the global namespace, simply including the jquery.js script still affects the jquery loaded by RequireJS, since the following lines in jquery.js  from http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.js are run unconditionally, and are not undone by noConflict:

```
if ( typeof define === "function" && define.amd ) {
    define( "jquery", [], function() {
        return jQuery;
    });
}
```

This patch temporarily undefines RequireJS's "define" while loading the vendored jQuery, preventing itself from registering.

This is especially important in our case, where we have no global jQuery since it is only loaded via RequireJS. Our jQuery is loaded asynchronously, and since this vendored version of jQuery is loaded inline syncrhonously, this affects loading of other things that require jQuery.
