### PR TITLE
Consider query params when detecting duplicate queries

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -149,7 +149,7 @@ class SQLPanel(Panel):
             return query['raw_sql']
 
         def duplicate_params_key(query):
-            return (query['raw_sql'], query['raw_params'])
+            return (query['raw_sql'], tuple(query['raw_params']))
 
         if self._queries:
             width_ratio_tally = 0

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -217,7 +217,7 @@ class SQLPanel(Panel):
         # Queries are duplicates only if there's as least 2 of them.
         # Also, to hide queries, we need to give all the duplicate groups an id
         query_colors = contrasting_color_generator()
-        query_duplicates = {
+        query_duplicates_colors = {
             alias: {
                 query: (duplicate_count, next(query_colors))
                 for query, duplicate_count in queries.items()
@@ -228,7 +228,7 @@ class SQLPanel(Panel):
 
         for alias, query in self._queries:
             try:
-                duplicates_count, color = query_duplicates[alias][duplicate_key(query)]
+                duplicates_count, color = query_duplicates_colors[alias][duplicate_key(query)]
                 query["duplicate_count"] = duplicates_count
                 query["duplicate_color"] = color
             except KeyError:
@@ -236,7 +236,9 @@ class SQLPanel(Panel):
 
         for alias, alias_info in self._databases.items():
             try:
-                alias_info["duplicate_count"] = sum(e[0] for e in query_duplicates[alias].values())
+                alias_info["duplicate_count"] = sum(
+                    e[0] for e in query_duplicates_colors[alias].values()
+                )
             except KeyError:
                 pass
 

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -145,7 +145,7 @@ class SQLPanel(Panel):
 
         # The key used to determine duplicate queries.
         def duplicate_key(query):
-            return query['raw_sql']
+            return (query['raw_sql'], query['params'])
 
         if self._queries:
             width_ratio_tally = 0

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -142,6 +142,11 @@ class SQLPanel(Panel):
         colors = contrasting_color_generator()
         trace_colors = defaultdict(lambda: next(colors))
         query_duplicates = defaultdict(lambda: defaultdict(int))
+
+        # The key used to determine duplicate queries.
+        def duplicate_key(query):
+            return query['raw_sql']
+
         if self._queries:
             width_ratio_tally = 0
             factor = int(256.0 / (len(self._databases) * 2.5))
@@ -164,7 +169,7 @@ class SQLPanel(Panel):
             trans_id = None
             i = 0
             for alias, query in self._queries:
-                query_duplicates[alias][query["raw_sql"]] += 1
+                query_duplicates[alias][duplicate_key(query)] += 1
 
                 trans_id = query.get('trans_id')
                 last_trans_id = trans_ids.get(alias)
@@ -223,7 +228,7 @@ class SQLPanel(Panel):
 
         for alias, query in self._queries:
             try:
-                duplicates_count, color = query_duplicates[alias][query["raw_sql"]]
+                duplicates_count, color = query_duplicates[alias][duplicate_key(query)]
                 query["duplicate_count"] = duplicates_count
                 query["duplicate_color"] = color
             except KeyError:

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -134,6 +134,7 @@ class NormalCursorWrapper(object):
                 'duration': duration,
                 'raw_sql': sql,
                 'params': _params,
+                'raw_params': params,
                 'stacktrace': stacktrace,
                 'start_time': start_time,
                 'stop_time': stop_time,

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -7,6 +7,9 @@
 				<span class="djdt-info">{{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
 				{% if info.duplicate_count %}
 					{% blocktrans with dupes=info.duplicate_count %}including {{ dupes }} duplicates{% endblocktrans %}
+					{% if info.duplicate_params_count %}
+						{% blocktrans with dupes=info.duplicate_params_count %}and {{ dupes }} duplicates with params{% endblocktrans %}
+					{% endif %}
 				{% endif %})</span>
 			</li>
 		{% endfor %}
@@ -39,6 +42,12 @@
 							<strong>
 								<span data-background-color="{{ query.duplicate_color }}">&#160;</span>
 								{% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
+							</strong>
+						{% endif %}
+						{% if query.duplicate_params_count %}
+							<strong>
+								<span data-background-color="{{ query.duplicate_params_color }}">&#160;</span>
+								{% blocktrans with dupes=query.duplicate_params_count %}Duplicated {{ dupes }} times with params.{% endblocktrans %}
 							</strong>
 						{% endif %}
 					</td>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -5,8 +5,8 @@
 			<li>
 				<strong class="djdt-label"><span data-background-color="rgb({{ info.rgb_color|join:", " }})" class="djdt-color">&#160;</span> {{ alias }}</strong>
 				<span class="djdt-info">{{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
-				{% if info.duplicate_count %}
-					{% blocktrans with dupes=info.duplicate_count %}including {{ dupes }} duplicates{% endblocktrans %}
+				{% if info.similar_count %}
+					{% blocktrans with count=info.similar_count %}including {{ count }} similar{% endblocktrans %}
 					{% if info.duplicate_params_count %}
 						{% blocktrans with dupes=info.duplicate_params_count %}and {{ dupes }} duplicates with params{% endblocktrans %}
 					{% endif %}
@@ -38,10 +38,10 @@
 						<div class="djDebugSqlWrap">
 							<div class="djDebugSql">{{ query.sql|safe }}</div>
 						</div>
-						{% if query.duplicate_count %}
+						{% if query.similar_count %}
 							<strong>
-								<span data-background-color="{{ query.duplicate_color }}">&#160;</span>
-								{% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
+								<span data-background-color="{{ query.similar_color }}">&#160;</span>
+								{% blocktrans with count=query.similar_count %}{{ count }} similar queries.{% endblocktrans %}
 							</strong>
 						{% endif %}
 						{% if query.duplicate_params_count %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -6,9 +6,13 @@
 				<strong class="djdt-label"><span data-background-color="rgb({{ info.rgb_color|join:", " }})" class="djdt-color">&#160;</span> {{ alias }}</strong>
 				<span class="djdt-info">{{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
 				{% if info.similar_count %}
-					{% blocktrans with count=info.similar_count %}including {{ count }} similar{% endblocktrans %}
+					{% blocktrans with count=info.similar_count trimmed %}
+						including <abbr title="Similar queries are queries with the same SQL, but potentially different parameters.">{{ count }} similar</abbr>
+					{% endblocktrans %}
 					{% if info.duplicate_count %}
-						{% blocktrans with dupes=info.duplicate_count %}and {{ dupes }} duplicates{% endblocktrans %}
+						{% blocktrans with dupes=info.duplicate_count trimmed %}
+							and <abbr title="Duplicate queries are identical to each other: they execute exactly the same SQL and parameters.">{{ dupes }} duplicates</abbr>
+						{% endblocktrans %}
 					{% endif %}
 				{% endif %})</span>
 			</li>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -7,8 +7,8 @@
 				<span class="djdt-info">{{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
 				{% if info.similar_count %}
 					{% blocktrans with count=info.similar_count %}including {{ count }} similar{% endblocktrans %}
-					{% if info.duplicate_params_count %}
-						{% blocktrans with dupes=info.duplicate_params_count %}and {{ dupes }} duplicates with params{% endblocktrans %}
+					{% if info.duplicate_count %}
+						{% blocktrans with dupes=info.duplicate_count %}and {{ dupes }} duplicates{% endblocktrans %}
 					{% endif %}
 				{% endif %})</span>
 			</li>
@@ -44,10 +44,10 @@
 								{% blocktrans with count=query.similar_count %}{{ count }} similar queries.{% endblocktrans %}
 							</strong>
 						{% endif %}
-						{% if query.duplicate_params_count %}
+						{% if query.duplicate_count %}
 							<strong>
-								<span data-background-color="{{ query.duplicate_params_color }}">&#160;</span>
-								{% blocktrans with dupes=query.duplicate_params_count %}Duplicated {{ dupes }} times with params.{% endblocktrans %}
+								<span data-background-color="{{ query.duplicate_color }}">&#160;</span>
+								{% blocktrans with dupes=query.duplicate_count %}Duplicated {{ dupes }} times.{% endblocktrans %}
 							</strong>
 						{% endif %}
 					</td>


### PR DESCRIPTION
Currently, the SQL panel's duplicate query detection considers all queries with the same `raw_sql` to be duplicates, even when their `params` are different. This leads to some confusing reports.

This PR changes the key used to group duplicate queries to include the `params` too, so that queries with distinct params are counted as distinct.