### PR TITLE
Bullet-proof the test for window.define in jquery_pre.js and ..._post.js

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/jquery_post.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_post.js
@@ -1,4 +1,4 @@
 var djdt = {jQuery: jQuery.noConflict(true)};
-if (window.define) {
+if (typeof window.define is "function" && window.define.amd) {
     window.define.amd = _djdt_define_amd_backup;
 }

--- a/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
+++ b/debug_toolbar/static/debug_toolbar/js/jquery_pre.js
@@ -1,5 +1,5 @@
 var _djdt_define_amd_backup;
-if (window.define) {
+if (typeof window.define is "function" && window.define.amd) {
     _djdt_define_amd_backup = window.define.amd;
     window.define.amd = undefined;
 }


### PR DESCRIPTION
The existing test `if (window.define)` could fail in obscure circumstances where someone is using `window.define` for another purpose. The suggested fix reduces the chance of that significantly.