### PR TITLE
store_id not found in QueryDict Exception in render_panel view.

### DIFF
--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -9,6 +9,11 @@ from debug_toolbar.toolbar import DebugToolbar
 
 def render_panel(request):
     """Render the contents of a panel"""
+    # Check if store_id key exist in GET request.
+    if not request.GET.has_key('store_id'):
+        content = _('"store_id" key is required')
+        return HttpResponse(content)
+
     toolbar = DebugToolbar.fetch(request.GET['store_id'])
     if toolbar is None:
         content = _("Data for this panel isn't available anymore. "


### PR DESCRIPTION
Getting exception 'store_id' not found when not providing 'store_id' in querystring.

```
MultiValueDictKeyError at /__debug__/render_panel/
"Key u'store_id' not found in <QueryDict: {}>"
```
