### PR TITLE
duplicate_key: Handle raw_params being None sometimes

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -149,7 +149,8 @@ class SQLPanel(Panel):
             return query['raw_sql']
 
         def duplicate_key(query):
-            return (query['raw_sql'], tuple(query['raw_params']))
+            raw_params = () if query['raw_params'] is None else tuple(query['raw_params'])
+            return (query['raw_sql'], raw_params)
 
         if self._queries:
             width_ratio_tally = 0


### PR DESCRIPTION
This is a small bug-fix update to #995 that I missed in my local testing. (Whoops.)