### PR TITLE
Remove unused import.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,7 +43,7 @@ URLconf
 Add the Debug Toolbar's URLs to your project's URLconf as follows::
 
     from django.conf import settings
-    from django.conf.urls import include, patterns, url
+    from django.conf.urls import include, url
 
     if settings.DEBUG:
         import debug_toolbar


### PR DESCRIPTION
`django.conf.urls.patterns` has been deprecated and removed as of Django 1.10.