### PR TITLE
configured_storage_cls can be a function

### DIFF
--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -61,6 +61,8 @@ class DebugConfiguredStorage(LazyObject):
     def _setup(self):
 
         configured_storage_cls = get_storage_class(settings.STATICFILES_STORAGE)
+        if hasattr(configured_storage_cls, '__call__'):
+            configured_storage_cls = configured_storage_cls()
 
         class DebugStaticFilesStorage(configured_storage_cls):
 


### PR DESCRIPTION
Functions can used with S3BotoStorage like so:

StaticRootS3BotoStorage = lambda: S3BotoStorage(location='static')
MediaRootS3BotoStorage  = lambda: S3BotoStorage(location='media')
