### PR TITLE
support structured types when recording SQL

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -96,6 +96,14 @@ class NormalCursorWrapper(object):
         return [self._quote_expr(p) for p in params]
 
     def _decode(self, param):
+        # If a sequence type, decode each element separately
+        if isinstance(param, list) or isinstance(param, tuple):
+            return [self._decode(element) for element in param]
+
+        # If a dictionary type, decode each value separately
+        if isinstance(param, dict):
+            return {key: self._decode(value) for key, value in param.items()}
+
         # make sure datetime, date and time are converted to string by force_text
         CONVERT_TYPES = (datetime.datetime, datetime.date, datetime.time)
         try:


### PR DESCRIPTION
If Django's support for array/JSON/HStore Postgres fields is used then the SQL query can no-longer be explained because array and dictionary parameters are forced into textual representations.

Teach the _decode method of panels.sql.tracking.NormalCursorWrapper how to recurse into list, tuple and dictionary objects. It's plausible that more sequence/mapping types may need to be added in future or one could use the abstract base classes from [1] but then a special case would need to be made for all string-like objects; strings are sequences but should not be recursed as other sequences.

[1] https://docs.python.org/3/library/collections.abc.html

Closes #796. Closes #1001.