### PR TITLE
add the 'CHECK_FOR_INTERNAL_IPS' configuration option

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -24,8 +24,9 @@ def show_toolbar(request):
     """
     Default function to determine whether to show the toolbar on a given page.
     """
-    if request.META.get('REMOTE_ADDR', None) not in settings.INTERNAL_IPS:
-        return False
+    if dt_settings.CONFIG['CHECK_FOR_INTERNAL_IPS']:
+        if request.META.get('REMOTE_ADDR', None) not in settings.INTERNAL_IPS:
+            return False
 
     if request.is_ajax():
         return False

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -23,6 +23,7 @@ CONFIG_DEFAULTS = {
     'RESULTS_CACHE_SIZE': 10,
     'ROOT_TAG_EXTRA_ATTRS': '',
     'SHOW_COLLAPSED': False,
+    'CHECK_FOR_INTERNAL_IPS': True,
     'SHOW_TOOLBAR_CALLBACK': 'debug_toolbar.middleware.show_toolbar',
     # Panel options
     'EXTRA_SIGNALS': [],

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -124,6 +124,13 @@ Toolbar options
   request must not be an AJAX request. You can provide your own function
   ``callback(request)`` which returns ``True`` or ``False``.
 
+* ``CHECK_FOR_INTERNAL_IPS``
+
+  Default: ``True``
+
+  Checks that the IP of the client in the request is in ``INTERNAL_IPS`` in the default
+  toolbar callback. (INTERNAL_IPS default to ``("127.0.0.1", "::1")`` )
+  
 Panel options
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
to disable internal ips check in the middleware. 

As more and more people (including me :-) ) are using virtualisation solution for dev (Docker, vagrant .. ) you might not know what to put in INTERNAL_IPS, and the  SHOW_TOOLBAR_CALLBACK option is difficult to understand for such a trivial problem. 
The new option is false by default, and if true will disable the IP address checks (so it has to be a conscious choice). The rationale is that if you are using docker to develop, the container is not public anyway. 

