### PR TITLE
Check if context is dictionary and process further

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -55,8 +55,7 @@ def _request_context__init__(
         context = processor(request)
         self.context_processors[name] = context
         if isinstance(context, dict):
-            for k, v in context.iteritems():
-                updates[k] = v
+            updates.update(context)
     self.update(updates)
 
 RequestContext.__init__ = _request_context__init__


### PR DESCRIPTION
Sorry, I was using this pull request for the first time and got confused. 

Anyways, I was having this issue: ValueError: dictionary update sequence element #0 has length 0; 2 is required at debug_toolbar.panels.templates.panel in _request_context__init__. 

It looks like it's complaining that request context consists an object. When rendering to response I always pass variables into context so that I can use them in templates. Isn't that a common Django practice?

So this fix just checks if context is dictionary and processes further. 

Here's the stacktrace: 
![screenshot at nov 05 22-01-46](https://cloud.githubusercontent.com/assets/2887118/4930246/53bbd406-6561-11e4-9417-d354a979cf02.png)
