### PR TITLE
Support recursive template extension.

### DIFF
--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -6,15 +6,21 @@ from django.template import TemplateDoesNotExist
 from django.template.engine import Engine
 from django.utils.safestring import mark_safe
 
+try:
+    from django.template import Origin
+except ImportError:
+    Origin = None
+
 
 def template_source(request):
     """
     Return the source of a template, syntax-highlighted by Pygments if
     it's available.
     """
-    template_name = request.GET.get('template', None)
-    if template_name is None:
-        return HttpResponseBadRequest('"template" key is required')
+    template_origin_name = request.GET.get('template_origin', None)
+    if template_origin_name is None:
+        return HttpResponseBadRequest('"template_origin" key is required')
+    template_name = request.GET.get('template', template_origin_name)
 
     final_loaders = []
     loaders = Engine.get_default().template_loaders
@@ -30,11 +36,21 @@ def template_source(request):
                 final_loaders.append(loader)
 
     for loader in final_loaders:
-        try:
-            source, display_name = loader.load_template_source(template_name)
-            break
-        except TemplateDoesNotExist:
-            source = "Template Does Not Exist: %s" % (template_name,)
+        if Origin:  # django>=1.9
+            origin = Origin(template_origin_name)
+            try:
+                source = loader.get_contents(origin)
+                break
+            except TemplateDoesNotExist:
+                pass
+        else:  # django<1.9
+            try:
+                source, _ = loader.load_template_source(template_name)
+                break
+            except TemplateDoesNotExist:
+                pass
+    else:
+        source = "Template Does Not Exist: %s" % (template_origin_name,)
 
     try:
         from pygments import highlight

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -14,7 +14,7 @@
 {% if templates %}
 <dl>
 {% for template in templates %}
-	<dt><strong><a class="remoteCall toggleTemplate" href="{% url 'djdt:template_source' %}?template={{ template.template.name }}">{{ template.template.name|addslashes }}</a></strong></dt>
+<dt><strong><a class="remoteCall toggleTemplate" href="{% url 'djdt:template_source' %}?template={{ template.template.name }}&template_origin={{ template.template.origin_name }}">{{ template.template.name|addslashes }}</a></strong></dt>
 	<dd><samp>{{ template.template.origin_name|addslashes }}</samp></dd>
 	{% if template.context %}
 	<dd>


### PR DESCRIPTION
From the [django 1.9 release
notes](https://docs.djangoproject.com/en/1.10/releases/1.9/):

> - Django template loaders can now extend templates recursively.

...

> Django template loaders have been updated to allow recursive template
> extending. This change necessitated a new template loader API. The old
> load_template() and load_template_sources() methods are now
> deprecated.

Prior to this patch, when a template is recursively extended the latest
template in the template loaders is displayed regardless of the template
origin since the proper template can no longer be disambiguated by
template_name.
