### PR TITLE
handling the case if return_value is None in get_many

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -163,7 +163,7 @@ class CachePanel(Panel):
                 self.misses += 1
             else:
                 self.hits += 1
-        elif name == 'get_many':
+        elif name == 'get_many' and return_value:  # what if return_value is None?
             for key, value in return_value.items():
                 if value is None:
                     self.misses += 1


### PR DESCRIPTION
Hi,

I ran into a case where I am trying `get_many` with empty list, in that case, debug toolbar is throwing exception and the toolbar is not appearing. Here I came up with a fix. I think that if `return_value` is `None` it's neither a cache miss nor a cache hit right??? Please review and merge if the code is correct.