### PR TITLE
Escape stats output in profiling panel

### DIFF
--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -6,7 +6,7 @@ from colorsys import hsv_to_rgb
 from pstats import Stats
 
 from django.utils import six
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
 from debug_toolbar import settings as dt_settings
@@ -78,15 +78,15 @@ class FunctionCall(object):
 
             file_path, file_name = file_name.rsplit(os.sep, 1)
 
-            return mark_safe(
+            return format_html(
                 '<span class="djdt-path">{0}/</span>'
                 '<span class="djdt-file">{1}</span>'
                 ' in <span class="djdt-func">{3}</span>'
-                '(<span class="djdt-lineno">{2}</span>)'.format(
-                    file_path,
-                    file_name,
-                    line_num,
-                    method))
+                '(<span class="djdt-lineno">{2}</span>)',
+                file_path,
+                file_name,
+                line_num,
+                method)
 
     def subfuncs(self):
         i = 0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,14 @@
 Change log
 ==========
 
+1.9 (upcoming)
+--------------
+
+Bugfixes
+~~~~~~~~
+
+* The profiling panel now escapes reported data resulting in valid HTML.
+
 1.8
 ---
 

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
+import unittest
+
 from django.contrib.auth.models import User
 from django.db import IntegrityError, transaction
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils import six
 
 from ..base import BaseTestCase
-from ..views import regular_view
+from ..views import listcomp_view, regular_view
 
 
 @override_settings(DEBUG_TOOLBAR_PANELS=['debug_toolbar.panels.profiling.ProfilingPanel'])
@@ -35,6 +38,13 @@ class ProfilingPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, self.response)
         # ensure the panel renders correctly.
         self.assertIn('regular_view', self.panel.content)
+
+    @unittest.skipIf(six.PY2, 'list comprehension not listed on Python 2')
+    def test_listcomp_escaped(self):
+        self.panel.process_view(self.request, listcomp_view, (), {})
+        self.panel.generate_stats(self.request, self.response)
+        self.assertNotIn('<span class="djdt-func"><listcomp></span>', self.panel.content)
+        self.assertIn('<span class="djdt-func">&lt;listcomp&gt;</span>', self.panel.content)
 
 
 @override_settings(DEBUG=True,

--- a/tests/views.py
+++ b/tests/views.py
@@ -34,3 +34,8 @@ def cached_view(request):
 
 def regular_jinjia_view(request, title):
     return render(request, 'jinja2/basic.jinja', {'title': title})
+
+
+def listcomp_view(request):
+    lst = [i for i in range(50000) if i % 2 == 0]
+    return render(request, 'basic.html', {'title': 'List comprehension', 'lst': lst})


### PR DESCRIPTION
A time consuming list comprehension is rendered as "`<listcomp>`". As this
contains angular brackets, it should be escaped to be valid HTML.