### PR TITLE
stacktrace: include number of hidden frames

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -32,7 +32,7 @@ def send_signal(method):
         if dt_settings.get_config()['ENABLE_STACKTRACES']:
             stacktrace = tidy_stacktrace(reversed(get_stack()))
         else:
-            stacktrace = []
+            stacktrace = ([], 0)
 
         template_info = get_template_info()
         cache_called.send(sender=self.__class__, time_taken=t,

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -113,7 +113,7 @@ class NormalCursorWrapper(object):
             if dt_settings.get_config()['ENABLE_STACKTRACES']:
                 stacktrace = tidy_stacktrace(reversed(get_stack()))
             else:
-                stacktrace = []
+                stacktrace = ([], 0)
             _params = ''
             try:
                 _params = json.dumps([self._decode(p) for p in params])

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -626,6 +626,9 @@
 #djDebug .djdt-stack span.djdt-code {
     font-weight: normal;
 }
+#djDebug .djdt-stack span.djdt-hidden_count {
+    font-weight: normal;
+}
 
 #djDebug .djdt-width-20 {
     width: 20%;

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -162,7 +162,7 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertTrue('stacktrace' in query[1])
 
         # ensure the stacktrace is empty
-        self.assertEqual([], query[1]['stacktrace'])
+        self.assertEqual(([], 0), query[1]['stacktrace'])
 
     @override_settings(DEBUG=True, TEMPLATES=[{
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
Re-opening #1072.

TODO:

- [ ] bug (https://github.com/jazzband/django-debug-toolbar/pull/1072#issuecomment-418983687)
  ```
  Traceback (most recent call last):                                                              
    File "/home/matthias/Projects/sites/***/venv/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
      response = get_response(request)                                                            
    File "/home/matthias/Projects/sites/***/venv/local/lib/python2.7/site-packages/django/utils/deprecation.py", line 142, in __call__
      response = self.process_response(request, response)
    File "/home/matthias/Projects/sites/***/venv/local/lib/python2.7/site-packages/debug_panel/middleware.py", line 67, in process_response
      panel.generate_stats(request, response)                                                                                                            
    File "/home/matthias/Projects/sites/***/venv/local/lib/python2.7/site-packages/debug_toolbar/panels/sql/panel.py", line 215, in generate_stats             
      query['stacktrace'] = render_stacktrace(query['stacktrace'])                                                                                                   
    File "/home/matthias/Projects/sites/***/venv/local/lib/python2.7/site-packages/debug_toolbar/utils.py", line 72, in render_stacktrace
      trace, hidden_count = trace           
  ValueError: too many values to unpack      
  ```

  `trace` contains a HTML string it seems.
