### PR TITLE
Use latest version of Selenium for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10a,<1.11
     coverage
-    selenium<3.0
+    selenium<4.0
     sqlparse
     django_jinja
 setenv =


### PR DESCRIPTION
Travis failure is due to breaking change in a readme_renderer dependency, and unrelated to this commit. See https://github.com/pypa/readme_renderer/pull/48