### PR TITLE
Encode with response's charset

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -119,7 +119,7 @@ class DebugToolbarMiddleware(MiddlewareMixin):
             response.set_cookie('djdt', 'hide', 864000)
 
         # Insert the toolbar in the response.
-        content = force_text(response.content, encoding=settings.DEFAULT_CHARSET)
+        content = force_text(response.content, encoding=response.charset)
         insert_before = dt_settings.get_config()['INSERT_BEFORE']
         pattern = re.escape(insert_before)
         bits = re.split(pattern, content, flags=re.IGNORECASE)


### PR DESCRIPTION
If charset is changed, raise following.

```
Traceback:

File "/Users/kitahara/.virtualenvs/test/lib/python3.5/site-packages/django/utils/encoding.py" in force_text
  74.                     s = six.text_type(s, encoding, errors)

During handling of the above exception ('utf-8' codec can't decode byte 0x83 in position 156: invalid start byte), another exception occurred:

File "/Users/kitahara/.virtualenvs/test/lib/python3.5/site-packages/django/core/handlers/exception.py" in inner
  39.             response = get_response(request)

File "/Users/kitahara/.virtualenvs/test/lib/python3.5/site-packages/django/utils/deprecation.py" in __call__
  138.             response = self.process_response(request, response)

File "/Users/kitahara/.virtualenvs/test/lib/python3.5/site-packages/debug_toolbar/middleware.py" in process_response
  122.         content = force_text(response.content, encoding=settings.DEFAULT_CHARSET)

File "/Users/kitahara/.virtualenvs/test/lib/python3.5/site-packages/django/utils/encoding.py" in force_text
  88.             raise DjangoUnicodeDecodeError(s, *e.args)
```