### PR TITLE
Fix erroneous ContentNotRenderedError raised by the redirects panel

### DIFF
--- a/debug_toolbar/panels/redirects.py
+++ b/debug_toolbar/panels/redirects.py
@@ -25,4 +25,5 @@ class RedirectsPanel(Panel):
                 # Using SimpleTemplateResponse avoids running global context processors.
                 response = SimpleTemplateResponse('debug_toolbar/redirect.html', context)
                 response.cookies = cookies
+                response.render()
         return response

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+UNRELEASED
+----------
+
+* Fix erroneous ``ContentNotRenderedError`` raised by the redirects panel.
+
 1.9
 ---
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -227,6 +227,17 @@ class DebugToolbarIntegrationTestCase(TestCase):
         self.assertIn(b'id="djDebug"', response.content)
         self.assertNotIn(b'data-store-id', response.content)
 
+    def test_view_returns_template_response(self):
+        response = self.client.get('/template_response/basic/')
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(DEBUG_TOOLBAR_CONFIG={'DISABLE_PANELS': set()})
+    def test_incercept_redirects(self):
+        response = self.client.get('/redirect/')
+        self.assertEqual(response.status_code, 200)
+        # Link to LOCATION header.
+        self.assertIn(b'href="/regular/redirect/"', response.content)
+
 
 @unittest.skipIf(webdriver is None, "selenium isn't installed")
 @unittest.skipUnless('DJANGO_SELENIUM_TESTS' in os.environ, "selenium tests not requested")

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -14,10 +14,12 @@ urlpatterns = [
     url(r'^resolving2/(?P<arg1>.+)/(?P<arg2>.+)/$', views.resolving_view),
     url(r'^resolving3/(.+)/$', views.resolving_view, {'arg2': 'default'}),
     url(r'^regular/(?P<title>.*)/$', views.regular_view),
+    url(r'^template_response/(?P<title>.*)/$', views.template_response_view),
     url(r'^regular_jinja/(?P<title>.*)/$', views.regular_jinjia_view),
     url(r'^non_ascii_request/$', views.regular_view, {'title': NonAsciiRepr()}),
     url(r'^new_user/$', views.new_user),
     url(r'^execute_sql/$', views.execute_sql),
     url(r'^cached_view/$', views.cached_view),
+    url(r'^redirect/$', views.redirect_view),
     url(r'^__debug__/', include(debug_toolbar.urls)),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib.auth.models import User
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
+from django.template.response import TemplateResponse
 from django.shortcuts import render
 from django.views.decorators.cache import cache_page
 
@@ -15,6 +16,10 @@ def execute_sql(request):
 
 def regular_view(request, title):
     return render(request, 'basic.html', {'title': title})
+
+
+def template_response_view(request, title):
+    return TemplateResponse(request, 'basic.html', {'title': title})
 
 
 def new_user(request, username='joe'):
@@ -39,3 +44,7 @@ def regular_jinjia_view(request, title):
 def listcomp_view(request):
     lst = [i for i in range(50000) if i % 2 == 0]
     return render(request, 'basic.html', {'title': 'List comprehension', 'lst': lst})
+
+
+def redirect_view(request):
+    return HttpResponseRedirect('/regular/redirect/')


### PR DESCRIPTION
`Panel.process_response()` must always return a rendered response.

Thanks Hiroki Kiyohara for the report.

Fixes #1009