### PR TITLE
Avoid rendering HTML data-store-id="None"

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -19,16 +19,15 @@
                 } else {
                     $('.djdt-panelContent').hide(); // Hide any that are already open
                     var inner = current.find('.djDebugPanelContent .djdt-scroll'),
-                        store_id = $('#djDebug').data('store-id'),
-                        render_panel_url = $('#djDebug').data('render-panel-url');
-                    if (store_id !== '' && inner.children().length === 0) {
+                        store_id = $('#djDebug').data('store-id');
+                    if (store_id && inner.children().length === 0) {
                         var ajax_data = {
                             data: {
                                 store_id: store_id,
                                 panel_id: this.className
                             },
                             type: 'GET',
-                            url: render_panel_url
+                            url: $('#djDebug').data('render-panel-url')
                         };
                         $.ajax(ajax_data).done(function(data){
                             inner.prev().remove();  // Remove AJAX loader

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -11,7 +11,10 @@
 {% endif %}
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
 <div id="djDebug" class="djdt-hidden" dir="ltr"
-     data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}"
+     {% if toolbar.store_id %}
+     data-store-id="{{ toolbar.store_id }}"
+     data-render-panel-url="{% url 'djdt:render_panel' %}"
+     {% endif %}
      {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>
 	<div class="djdt-hidden" id="djDebugToolbar">
 		<ul id="djDebugPanelList">

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -219,6 +219,13 @@ class DebugToolbarIntegrationTestCase(TestCase):
             response = self.client.post(url, data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
             self.assertEqual(response.status_code, 404)
 
+    @override_settings(DEBUG_TOOLBAR_CONFIG={'RENDER_PANELS': True})
+    def test_data_store_id_not_rendered_when_none(self):
+        url = '/regular/basic/'
+        response = self.client.get(url)
+        self.assertIn(b'id="djDebug"', response.content)
+        self.assertNotIn(b'data-store-id', response.content)
+
 
 @unittest.skipIf(webdriver is None, "selenium isn't installed")
 @unittest.skipUnless('DJANGO_SELENIUM_TESTS' in os.environ, "selenium tests not requested")


### PR DESCRIPTION
When panels are always rendered, the `store_id` is `None`. Previously, this was rendered into the HTML as `data-store-id="None"`, which could appear to the JS as a valid `store_id`. Avoid rendering it entirely if the value is not needed.