### PR TITLE
Declare local JS variable to avoid leaking to global scope

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -212,7 +212,7 @@
             $('#djDebugToolbar li').removeClass('djdt-active');
             // finally close toolbar
             $('#djDebugToolbar').hide('fast');
-            handle = $('#djDebugToolbarHandle');
+            var handle = $('#djDebugToolbarHandle');
             handle.show();
             // set handle position
             var handleTop = djdt.cookie.get('djdttop');


### PR DESCRIPTION
Without the use of `var`, `handle` becomes a global variable. Avoid that by declaring it local.