### PR TITLE
Rename [wheel] section to [bdist_wheel] as the former is legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,5 +13,5 @@ known_first_party = debug_toolbar
 multi_line_output = 5
 not_skip = __init__.py
 
-[wheel]
+[bdist_wheel]
 universal = 1


### PR DESCRIPTION
See:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?fileviewer=file-view-default#bdist_wheel.py-119:125

http://pythonwheels.com/