### PR TITLE
Consistently use HTML5 self closing tag syntax

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/request.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request.html
@@ -24,8 +24,8 @@
 	<h4>{% trans "Cookies" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20"/>
-			<col/>
+			<col class="djdt-width-20" />
+			<col />
 		</colgroup>
 		<thead>
 			<tr>
@@ -50,8 +50,8 @@
 	<h4>{% trans "Session data" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20"/>
-			<col/>
+			<col class="djdt-width-20" />
+			<col />
 		</colgroup>
 		<thead>
 			<tr>
@@ -76,8 +76,8 @@
 	<h4>{% trans "GET data" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20"/>
-			<col/>
+			<col class="djdt-width-20" />
+			<col />
 		</colgroup>
 		<thead>
 			<tr>
@@ -102,8 +102,8 @@
 	<h4>{% trans "POST data" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20"/>
-			<col/>
+			<col class="djdt-width-20" />
+			<col />
 		</colgroup>
 			<tr>
 				<th>{% trans "Variable" %}</th>

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -2,8 +2,8 @@
 <h4>{% trans "Resource usage" %}</h4>
 <table>
 	<colgroup>
-		<col class="djdt-width-20"/>
-		<col/>
+		<col class="djdt-width-20" />
+		<col />
 	</colgroup>
 	<thead>
 		<tr>
@@ -26,9 +26,9 @@
 	<h4>{% trans "Browser timing" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20"/>
-			<col class="djdt-width-60"/>
-			<col class="djdt-width-20"/>
+			<col class="djdt-width-20" />
+			<col class="djdt-width-60" />
+			<col class="djdt-width-20" />
 		</colgroup>
 		<thead>
 			<tr>

--- a/debug_toolbar/templates/debug_toolbar/panels/versions.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/versions.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <table>
 	<colgroup>
-		<col style="width:15%">
-		<col style="width:15%">
-		<col>
+		<col style="width:15%" />
+		<col style="width:15%" />
+		<col />
 	</colgroup>
 	<thead>
 		<tr>

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>Index of Tests</title>
 </head>
 <body>

--- a/example/templates/jquery/index.html
+++ b/example/templates/jquery/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<title>jQuery Test</title>
 	<style>
 	.hide {display:none;}

--- a/example/templates/mootools/index.html
+++ b/example/templates/mootools/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<title>MooTools Test</title>
 	<style>
 	.hide {display:none;}

--- a/example/templates/prototype/index.html
+++ b/example/templates/prototype/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8">
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 	<title>Prototype Test</title>
 	<style>
 	.hide {display:none;}
@@ -18,4 +18,3 @@
 	<p class="hide" id="showme">If you see this, Prototype is working.</p>
 </body>
 </html>
-


### PR DESCRIPTION
Was previously a mix of "`/>`", "` />`", and "`>`".

As a result of using HTML5 syntax, removed XML test.