### PR TITLE
Update jQuery to 3.3.1

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -17,7 +17,7 @@ CONFIG_DEFAULTS = {
     # Toolbar options
     'DISABLE_PANELS': {'debug_toolbar.panels.redirects.RedirectsPanel'},
     'INSERT_BEFORE': '</body>',
-    'JQUERY_URL': '//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js',
+    'JQUERY_URL': '//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js',
     'RENDER_PANELS': None,
     'RESULTS_CACHE_SIZE': 10,
     'ROOT_TAG_EXTRA_ATTRS': '',

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -66,7 +66,7 @@ Toolbar options
 
 * ``JQUERY_URL``
 
-  Default: ``'//ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js'``
+  Default: ``'//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js'``
 
   URL of the copy of jQuery that will be used by the toolbar. Set it to a
   locally-hosted version of jQuery for offline development. Make it empty to


### PR DESCRIPTION
jQuery 2.x is no longer supported. I've done some testing and everything
I've looked at is working with jQuery 3.