### PR TITLE
Test HTML of all panels is valid; fix invalid

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -14,7 +14,7 @@
 {% if templates %}
 <dl>
 {% for template in templates %}
-<dt><strong><a class="remoteCall toggleTemplate" href="{% url 'djdt:template_source' %}?template={{ template.template.name }}&template_origin={{ template.template.origin_name }}">{{ template.template.name|addslashes }}</a></strong></dt>
+<dt><strong><a class="remoteCall toggleTemplate" href="{% url 'djdt:template_source' %}?template={{ template.template.name }}&gt;template_origin={{ template.template.origin_name }}">{{ template.template.name|addslashes }}</a></strong></dt>
 	<dd><samp>{{ template.template.origin_name|addslashes }}</samp></dd>
 	{% if template.context %}
 	<dd>

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,8 +11,9 @@ django_jinja
 # Testing
 
 coverage
-isort
 flake8
+html5lib
+isort
 selenium
 tox
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import threading
 
+import html5lib
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
 
@@ -24,3 +25,16 @@ class BaseTestCase(TestCase):
         self.response = response
         self.toolbar = toolbar
         self.toolbar.stats = {}
+
+    def assertValidHTML(self, content, msg=None):
+        parser = html5lib.HTMLParser()
+        parser.parseFragment(self.panel.content)
+        if parser.errors:
+            default_msg = ['Content is invalid HTML:']
+            lines = content.split('\n')
+            for position, errorcode, datavars in parser.errors:
+                default_msg.append('  %s' % html5lib.constants.E[errorcode] % datavars)
+                default_msg.append('    %s' % lines[position[0] - 1])
+
+            msg = self._formatMessage(msg, '\n'.join(default_msg))
+            raise self.failureException(msg)

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -47,3 +47,4 @@ class CachePanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, self.response)
         # ensure the panel renders correctly.
         self.assertIn('café', self.panel.content)
+        self.assertValidHTML(self.panel.content)

--- a/tests/panels/test_logging.py
+++ b/tests/panels/test_logging.py
@@ -57,6 +57,7 @@ class LoggingPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, self.response)
         # ensure the panel renders correctly.
         self.assertIn('café', self.panel.content)
+        self.assertValidHTML(self.panel.content)
 
     def test_failing_formatting(self):
         class BadClass(object):

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -38,6 +38,7 @@ class ProfilingPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, self.response)
         # ensure the panel renders correctly.
         self.assertIn('regular_view', self.panel.content)
+        self.assertValidHTML(self.panel.content)
 
     @unittest.skipIf(six.PY2, 'list comprehension not listed on Python 2')
     def test_listcomp_escaped(self):

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -46,3 +46,4 @@ class RequestPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, self.response)
         # ensure the panel renders correctly.
         self.assertIn('nôt åscíì', self.panel.content)
+        self.assertValidHTML(self.panel.content)

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -81,6 +81,7 @@ class SQLPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, self.response)
         # ensure the panel renders correctly.
         self.assertIn('café', self.panel.content)
+        self.assertValidHTML(self.panel.content)
 
     @unittest.skipUnless(connection.vendor == 'postgresql',
                          'Test valid only on PostgreSQL')

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -42,3 +42,4 @@ class StaticFilesPanelTestCase(BaseTestCase):
         # ensure the panel renders correctly.
         self.assertIn('django.contrib.staticfiles.finders.'
                       'AppDirectoriesFinder', self.panel.content)
+        self.assertValidHTML(self.panel.content)

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -64,6 +64,7 @@ class TemplatesPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, self.response)
         # ensure the panel renders correctly.
         self.assertIn('nôt åscíì', self.panel.content)
+        self.assertValidHTML(self.panel.content)
 
     def test_custom_context_processor(self):
         self.panel.process_request(self.request)

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,10 @@ deps =
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<2.0
     coverage
+    django_jinja
+    html5lib
     selenium<4.0
     sqlparse
-    django_jinja
 setenv =
     PYTHONPATH = {toxinidir}
 whitelist_externals = make


### PR DESCRIPTION
A number of one-off commits have fixed invalid HTML:

- 83edbacc6159d20fb04db93d5c45e12bb0d93998
- 408f4ea94dcd8017ba9d7641cb63e92ffa8fef81

Most recently, templates.html was discovered to contain invalid HTML. To
avoid regressions on valid HTML, add tests for valid HTML across many
panels.

Added new test dependency, html5lib.