### PR TITLE
Avoid installing package in editable mode for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ isort_check_only:
 
 example:
 	DJANGO_SETTINGS_MODULE=example.settings \
-		django-admin runserver
+		python -m django runserver
 
 jshint: node_modules/jshint/bin/jshint
 	./node_modules/jshint/bin/jshint debug_toolbar/static/debug_toolbar/js/*.js
@@ -21,24 +21,24 @@ node_modules/jshint/bin/jshint:
 
 test:
 	DJANGO_SETTINGS_MODULE=tests.settings \
-		django-admin test $${TEST_ARGS:-tests}
+		python -m django test $${TEST_ARGS:-tests}
 
 test_selenium:
 	DJANGO_SELENIUM_TESTS=true DJANGO_SETTINGS_MODULE=tests.settings \
-		django-admin test $${TEST_ARGS:-tests}
+		python -m django test $${TEST_ARGS:-tests}
 
 coverage:
 	python --version
 	coverage erase
 	DJANGO_SETTINGS_MODULE=tests.settings \
-		coverage run `which django-admin` test -v2 $${TEST_ARGS:-tests}
+		coverage run -m django test -v2 $${TEST_ARGS:-tests}
 	coverage report
 	coverage html
 
 translatable_strings:
-	cd debug_toolbar && django-admin makemessages -l en --no-obsolete
+	cd debug_toolbar && python -m django makemessages -l en --no-obsolete
 	@echo "Please commit changes and run 'tx push -s' (or wait for Transifex to pick them)"
 
 update_translations:
 	tx pull -a --minimum-perc=10
-	cd debug_toolbar && django-admin compilemessages
+	cd debug_toolbar && python -m django compilemessages

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -32,8 +32,8 @@ the libraries required for working on the Debug Toolbar::
 
 You can run now run the example application::
 
-    $ DJANGO_SETTINGS_MODULE=example.settings django-admin migrate
-    $ DJANGO_SETTINGS_MODULE=example.settings django-admin runserver
+    $ DJANGO_SETTINGS_MODULE=example.settings python -m django migrate
+    $ DJANGO_SETTINGS_MODULE=example.settings python -m django runserver
 
 For convenience, there's an alias for the second command::
 

--- a/example/README.rst
+++ b/example/README.rst
@@ -22,8 +22,8 @@ the debug toolbar, ie. the directory that contains ``example/``.
 
 Before running the example for the first time, you must create a database::
 
-    $ PYTHONPATH=. django-admin migrate --settings=example.settings
+    $ python -m django migrate --settings=example.settings
 
 Then you can use the following command to run the example::
 
-    $ PYTHONPATH=. django-admin runserver --settings=example.settings
+    $ python -m django runserver --settings=example.settings

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,3 @@
-# The debug toolbar itself
-
--e .
-
 # Runtime dependencies
 
 Django

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 whitelist_externals = make
 pip_pre = True
-usedevelop = true
 commands = make coverage TEST_ARGS='{posargs:tests}'
 
 [testenv:flake8]


### PR DESCRIPTION
No longer need to install the django-debug-toolbar package itself for testing. Modern Python and Django can use the `-m` command line argument to execute the Django module entry point.

Allows for simpler test setup and less manipulation of the local environment.