### PR TITLE
Remove duplicate CSS

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/print.css
+++ b/debug_toolbar/static/debug_toolbar/css/print.css
@@ -1,3 +1,3 @@
 #djDebug {
-  display:none;
+  display: none !important;
 }

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -627,12 +627,6 @@
     font-weight: normal;
 }
 
-@media print {
-    #djDebug {
-        display: none !important;
-    }
-}
-
 #djDebug .djdt-width-20 {
     width: 20%;
 }


### PR DESCRIPTION
Hiding the toolbar was being done twice. Once in toolbar.css wrapped by "@media print" and once in print.css which is included as:

```
<link rel="stylesheet" href=".../debug_toolbar/css/print.css" type="text/css" media="print">
```