### PR TITLE
use HMAC and timing safe comparison

### DIFF
--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -8,8 +8,8 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import connections
-from django.utils.encoding import force_text
 from django.utils.crypto import constant_time_compare
+from django.utils.encoding import force_text
 from django.utils.functional import cached_property
 
 from debug_toolbar.panels.sql.utils import reformat_sql
@@ -83,7 +83,8 @@ class SQLSelectForm(forms.Form):
         # Replace lines endings with spaces to preserve the hash value
         # even when the browser normalizes \r\n to \n in inputs.
         items = [' '.join(force_text(item).splitlines()) for item in items]
-        return hmac.new(settings.SECRET_KEY, ''.join(items).encode('utf-8'), hashlib.sha1).hexdigest()
+        return hmac.new(settings.SECRET_KEY.encode('utf-8'),
+                        ''.join(items).encode('utf-8'), hashlib.sha1).hexdigest()
 
     @property
     def connection(self):


### PR DESCRIPTION
Instead of naive code vulnerable to length-extension attack and instead of short-circuiting string comparison.

https://en.wikipedia.org/wiki/Hash-based_message_authentication_code#Design_principles

https://docs.python.org/2/library/hmac.html#hmac.compare_digest
