### PR TITLE
Support static files with LiveServerTestCase.

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,7 +12,13 @@ try:
 except ImportError:
     webdriver = None
 
-from django.test import LiveServerTestCase, RequestFactory, TestCase
+try:
+    from django.contrib.staticfiles.testing import StaticLiveServerTestCase \
+        as LiveServerTestCase
+except ImportError:
+    # When we're using < Django 1.7
+    from django.test import LiveServerTestCase
+from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.utils.unittest import skipIf, skipUnless
 

--- a/tox.ini
+++ b/tox.ini
@@ -89,25 +89,25 @@ deps =
 [testenv:py27-django17]
 basepython = python2.7
 deps =
-    https://www.djangoproject.com/download/1.7b1/tarball/
+    Django>=1.7,<1.8
     {[testenv]deps}
 
 [testenv:py32-django17]
 basepython = python3.2
 deps =
-    https://www.djangoproject.com/download/1.7b1/tarball/
+    Django>=1.7,<1.8
     {[testenv]deps}
 
 [testenv:py33-django17]
 basepython = python3.3
 deps =
-    https://www.djangoproject.com/download/1.7b1/tarball/
+    Django>=1.7,<1.8
     {[testenv]deps}
 
 [testenv:py34-django17]
 basepython = python3.4
 deps =
-    https://www.djangoproject.com/download/1.7b1/tarball/
+    Django>=1.7,<1.8
     {[testenv]deps}
 
 [testenv:flake8]


### PR DESCRIPTION
Change the Django 1.7 dependencies in the tox.ini so they pull from pypi rather than the builds on www.djangoproject.com.

Currently the selenium related tests will fail with Django 1.7 due to LiveServerTestCase no longer serving up the static files. I have changed it so it will try to import the StaticLiveServerTestCase class first and then the LiveServerTestCase if it fails. 
