### PR TITLE
Add a third <col> element to versions.html template

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/versions.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/versions.html
@@ -1,7 +1,10 @@
 {% load i18n %}
 <table>
-    <col style="width:15%">
-    <col style="width:15%">
+	<colgroup>
+		<col style="width:15%">
+		<col style="width:15%">
+		<col>
+	</colgroup>
 	<thead>
 		<tr>
             <th>{% trans "Package" %}</th>


### PR DESCRIPTION
The number of `<col>` elements should match the number of rendered columns
for HTML5 validation.

Without the third `<col>`, <https://html5.validator.nu/> reports:

> A table row was 3 columns wide and exceeded the column count established
using column markup (2).