### PR TITLE
In templates, load "static" templatetag instead of "staticfiles"

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static %}
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" type="text/css" media="print" />
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css" />
 {% if toolbar.config.JQUERY_URL %}

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static %}
 <table width="100%">
 	<thead>
 		<tr>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -1,4 +1,4 @@
-{% load i18n l10n %}{% load static from staticfiles %}
+{% load i18n l10n %}{% load static %}
 <div class="djdt-clearfix">
 	<ul class="djdt-stats">
 		{% for alias, info in databases %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href=""></a>
 	<h3>{% trans "SQL explained" %}</h3>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href=""></a>
 	<h3>{% trans "SQL profiled" %}</h3>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose djDebugBack" href=""></a>
 	<h3>{% trans "SQL selected" %}</h3>

--- a/debug_toolbar/templates/debug_toolbar/panels/staticfiles.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/staticfiles.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles%}
+{% load i18n %}
 
 <h4>{% blocktrans count staticfiles_dirs|length as dirs_count %}Static file path{% plural %}Static file paths{% endblocktrans %}</h4>
 {% if staticfiles_dirs %}

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static %}
 <h4>{% blocktrans count template_dirs|length as template_count %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
 {% if template_dirs %}
 	<ol>

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static from staticfiles %}
+{% load i18n %}{% load static %}
 <h4>{% trans "Resource usage" %}</h4>
 <table>
 	<colgroup>


### PR DESCRIPTION
Since Django 1.10, it is preferable to load the static templatetag. If in `INSTALLED_APPS`, the templatetag will use `django.contrib.staticfiles` to determine static paths. For additional details, see:

https://docs.djangoproject.com/en/dev/releases/1.10/#django-contrib-staticfiles

> The static template tag now uses `django.contrib.staticfiles` if it’s in `INSTALLED_APPS`. This is especially useful for third-party apps which can now always use `{% load static %}` (instead of `{% load staticfiles %}` or `{% load static from staticfiles %}`) and not worry about whether or not the `staticfiles` app is installed.

The staticfiles templatetag will be deprecated and removed in a future Django version.