### PR TITLE
Fix "make example" command to run the dev server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ isort_check_only:
 	isort -rc -c debug_toolbar example tests
 
 example:
-	DJANGO_SETTINGS_MODULE=example.settings \
-		python -m django runserver
+	python example/manage.py runserver
 
 jshint: node_modules/jshint/bin/jshint
 	./node_modules/jshint/bin/jshint debug_toolbar/static/debug_toolbar/js/*.js

--- a/example/manage.py
+++ b/example/manage.py
@@ -2,6 +2,8 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example.settings")
 


### PR DESCRIPTION
Previously failed with:

```
  ModuleNotFoundError: No module named 'example'
```