### PR TITLE
Possible fix for pathological performance in Django 1.11 (widget rendering)

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -69,6 +69,16 @@ class TemplatesPanel(Panel):
     def __init__(self, *args, **kwargs):
         super(TemplatesPanel, self).__init__(*args, **kwargs)
         self.templates = []
+        # Refs GitHub issue #910
+        # Hold a series of seen dictionaries within Contexts. A dictionary is
+        # considered seen if it is `in` this list, requiring that the __eq__
+        # for the dictionary matches. If *anything* in the dictionary is
+        # different it is counted as a new layer.
+        self.seen_layers = []
+        # Holds all dictionaries which have been prettified for output.
+        # This should align with the seen_layers such that an index here is
+        # the same as the index there.
+        self.pformat_layers = []
 
     def _store_template_info(self, sender, **kwargs):
         template, context = kwargs['template'], kwargs['context']
@@ -80,47 +90,66 @@ class TemplatesPanel(Panel):
 
         context_list = []
         for context_layer in context.dicts:
-            temp_layer = {}
-            if hasattr(context_layer, 'items'):
-                for key, value in context_layer.items():
-                    # Replace any request elements - they have a large
-                    # unicode representation and the request data is
-                    # already made available from the Request panel.
-                    if isinstance(value, http.HttpRequest):
-                        temp_layer[key] = '<<request>>'
-                    # Replace the debugging sql_queries element. The SQL
-                    # data is already made available from the SQL panel.
-                    elif key == 'sql_queries' and isinstance(value, list):
-                        temp_layer[key] = '<<sql_queries>>'
-                    # Replace LANGUAGES, which is available in i18n context processor
-                    elif key == 'LANGUAGES' and isinstance(value, tuple):
-                        temp_layer[key] = '<<languages>>'
-                    # QuerySet would trigger the database: user can run the query from SQL Panel
-                    elif isinstance(value, (QuerySet, RawQuerySet)):
-                        model_name = "%s.%s" % (
-                            value.model._meta.app_label, value.model.__name__)
-                        temp_layer[key] = '<<%s of %s>>' % (
-                            value.__class__.__name__.lower(), model_name)
-                    else:
-                        try:
-                            recording(False)
-                            pformat(value)  # this MAY trigger a db query
-                        except SQLQueryTriggered:
-                            temp_layer[key] = '<<triggers database query>>'
-                        except UnicodeEncodeError:
-                            temp_layer[key] = '<<unicode encode error>>'
-                        except Exception:
-                            temp_layer[key] = '<<unhandled exception>>'
+            if hasattr(context_layer, 'items') and context_layer:
+                # Refs GitHub issue #910
+                # If we can find this layer in our pseudo-cache then find the
+                # matching prettified version in the associated list.
+                key_values = sorted(context_layer.items())
+                if key_values in self.seen_layers:
+                    index = self.seen_layers.index(key_values)
+                    pformatted = self.pformat_layers[index]
+                    context_list.append(pformatted)
+                else:
+                    temp_layer = {}
+                    for key, value in context_layer.items():
+                        # Replace any request elements - they have a large
+                        # unicode representation and the request data is
+                        # already made available from the Request panel.
+                        if isinstance(value, http.HttpRequest):
+                            temp_layer[key] = '<<request>>'
+                        # Replace the debugging sql_queries element. The SQL
+                        # data is already made available from the SQL panel.
+                        elif key == 'sql_queries' and isinstance(value, list):
+                            temp_layer[key] = '<<sql_queries>>'
+                        # Replace LANGUAGES, which is available in i18n context processor
+                        elif key == 'LANGUAGES' and isinstance(value, tuple):
+                            temp_layer[key] = '<<languages>>'
+                        # QuerySet would trigger the database: user can run the query from SQL Panel
+                        elif isinstance(value, (QuerySet, RawQuerySet)):
+                            model_name = "%s.%s" % (
+                                value.model._meta.app_label, value.model.__name__)
+                            temp_layer[key] = '<<%s of %s>>' % (
+                                value.__class__.__name__.lower(), model_name)
                         else:
-                            temp_layer[key] = value
-                        finally:
-                            recording(True)
-            try:
-                context_list.append(pformat(temp_layer))
-            except UnicodeEncodeError:
-                pass
+                            try:
+                                recording(False)
+                                force_text(value)  # this MAY trigger a db query
+                            except SQLQueryTriggered:
+                                temp_layer[key] = '<<triggers database query>>'
+                            except UnicodeEncodeError:
+                                temp_layer[key] = '<<unicode encode error>>'
+                            except Exception:
+                                temp_layer[key] = '<<unhandled exception>>'
+                            else:
+                                temp_layer[key] = value
+                            finally:
+                                recording(True)
+                    # Refs GitHub issue #910
+                    # If we've not seen the layer before then we will add it
+                    # so that if we see it again we can skip formatting it.
+                    self.seen_layers.append(key_values)
+                    # Note: this *ought* to be len(...) - 1 but let's be safe.
+                    index = self.seen_layers.index(key_values)
+                    try:
+                        pformatted = force_text(pformat(temp_layer))
+                    except UnicodeEncodeError:
+                        pass
+                    else:
+                        # Note: this *ought* to be len(...) - 1 but let's be safe.
+                        self.pformat_layers.insert(index, pformatted)
+                        context_list.append(pformatted)
 
-        kwargs['context'] = [force_text(item) for item in context_list]
+        kwargs['context'] = context_list
         kwargs['context_processors'] = getattr(context, 'context_processors', None)
         self.templates.append(kwargs)
 


### PR DESCRIPTION
See #910 for details.
Essentially, try and reduce the number of calls to `pformat` by storing a string representation of a given context layer and only doing a `pformat` when we haven't seen it before.

In practice for me on Python 2.7 this makes a massive difference. 
In theory the difference is somewhere between the best case I'm presenting, and the current pathological situation, because a context which itself contains nested un-ordered data structures (sets, dictionaries) probably don't guarantee their output when converted to a string representation, but there's not a huge amount that can be done by that, I don't think.

Rendering a *user* change form in the admin with *50* groups, in the current pathological case will do **1121**  `pformat` calls at the point where it attempts to put the `temp_layer` in the `context_list` and another **2226** to `pformat` an individual value within a context layer.

With the proposed changes, the total number of pformat calls becomes **175**, which is slightly under the number of templates rendered.

These numbers are only my findings using a single test case, one version of Python, and one operating system (OSX) ... so if anyone wants to try this patch out to independently verify whether or not it has a real world affect elsewhere, that'd be nice.