### PR TITLE
Fix example.urls to work with Django 2.0

### DIFF
--- a/example/urls.py
+++ b/example/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     url(r'^jquery/$', TemplateView.as_view(template_name='jquery/index.html')),
     url(r'^mootools/$', TemplateView.as_view(template_name='mootools/index.html')),
     url(r'^prototype/$', TemplateView.as_view(template_name='prototype/index.html')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
Fixes unhandled exception:

```
django.core.exceptions.ImproperlyConfigured: Passing a 3-tuple to include() is not supported. Pass a 2-tuple containing the list of patterns and app_name, and provide the namespace argument to include() instead.
```