### PR TITLE
Fix #922: Assume less about the signature of apps' `get_version()` in VersionsPanel

### DIFF
--- a/debug_toolbar/panels/versions.py
+++ b/debug_toolbar/panels/versions.py
@@ -41,20 +41,25 @@ class VersionsPanel(Panel):
                 yield app.__name__, name, version
 
     def get_app_version(self, app):
-        if hasattr(app, 'get_version'):
-            get_version = app.get_version
-            if callable(get_version):
-                version = get_version()
-            else:
-                version = get_version
-        elif hasattr(app, 'VERSION'):
-            version = app.VERSION
-        elif hasattr(app, '__version__'):
-            version = app.__version__
-        else:
-            return
+        version = self.get_version_from_app(app)
         if isinstance(version, (list, tuple)):
             # We strip dots from the right because we do not want to show
             # trailing dots if there are empty elements in the list/tuple
             version = '.'.join(str(o) for o in version).rstrip('.')
         return version
+
+    def get_version_from_app(self, app):
+        if hasattr(app, 'get_version'):
+            get_version = app.get_version
+            if callable(get_version):
+                try:
+                    return get_version()
+                except TypeError:
+                    pass
+            else:
+                return get_version
+        if hasattr(app, 'VERSION'):
+            return app.VERSION
+        if hasattr(app, '__version__'):
+            return app.__version__
+        return

--- a/tests/panels/test_versions.py
+++ b/tests/panels/test_versions.py
@@ -25,6 +25,18 @@ class VersionsPanelTestCase(BaseTestCase):
 
         self.assertEqual(self.panel.get_app_version(FakeApp()), '1.2.3')
 
+    def test_incompatible_app_version_fn(self):
+
+        class FakeApp:
+
+            def get_version(self, some_other_arg):
+                # This should be ignored by the get_version_from_app
+                return version_info_t(0, 0, 0, '', '')
+
+            VERSION = version_info_t(1, 2, 3, '', '')
+
+        self.assertEqual(self.panel.get_app_version(FakeApp()), '1.2.3')
+
     def test_app_version_from_VERSION(self):
 
         class FakeApp:
@@ -32,7 +44,7 @@ class VersionsPanelTestCase(BaseTestCase):
 
         self.assertEqual(self.panel.get_app_version(FakeApp()), '1.2.3')
 
-    def test_app_version_from_underscode_version(self):
+    def test_app_version_from_underscore_version(self):
 
         class FakeApp:
             __version__ = version_info_t(1, 2, 3, '', '')


### PR DESCRIPTION
Fixes #922

Greetings :) Since nobody else has picked this up here, I decided to submit a fix myself (The issue was originally raised on the wagtailmenus issue board, which is a project I run in my spare time). Hope you don't mind me abstracting things out further into another method - it seemed to me to be the most efficient solution -  Always happy to hear alternative suggestions though.

