### PR TITLE
cleaned up urls for django1.8

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -4,7 +4,7 @@ import uuid
 from copy import copy
 from collections import defaultdict
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.db import connections
 from django.utils.translation import ugettext_lazy as _, ungettext_lazy as __
 
@@ -13,6 +13,7 @@ from debug_toolbar.panels.sql.forms import SQLSelectForm
 from debug_toolbar.utils import render_stacktrace
 from debug_toolbar.panels.sql.utils import reformat_sql, contrasting_color_generator
 from debug_toolbar.panels.sql.tracking import wrap_cursor, unwrap_cursor
+from debug_toolbar.panels.sql import views
 
 
 def get_isolation_level_display(vendor, level):
@@ -120,11 +121,11 @@ class SQLPanel(Panel):
 
     @classmethod
     def get_urls(cls):
-        return patterns('debug_toolbar.panels.sql.views',               # noqa
-            url(r'^sql_select/$', 'sql_select', name='sql_select'),
-            url(r'^sql_explain/$', 'sql_explain', name='sql_explain'),
-            url(r'^sql_profile/$', 'sql_profile', name='sql_profile'),
-        )
+        return [
+            url(r'^sql_select/$', views.sql_select, name='sql_select'),
+            url(r'^sql_explain/$', views.sql_explain, name='sql_explain'),
+            url(r'^sql_profile/$', views.sql_profile, name='sql_profile'),
+        ]
 
     def enable_instrumentation(self):
         # This is thread-safe because database connections are thread-local.

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -10,7 +10,7 @@ from pprint import pformat
 import django
 from django import http
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.db.models.query import QuerySet, RawQuerySet
 from django.template import Context, RequestContext, Template
 from django.template.context import get_standard_processors
@@ -22,6 +22,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql.tracking import recording, SQLQueryTriggered
+from debug_toolbar.panels.templates import views
 
 
 # Monkey-patch to enable the template_rendered signal. The receiver returns
@@ -155,9 +156,9 @@ class TemplatesPanel(Panel):
 
     @classmethod
     def get_urls(cls):
-        return patterns('debug_toolbar.panels.templates.views',         # noqa
-            url(r'^template_source/$', 'template_source', name='template_source'),
-        )
+        return [
+            url(r'^template_source/$', views.template_source, name='template_source'),
+        ]
 
     def enable_instrumentation(self):
         template_rendered.connect(self._store_template_info)

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -199,16 +199,16 @@ def patch_middleware_classes():
 
 
 def patch_root_urlconf():
-    from django.conf.urls import include, patterns, url
+    from django.conf.urls import include, url
     from django.core.urlresolvers import clear_url_caches, reverse, NoReverseMatch
     import debug_toolbar
     try:
         reverse('djdt:render_panel')
     except NoReverseMatch:
         urlconf_module = import_module(settings.ROOT_URLCONF)
-        urlconf_module.urlpatterns = patterns('',                      # noqa
+        urlconf_module.urlpatterns = [
             url(r'^__debug__/', include(debug_toolbar.urls)),
-        ) + urlconf_module.urlpatterns
+        ] + urlconf_module.urlpatterns
         clear_url_caches()
 
 

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -12,7 +12,7 @@ import uuid
 
 import django
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
@@ -151,11 +151,12 @@ class DebugToolbar(object):
     @classmethod
     def get_urls(cls):
         if cls._urlpatterns is None:
+            from . import views
             # Load URLs in a temporary variable for thread safety.
             # Global URLs
-            urlpatterns = patterns('debug_toolbar.views',               # noqa
-                url(r'^render_panel/$', 'render_panel', name='render_panel'),
-            )
+            urlpatterns = [
+                url(r'^render_panel/$', views.render_panel, name='render_panel'),
+            ]
             # Per-panel URLs
             for panel_class in cls.get_panel_classes():
                 urlpatterns += panel_class.get_urls()


### PR DESCRIPTION
this is compatible with django1.4+ and fixes the warnings on django master.
