### PR TITLE
Support Django's cached template loader.

### DIFF
--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -21,7 +21,13 @@ def template_source(request):
     for loader_name in settings.TEMPLATE_LOADERS:
         loader = find_template_loader(loader_name)
         if loader is not None:
-            loaders.append(loader)
+            # When the loader has loaders associated with it,
+            # append those loaders to the list. This occurs with
+            # django.template.loaders.cached.Loader
+            if hasattr(loader, 'loaders'):
+                loaders += loader.loaders
+            else:
+                loaders.append(loader)
     for loader in loaders:
         try:
             source, display_name = loader.load_template_source(template_name)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -159,3 +159,28 @@ class DebugToolbarLiveTestCase(LiveServerTestCase):
         error = WebDriverWait(self.selenium, timeout=10).until(
             lambda selenium: version_panel.find_element_by_tag_name('p'))
         self.assertIn("Data for this panel isn't available anymore.", error.text)
+
+    @override_settings(TEMPLATE_LOADERS=[(
+        'django.template.loaders.cached.Loader', (
+            'django.template.loaders.filesystem.Loader',
+            'django.template.loaders.app_directories.Loader',
+        ),
+    )])
+    def test_django_cached_template_loader(self):
+        self.selenium.get(self.live_server_url + '/regular/basic/')
+        version_panel = self.selenium.find_element_by_id('TemplatesPanel')
+
+        # Click to show the versions panel
+        self.selenium.find_element_by_class_name('TemplatesPanel').click()
+
+        # Version panel loads
+        trigger = WebDriverWait(self.selenium, timeout=10).until(
+            lambda selenium: version_panel.find_element_by_css_selector(
+                '.remoteCall'))
+        trigger.click()
+
+        # Verify the code is displayed
+        WebDriverWait(self.selenium, timeout=10).until(
+            lambda selenium: self.selenium.find_element_by_css_selector(
+                '#djDebugWindow code'))
+


### PR DESCRIPTION
Closes #660 
This approach assumes that other template loaders with similar functionality to the cached template loader will have the actual template loaders stored in the `loaders` property.
