### PR TITLE
Remove unnecessary CSS in jQuery example

### DIFF
--- a/example/templates/jquery/index.html
+++ b/example/templates/jquery/index.html
@@ -5,7 +5,6 @@
 	<title>jQuery Test</title>
 	<style>
 	.hide {display:none;}
-	#v {font-weight:bold;}
 	</style>
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 	<script type="text/javascript">
@@ -17,6 +16,6 @@
 </head>
 <body>
 	<h1>jQuery Test</h1>
-	<p class="hide">If you see this, jQuery <span id="v"></span> is working.</p>
+	<p class="hide">If you see this, jQuery <strong id="v"></strong> is working.</p>
 </body>
 </html>


### PR DESCRIPTION
Simply use a `<strong>` tag instead. One fewer CSS rule.