### PR TITLE
Get the relative top rather than the absolute top.

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -150,7 +150,7 @@
             $(document).on('mouseup', function () {
                 $(document).off('mousemove.djDebug');
                 if (djdt.handleDragged) {
-                    var top = handle.offset().top;
+                    var top = handle.offset().top - window.pageYOffset;
                     djdt.cookie.set('djdttop', top, {
                         path: '/',
                         expires: 10


### PR DESCRIPTION
When writing the top to the cookie, subtract off the page offset. Fixes #584.

One thing to note is that `window.pageYOffset` is not compatible with < IE9.
