### PR TITLE
Remove deprecated INTERCEPT_REDIRECTS from tests

### DIFF
--- a/tests/panels/test_redirects.py
+++ b/tests/panels/test_redirects.py
@@ -4,12 +4,10 @@ import copy
 
 from django.conf import settings
 from django.http import HttpResponse
-from django.test.utils import override_settings
 
 from ..base import BaseTestCase
 
 
-@override_settings(DEBUG_TOOLBAR_CONFIG={'INTERCEPT_REDIRECTS': True})
 class RedirectsPanelTestCase(BaseTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes warning:

```
django-debug-toolbar/debug_toolbar/settings.py:82: DeprecationWarning: INTERCEPT_REDIRECTS is deprecated. Please use the DISABLE_PANELS config in the DEBUG_TOOLBAR_CONFIG setting.
  "DEBUG_TOOLBAR_CONFIG setting.", DeprecationWarning)
```

The setting was not actually required for the test as the panel is
tested directly instead of through the middleware.