### PR TITLE
Add requires.io badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,10 @@ Django Debug Toolbar
     :alt: Build Status
     :target: http://travis-ci.org/django-debug-toolbar/django-debug-toolbar
 
+.. image:: https://requires.io/github/django-debug-toolbar/django-debug-toolbar/requirements.svg?branch=master
+     :target: https://requires.io/github/django-debug-toolbar/django-debug-toolbar/requirements/?branch=master
+     :alt: Requirements Status
+
 The Django Debug Toolbar is a configurable set of panels that display various
 debug information about the current request/response and when clicked, display
 more details about the panel's content.


### PR DESCRIPTION
Hi,

Adding a badge I was talking about.

I think it would be useful to enable notifications about outdated versions from this service.