### PR TITLE
Enable testing on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 env:
   - DJANGO_VERSION=1.4.10
   - DJANGO_VERSION=1.5.5
@@ -13,6 +14,8 @@ matrix:
     - python: "3.2"
       env: DJANGO_VERSION=1.4.10
     - python: "3.3"
+      env: DJANGO_VERSION=1.4.10
+    - python: "3.4"
       env: DJANGO_VERSION=1.4.10
 install:
   - pip install -e .


### PR DESCRIPTION
As per [this Travis CI blog post](http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/), testing on Python 3.4 is now supported.
