### PR TITLE
Pass through extra cursor arguments.

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -38,8 +38,8 @@ def wrap_cursor(connection, panel):
     if not hasattr(connection, '_djdt_cursor'):
         connection._djdt_cursor = connection.cursor
 
-        def cursor():
-            return state.Wrapper(connection._djdt_cursor(), connection, panel)
+        def cursor(*args, **kwargs):
+            return state.Wrapper(connection._djdt_cursor(*args, **kwargs), connection, panel)
 
         connection.cursor = cursor
         return cursor


### PR DESCRIPTION
Hi there. We have a server-side cursor implementation for PostgreSQL and Django and it requires us to pass in the name of the cursor to the `.cursor` method on connections. The `wrap_cursor` wrapper doesn't pass through arguments by default, so I made a very minor change to do so.