### PR TITLE
raise Http404 with error messages in the require_show_toolbar and fix…

### DIFF
--- a/debug_toolbar/decorators.py
+++ b/debug_toolbar/decorators.py
@@ -10,7 +10,11 @@ def require_show_toolbar(view):
 
         show_toolbar = get_show_toolbar()
         if not show_toolbar(request):
-            raise Http404
+            raise Http404(
+                'You do not have the permission to access debug-toolbar'
+                ' urls. Please check your INTERNAL_IPS and'
+                ' SHOW_TOOLBAR_CALLBACK configurations'
+            )
 
         return view(request, *args, **kwargs)
     return inner

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -113,9 +113,15 @@ Toolbar options
 
   This is the dotted path to a function used for determining whether the
   toolbar should show or not. The default checks are that ``DEBUG`` must be
-  set to ``True``, the IP of the request must be in ``INTERNAL_IPS``, and the
-  request must not be an AJAX request. You can provide your own function
-  ``callback(request)`` which returns ``True`` or ``False``.
+  set to ``True`` and the IP of the request must be in ``INTERNAL_IPS``.
+  You can provide your own function ``callback(request)`` which returns
+  ``True`` or ``False``.
+
+  For django-debug-toolbar <= 1.7, the callback should also check whether
+  the request is ajax. Since the 1.8 version, the ajax is checked in the
+  middleware, and the callback should not check the whether the request is
+  ajax anymore, otherwise django-debug-toolbar's own ajax requests will fail
+  with 404s.
 
 Panel options
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This PR provides an hint messages when raises 404 , and fix the outdated/misleading doc. See #954