### PR TITLE
Show the library versions on all example pages

### DIFF
--- a/example/templates/jquery/index.html
+++ b/example/templates/jquery/index.html
@@ -10,7 +10,7 @@
 	<script type="text/javascript">
 		$(document).ready(function() {
 			$('p.hide').show();
-			$('#v').append($.fn.jquery);
+			$('#v').text($.fn.jquery);
 		});
 	</script>
 </head>

--- a/example/templates/mootools/index.html
+++ b/example/templates/mootools/index.html
@@ -10,11 +10,12 @@
 	<script type="text/javascript">
 		window.addEvent('domready', function() {
 			$$('p.hide').setStyle('display', 'block');
+			$('v').set('text', MooTools.version);
 		});
 	</script>
 </head>
 <body>
 	<h1>MooTools Test</h1>
-	<p class="hide">If you see this, MooTools is working.</p>
+	<p class="hide">If you see this, MooTools <strong id="v"></strong> is working.</p>
 </body>
 </html>

--- a/example/templates/prototype/index.html
+++ b/example/templates/prototype/index.html
@@ -10,11 +10,12 @@
 	<script type="text/javascript">
 		document.observe('dom:loaded', function() {
 			$('showme').removeClassName('hide');
+			$('v').textContent = Prototype.Version;
 		});
 	</script>
 </head>
 <body>
 	<h1>Prototype Test</h1>
-	<p class="hide" id="showme">If you see this, Prototype is working.</p>
+	<p class="hide" id="showme">If you see this, Prototype <strong id="v"></strong> is working.</p>
 </body>
 </html>


### PR DESCRIPTION
Makes the examples more consistent. Show additional information to the user.