### PR TITLE
Fix infinite recursion bug with SQL and Cache panels

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -9,7 +9,6 @@ from django.core import cache
 from django.core.cache import cache as original_cache, get_cache as original_get_cache
 from django.core.cache.backends.base import BaseCache
 from django.dispatch import Signal
-from django.template import Node
 from django.utils.translation import ugettext_lazy as _, ungettext
 try:
     from collections import OrderedDict
@@ -37,19 +36,7 @@ def send_signal(method):
         else:
             stacktrace = []
 
-        template_info = None
-        cur_frame = sys._getframe().f_back
-        try:
-            while cur_frame is not None:
-                if cur_frame.f_code.co_name == 'render':
-                    node = cur_frame.f_locals['self']
-                    if isinstance(node, Node):
-                        template_info = get_template_info(node.source)
-                        break
-                cur_frame = cur_frame.f_back
-        except Exception:
-            pass
-        del cur_frame
+        template_info = get_template_info()
         cache_called.send(sender=self.__class__, time_taken=t,
                           name=method.__name__, return_value=value,
                           args=args, kwargs=kwargs, trace=stacktrace,

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
-import sys
-
 import json
 from threading import local
 from time import time
 
-from django.template import Node
 from django.utils.encoding import force_text
 from django.utils import six
 
@@ -115,19 +112,7 @@ class NormalCursorWrapper(object):
             except Exception:
                 pass  # object not JSON serializable
 
-            template_info = None
-            cur_frame = sys._getframe().f_back
-            try:
-                while cur_frame is not None:
-                    if cur_frame.f_code.co_name == 'render':
-                        node = cur_frame.f_locals['self']
-                        if isinstance(node, Node):
-                            template_info = get_template_info(node.source)
-                            break
-                    cur_frame = cur_frame.f_back
-            except Exception:
-                pass
-            del cur_frame
+            template_info = get_template_info()
 
             alias = getattr(self.db, 'alias', 'default')
             conn = self.db.connection

--- a/tests/loaders.py
+++ b/tests/loaders.py
@@ -1,0 +1,10 @@
+from django.contrib.auth.models import User
+from django.template.loaders.app_directories import Loader
+
+
+class LoaderWithSQL(Loader):
+    def load_template_source(self, template_name, template_dirs=None):
+        # Force the template loader to run some SQL. Simulates a CMS.
+        User.objects.all().count()
+        return super(LoaderWithSQL, self).load_template_source(
+            template_name, template_dirs=template_dirs)

--- a/tests/templates/base.html
+++ b/tests/templates/base.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{{ title }}</title>
+    </head>
+    <body>
+    {% block content %}{% endblock %}
+    </body>
+</html>

--- a/tests/templates/basic.html
+++ b/tests/templates/basic.html
@@ -1,8 +1,2 @@
-<!DOCTYPE html>
-<html>
-    <head>
-        <title>{{ title }}</title>
-    </head>
-    <body>
-    </body>
-</html>
+{% extends "base.html" %}
+{% block content %}Test for {{ title }}{% endblock %}


### PR DESCRIPTION
Move the stack trace loop into a utility method. Check for calls to get_template_context.

I wasn't sure about the logic to check the current file. I had it done programmatically, but that was ugly and probably more confusing than just checking the string value of the name.

Closes #598
