### PR TITLE
Documented backwards incompatible change in 1.8

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,16 @@ Bugfixes
 This version is compatible with Django 1.11 and requires Django 1.8 or
 later.
 
+**Backwards incompatible changes**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``debug_toolbar.middleware.show_toolbar`` (the default value of setting
+  ``SHOW_TOOLBAR_CALLBACK``) no longer returns ``False`` for AJAX requests.
+  This is to allow reusing the ``SHOW_TOOLBAR_CALLBACK`` function to verify
+  access to panel views requested via AJAX. Projects defining a custom
+  ``SHOW_TOOLBAR_CALLBACK`` should remove checks for AJAX requests in order to
+  continue to allow access to these panels.
+
 Features
 ~~~~~~~~
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -112,10 +112,15 @@ Toolbar options
   Default: 'debug_toolbar.middleware.show_toolbar'
 
   This is the dotted path to a function used for determining whether the
-  toolbar should show or not. The default checks are that ``DEBUG`` must be
-  set to ``True``, the IP of the request must be in ``INTERNAL_IPS``, and the
-  request must not be an AJAX request. You can provide your own function
-  ``callback(request)`` which returns ``True`` or ``False``.
+  toolbar should show or not. The default checks are that ``DEBUG`` must be set
+  to ``True`` and the IP of the request must be in ``INTERNAL_IPS``. You can
+  provide your own function ``callback(request)`` which returns ``True`` or
+  ``False``.
+
+  For versions < 1.8, the callback should also return ``False`` for AJAX
+  requests. Since version 1.8, AJAX requests are checked in the middleware, not
+  the callback. This allows reusing the callback to verify access to panel
+  views requested via AJAX.
 
 Panel options
 ~~~~~~~~~~~~~


### PR DESCRIPTION
SHOW_TOOLBAR_CALLBACK no longer returns False for AJAX requests. Custom values shouldn't either.

Fixes #954