### PR TITLE
Use HTML5 syntax in templates

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,6 +1,6 @@
 {% load i18n %}{% load static from staticfiles %}
-<link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" type="text/css" media="print" />
-<link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
+<link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" type="text/css" media="print">
+<link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css">
 {% if toolbar.config.JQUERY_URL %}
 <!-- Prevent our copy of jQuery from registering as an AMD module on sites that use RequireJS. -->
 <script src="{% static 'debug_toolbar/js/jquery_pre.js' %}"></script>
@@ -25,7 +25,7 @@
 			{% endif %}
 			{% for panel in toolbar.panels %}
 				<li class="djDebugPanelButton">
-					<input type="checkbox" data-cookie="djdt{{ panel.panel_id }}" {% if panel.enabled %}checked="checked" title="{% trans "Disable for next and successive requests" %}"{% else %}title="{% trans "Enable for next and successive requests" %}"{% endif %} />
+					<input type="checkbox" data-cookie="djdt{{ panel.panel_id }}" {% if panel.enabled %}checked title="{% trans "Disable for next and successive requests" %}"{% else %}title="{% trans "Enable for next and successive requests" %}"{% endif %}>
 					{% if panel.has_content and panel.enabled %}
 						<a href="#" title="{{ panel.title }}" class="{{ panel.panel_id }}">
 					{% else %}
@@ -34,7 +34,7 @@
 					{{ panel.nav_title }}
 					{% if panel.enabled %}
 					{% with panel.nav_subtitle as subtitle %}
-						{% if subtitle %}<br /><small>{{ subtitle }}</small>{% endif %}
+						{% if subtitle %}<br><small>{{ subtitle }}</small>{% endif %}
 					{% endwith %}
 					{% endif %}
 					{% if panel.has_content and panel.enabled %}
@@ -58,7 +58,7 @@
 				</div>
 				<div class="djDebugPanelContent">
 					{% if toolbar.store_id %}
-					<img src="{% static 'debug_toolbar/img/ajax-loader.gif' %}" alt="loading" class="djdt-loader" />
+					<img src="{% static 'debug_toolbar/img/ajax-loader.gif' %}" alt="loading" class="djdt-loader">
 					<div class="djdt-scroll"></div>
 					{% else %}
 					<div class="djdt-scroll">{{ panel.content }}</div>

--- a/debug_toolbar/templates/debug_toolbar/panels/request.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request.html
@@ -24,8 +24,8 @@
 	<h4>{% trans "Cookies" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20" />
-			<col />
+			<col class="djdt-width-20">
+			<col>
 		</colgroup>
 		<thead>
 			<tr>
@@ -50,8 +50,8 @@
 	<h4>{% trans "Session data" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20" />
-			<col />
+			<col class="djdt-width-20">
+			<col>
 		</colgroup>
 		<thead>
 			<tr>
@@ -76,8 +76,8 @@
 	<h4>{% trans "GET data" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20" />
-			<col />
+			<col class="djdt-width-20">
+			<col>
 		</colgroup>
 		<thead>
 			<tr>
@@ -102,8 +102,8 @@
 	<h4>{% trans "POST data" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20" />
-			<col />
+			<col class="djdt-width-20">
+			<col>
 		</colgroup>
 			<tr>
 				<th>{% trans "Variable" %}</th>

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -2,8 +2,8 @@
 <h4>{% trans "Resource usage" %}</h4>
 <table>
 	<colgroup>
-		<col class="djdt-width-20" />
-		<col />
+		<col class="djdt-width-20">
+		<col>
 	</colgroup>
 	<thead>
 		<tr>
@@ -26,9 +26,9 @@
 	<h4>{% trans "Browser timing" %}</h4>
 	<table>
 		<colgroup>
-			<col class="djdt-width-20" />
-			<col class="djdt-width-60" />
-			<col class="djdt-width-20" />
+			<col class="djdt-width-20">
+			<col class="djdt-width-60">
+			<col class="djdt-width-20">
 		</colgroup>
 		<thead>
 			<tr>

--- a/debug_toolbar/templates/debug_toolbar/panels/versions.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/versions.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <table>
 	<colgroup>
-		<col style="width:15%" />
-		<col style="width:15%" />
-		<col />
+		<col style="width:15%">
+		<col style="width:15%">
+		<col>
 	</colgroup>
 	<thead>
 		<tr>

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <title>Index of Tests</title>
 </head>
 <body>

--- a/example/templates/jquery/index.html
+++ b/example/templates/jquery/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
 	<title>jQuery Test</title>
 	<style>
 	.hide {display:none;}

--- a/example/templates/mootools/index.html
+++ b/example/templates/mootools/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
 	<title>MooTools Test</title>
 	<style>
 	.hide {display:none;}

--- a/example/templates/prototype/index.html
+++ b/example/templates/prototype/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta http-equiv="content-type" content="text/html; charset=utf-8">
 	<title>Prototype Test</title>
 	<style>
 	.hide {display:none;}


### PR DESCRIPTION
- Drop unnecessary trailing slash from void tags
- Use boolean attribute syntax
- Adjust test to verify Django debug toolbar is valid HTML