### PR TITLE
Add license-file to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,6 @@ not_skip = __init__.py
 
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license-file = LICENSE


### PR DESCRIPTION
Copies license file to package's dist-info on install. The metadata is supported by the wheel package:

https://bitbucket.org/pypa/wheel/issues/47
https://bitbucket.org/pypa/wheel/commits/3850a56bfc00df2b983ec515b9cd997a8c983a26