### PR TITLE
Warn the user when the gzip middleware is imported before the toolbar.

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -13,3 +13,4 @@ class DebugToolbarConfig(AppConfig):
     def ready(self):
         if dt_settings.PATCH_SETTINGS:
             dt_settings.patch_all()
+        dt_settings.check_middleware()


### PR DESCRIPTION
This raises a warning in the console when a project is run with the `django.middleware.gzip.GZipMiddleware` is installed before the `debug_toolbar.middleware.DebugToolbarMiddleware`. This will also work with the automatic setup.
