### PR TITLE
Allow tests to pass with Django 2.0

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -30,7 +30,7 @@ INSTALLED_APPS = [
 
 MEDIA_URL = '/media/'   # Avoids https://code.djangoproject.com/ticket/21451
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -40,6 +40,8 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+# Django < 1.10
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 ROOT_URLCONF = 'tests.urls'
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -375,7 +375,7 @@ class DebugToolbarSystemChecksTestCase(BaseTestCase):
     def test_middleware_factory_functions_supported(self):
         messages = run_checks()
 
-        if django.VERSION[:2] < (1, 10):
+        if django.VERSION[:2] < (1, 10) or django.VERSION[:2] >= (2, 0):
             self.assertEqual(messages, [])
         else:
             self.assertEqual(messages[0].id, '1_10.W001')


### PR DESCRIPTION
Django 2.0 has removed the deprecated setting `MIDDLEWARE_CLASSES`. Use `MIDDLEWARE` instead.

As a result, adjust the the expected warnings during test as system check warning `1_10.W001` was removed.