### PR TITLE
Fix issue that occurs when using bytes as secret key.

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,7 +7,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Quick-start development settings - unsuitable for production
 
-SECRET_KEY = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
+SECRET_KEY = bytes(bytearray([i for i in range(256)]))
 
 INTERNAL_IPS = ['127.0.0.1']
 


### PR DESCRIPTION
The Django secret key can and should be random bytes which may or may
not be decodable to UTF-8.