### PR TITLE
Make JS varaible "current" local to the event handler

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -7,12 +7,11 @@
         isReady: false,
         init: function() {
             $('#djDebug').show();
-            var current = null;
             $('#djDebugPanelList').on('click', 'li a', function() {
                 if (!this.className) {
                     return false;
                 }
-                current = $('#djDebug #' + this.className);
+                var current = $('#djDebug #' + this.className);
                 if (current.is(':visible')) {
                     $(document).trigger('close.djDebug');
                     $(this).parent().removeClass('djdt-active');


### PR DESCRIPTION
Save a tiny amount of memory by not keeping the value around. Only used by the event handler. The value does not need to be remembered across different invocations of the event handler.