### PR TITLE
Test using Django 2.1 final release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 deps =
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1a1,<2.2
+    dj21: Django>=2.1,<2.2
     djmaster: https://github.com/django/django/archive/master.tar.gz
     coverage
     django_jinja


### PR DESCRIPTION
Django 2.1 was released on August 1, 2018.

https://docs.djangoproject.com/en/2.1/releases/2.1/