### PR TITLE
WIP - template panel context issues

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from collections import OrderedDict
 from contextlib import contextmanager
 from os.path import normpath
-from pprint import pformat
+from pprint import pformat, saferepr
 
 from django import http
 from django.conf.urls import url
@@ -126,7 +126,7 @@ class TemplatesPanel(Panel):
                         else:
                             try:
                                 recording(False)
-                                force_text(value)  # this MAY trigger a db query
+                                saferepr(value)  # this MAY trigger a db query
                             except SQLQueryTriggered:
                                 temp_layer[key] = '<<triggers database query>>'
                             except UnicodeEncodeError:


### PR DESCRIPTION
As I've now encountered an issue myself where the #910 changes caused problems, possibly related to some of the others, probably I should try and fix them all up.

As a short reminder, after template based widgets came along, and before #942 landed, I tried to ensure the number of calls to `pprint.pformat` was kept to a minimum, as it is an expensive calculation (#933).

In doing so, the call changed from: `try: ... pformat(value); except: ...` to use `force_text` instead of `pformat`. This was, in hindsight, a mistake, mostly around usages of `Form` instances.

Because `__str__` on a Form will by default **render** the form, it has a number of side-effects:
- The repr won't get used if the rendering causes an SQL query to be triggered (ie: most forms!) (one I've now encountered)
- The form instance can have `full_clean` called on it because the `__str__` includes error printing (one I've now encountered)
- Possibly subsequently prevents forms from rendering correctly at all? (#989)

------------

In an ideal world, we could just change to `repr` (#725) instead of `force_text`, as this is similarly lightning fast. Instead, to err on the side of caution, I've opted for calling `pprint.saferepr` instead, which is *protected against recursive data structures.* 
This has the benefit of still being faster than pformat (as far as I can tell) and avoids a certain class of problems the other options bring. But it's much slower than calling `repr` or `force_text` 
directly.

------------
Marking as `WIP` because there's a number of other issues (#989, #1024, #1053, #725) are related, and one option is just to **undo** the changes I made to avoid too many `pformat` calls. Also there's no tests ;)