### PR TITLE
Avoid re-specifying default values for basepython in tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,9 @@ matrix:
       env: TOXENV=py35-dj111
     - python: 3.6
       env: TOXENV=py36-dj111
-    - python: 2.7
-      env: TOXENV=flake8
-    - python: 2.7
-      env: TOXENV=isort
-    - python: 2.7
-      env: TOXENV=readme
+    - env: TOXENV=flake8
+    - env: TOXENV=isort
+    - env: TOXENV=readme
 install:
   - pip install tox codecov
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,6 @@ envlist =
     readme
 
 [testenv]
-basepython =
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
 deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
@@ -32,20 +26,16 @@ usedevelop = true
 commands = make coverage
 
 [testenv:flake8]
-basepython = python2.7
 commands = make flake8
 deps = flake8
 
 [testenv:isort]
-basepython = python2.7
 commands = make isort_check_only
 deps = isort
 
 [testenv:jshint]
-basepython = python2.7
 commands = make jshint
 
 [testenv:readme]
-basepython = python2.7
 commands = python setup.py check -r -s
 deps = readme_renderer


### PR DESCRIPTION
Tidies up and simplifies tox configuration.

From:

https://tox.readthedocs.io/en/latest/example/general.html#basepython-defaults-overriding

> By default, for any pyXY test environment name the underlying “pythonX.Y” executable will be searched in your system PATH. It must exist in order to successfully create virtualenv environments.

For non-pyXY environments, the Python interpreter used to invoke tox will be used.

From:

https://tox.readthedocs.io/en/latest/config.html#confval-basepython=NAME-OR-PATH

> name or path to a Python interpreter which will be used for creating the virtual environment. default: interpreter used for tox invocation.

In the Travis configuration, can simply use the default Python version for non-pyXY environments.

From

https://docs.travis-ci.com/user/languages/python/#Default-Python-Version

> If you leave the python key out of your .travis.yml, Travis CI will use Python 2.7.