### PR TITLE
Prevent unauthorized access to views

### DIFF
--- a/debug_toolbar/decorators.py
+++ b/debug_toolbar/decorators.py
@@ -1,0 +1,16 @@
+import functools
+
+from django.http import Http404
+
+from debug_toolbar.middleware import get_show_toolbar
+
+
+def require_show_toolbar(view):
+    @functools.wraps(view)
+    def inner(request, *args, **kwargs):
+        show_toolbar = get_show_toolbar()
+        if not show_toolbar(request):
+            raise Http404
+
+        return view(request, *args, **kwargs)
+    return inner

--- a/debug_toolbar/panels/sql/views.py
+++ b/debug_toolbar/panels/sql/views.py
@@ -4,10 +4,12 @@ from django.http import HttpResponseBadRequest
 from django.shortcuts import render_to_response
 from django.views.decorators.csrf import csrf_exempt
 
+from debug_toolbar.decorators import require_show_toolbar
 from debug_toolbar.panels.sql.forms import SQLSelectForm
 
 
 @csrf_exempt
+@require_show_toolbar
 def sql_select(request):
     """Returns the output of the SQL SELECT statement"""
     form = SQLSelectForm(request.POST or None)
@@ -33,6 +35,7 @@ def sql_select(request):
 
 
 @csrf_exempt
+@require_show_toolbar
 def sql_explain(request):
     """Returns the output of the SQL EXPLAIN on the given query"""
     form = SQLSelectForm(request.POST or None)
@@ -69,6 +72,7 @@ def sql_explain(request):
 
 
 @csrf_exempt
+@require_show_toolbar
 def sql_profile(request):
     """Returns the output of running the SQL and getting the profiling statistics"""
     form = SQLSelectForm(request.POST or None)

--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -6,12 +6,15 @@ from django.template import TemplateDoesNotExist
 from django.template.engine import Engine
 from django.utils.safestring import mark_safe
 
+from debug_toolbar.decorators import require_show_toolbar
+
 try:
     from django.template import Origin
 except ImportError:
     Origin = None
 
 
+@require_show_toolbar
 def template_source(request):
     """
     Return the source of a template, syntax-highlighted by Pygments if

--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -4,9 +4,11 @@ from django.http import HttpResponse
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
 
+from debug_toolbar.decorators import require_show_toolbar
 from debug_toolbar.toolbar import DebugToolbar
 
 
+@require_show_toolbar
 def render_panel(request):
     """Render the contents of a panel"""
     toolbar = DebugToolbar.fetch(request.GET['store_id'])

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,20 @@ Change log
 1.8 (upcoming)
 --------------
 
+Features
+~~~~~~~~
+
+* New decorator ``debug_toolbar.decorators.require_show_toolbar`` prevents
+  unauthorized access to decorated views by checking ``SHOW_TOOLBAR_CALLBACK``
+  every request. Unauthorized access results in a 404.
+
+Bugfixes
+~~~~~~~~
+
+* All views are now decorated with
+  ``debug_toolbar.decorators.require_show_toolbar`` preventing unauthorized
+  access.
+
 1.7
 ---
 

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -309,8 +309,9 @@ Third-party panels must subclass :class:`~debug_toolbar.panels.Panel`,
 according to the public API described below. Unless noted otherwise, all
 methods are optional.
 
-Panels can ship their own templates, static files and views. There is no public
-CSS API at this time.
+Panels can ship their own templates, static files and views. All views should
+be decorated with ``debug_toolbar.decorators.require_show_toolbar`` to prevent
+unauthorized access. There is no public CSS API at this time.
 
 .. autoclass:: debug_toolbar.panels.Panel(*args, **kwargs)
 


### PR DESCRIPTION
All views in debug_toolbar are now decorated with the new
debug_toolbar.decorators.require_show_toolbar. This prevents access when
the function defined by SHOW_TOOLBAR_CALLBACK returns False. For
example, when a request originated form outside INTERNAL_IPS.

Fixes #834