### PR TITLE
Make DebugToolarMiddleware compatible with Django 1.10's MIDDLEWARE setting

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,23 @@
 Change log
 ==========
 
+1.6 (upcoming)
+--------------
+
+Removed features
+~~~~~~~~~~~~~~~~
+
+* Support for automatic setup has been removed. Installation now requires
+  explicit setup. As a result, the ``DEBUG_TOOLBAR_PATCH_SETTINGS`` setting has
+  also been removed. See the :doc:`installation documentation <installation>`
+  for details.
+
+Bugfixes
+~~~~~~~~
+
+* The ``DebugToolbarMiddleware`` now also supports Django 1.10's ``MIDDLEWARE``
+  setting.
+
 1.5
 ---
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -32,6 +32,7 @@ MEDIA_URL = '/media/'   # Avoids https://code.djangoproject.com/ticket/21451
 MIDDLEWARE_CLASSES = [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
(Refs #853.)

I'd very much appreciate additional guidance on required tests and/or docs. Modifying `tests/settings.py` to contain MIDDLEWARE instead of MIDDLEWARE_CLASSES does not work (obviously). 

Thanks for the project, and thanks for your time.