### PR TITLE
fix find_template_loader move on django 1.8

### DIFF
--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -4,7 +4,10 @@ from django.http import HttpResponseBadRequest
 from django.conf import settings
 from django.shortcuts import render_to_response
 from django.template import TemplateDoesNotExist
-from django.template.loader import find_template_loader
+try:
+    from django.template.loaders.utils import find_template_loader
+except ImportError:  # django < 1.8
+    from django.template.loader import find_template_loader
 from django.utils.safestring import mark_safe
 
 


### PR DESCRIPTION
the undocumented find_template_loader was moved in django 1.8.
