### PR TITLE
Add Template Profiler Panel

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -247,6 +247,15 @@ Path: ``template_timings_panel.panels.TemplateTimings.TemplateTimings``
 
 Displays template rendering times for your Django application.
 
+Template Profiler
+~~~~~~~~~~~~~~~~~
+
+URL: https://github.com/node13h/django-debug-toolbar-template-profiler
+
+Path: ``template_profiler_panel.panels.template.TemplateProfilerPanel``
+
+Shows template render call duration and distribution on the timeline. Lightweight. Compatible with WSGI servers which reuse threads for multiple requests (Werkzeug).
+
 User
 ~~~~
 


### PR DESCRIPTION
This one is similar to Template Timings, but uses
different visualisation approach and also works
correctly with servers which reuse threads for different
requests.

Does not include any SQL stats.
