### PR TITLE
Replace deprecated render_to_response with SimpleTemplateResponse

### DIFF
--- a/debug_toolbar/panels/redirects.py
+++ b/debug_toolbar/panels/redirects.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.shortcuts import render_to_response
+from django.template.response import SimpleTemplateResponse
 from django.utils.translation import ugettext_lazy as _
 
 from debug_toolbar.panels import Panel
@@ -22,6 +22,7 @@ class RedirectsPanel(Panel):
                 status_line = '%s %s' % (response.status_code, response.reason_phrase)
                 cookies = response.cookies
                 context = {'redirect_to': redirect_to, 'status_line': status_line}
-                response = render_to_response('debug_toolbar/redirect.html', context)
+                # Using SimpleTemplateResponse avoids running global context processors.
+                response = SimpleTemplateResponse('debug_toolbar/redirect.html', context)
                 response.cookies = cookies
         return response

--- a/debug_toolbar/panels/sql/views.py
+++ b/debug_toolbar/panels/sql/views.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.http import HttpResponseBadRequest
-from django.shortcuts import render_to_response
+from django.template.response import SimpleTemplateResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from debug_toolbar.decorators import require_show_toolbar
@@ -29,8 +29,8 @@ def sql_select(request):
             'headers': headers,
             'alias': form.cleaned_data['alias'],
         }
-        # Using render_to_response avoids running global context processors.
-        return render_to_response('debug_toolbar/panels/sql_select.html', context)
+        # Using SimpleTemplateResponse avoids running global context processors.
+        return SimpleTemplateResponse('debug_toolbar/panels/sql_select.html', context)
     return HttpResponseBadRequest('Form errors')
 
 
@@ -66,8 +66,8 @@ def sql_explain(request):
             'headers': headers,
             'alias': form.cleaned_data['alias'],
         }
-        # Using render_to_response avoids running global context processors.
-        return render_to_response('debug_toolbar/panels/sql_explain.html', context)
+        # Using SimpleTemplateResponse avoids running global context processors.
+        return SimpleTemplateResponse('debug_toolbar/panels/sql_explain.html', context)
     return HttpResponseBadRequest('Form errors')
 
 
@@ -113,6 +113,6 @@ def sql_profile(request):
             'headers': headers,
             'alias': form.cleaned_data['alias'],
         }
-        # Using render_to_response avoids running global context processors.
-        return render_to_response('debug_toolbar/panels/sql_profile.html', context)
+        # Using SimpleTemplateResponse avoids running global context processors.
+        return SimpleTemplateResponse('debug_toolbar/panels/sql_profile.html', context)
     return HttpResponseBadRequest('Form errors')

--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.http import HttpResponseBadRequest
-from django.shortcuts import render_to_response
 from django.template import TemplateDoesNotExist
 from django.template.engine import Engine
+from django.template.response import SimpleTemplateResponse
 from django.utils.safestring import mark_safe
 
 from debug_toolbar.decorators import require_show_toolbar
@@ -66,8 +66,8 @@ def template_source(request):
     except ImportError:
         pass
 
-    # Using render_to_response avoids running global context processors.
-    return render_to_response('debug_toolbar/panels/template_source.html', {
+    # Using SimpleTemplateResponse avoids running global context processors.
+    return SimpleTemplateResponse('debug_toolbar/panels/template_source.html', {
         'source': source,
         'template_name': template_name
     })


### PR DESCRIPTION
`render_to_response()` is deprecated in Django 2.0. It causes warnings when running tests with Python warnings enabled. SimpleTemplateResponse is available in all supported Django versions but
does not produce such warning. Fixes warning of the form:

> RemovedInDjango30Warning: `render_to_response()` is deprecated in favor `render()`. It has the same signature except that it also requires a request.

Not using the recommended `render()` to avoid running global context processors.

For details on the deprecation on render_to_response(), see:

https://docs.djangoproject.com/en/dev/releases/2.0/#id1