### PR TITLE
adding support to view file from stacktraces

### DIFF
--- a/debug_toolbar/forms.py
+++ b/debug_toolbar/forms.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import, unicode_literals
+
+import hashlib
+import hmac
+import os
+
+from django import forms
+from django.conf import settings
+from django.utils.crypto import constant_time_compare
+from django.utils.encoding import force_bytes
+
+
+class ViewFileForm(forms.Form):
+    """
+    Validate params
+        full_path: Full path to file to view
+        line_no: Line number to highlight
+        hash: the hash of (secret + path + line_no) for tamper checking
+    """
+    full_path = forms.CharField(widget=forms.HiddenInput())
+    line_no = forms.IntegerField(min_value=1, widget=forms.HiddenInput())
+    hash = forms.CharField(widget=forms.HiddenInput())
+
+    def __init__(self, *args, **kwargs):
+        initial = kwargs.get('initial', None)
+
+        if initial is not None:
+            initial['hash'] = self.make_hash(initial)
+
+        super(ViewFileForm, self).__init__(*args, **kwargs)
+
+    def clean_full_path(self):
+        path = self.cleaned_data['full_path']
+
+        if not os.path.exists(path):
+            raise forms.ValidationError('File does not exist')
+
+        return path
+
+    def clean_hash(self):
+        hash = self.cleaned_data['hash']
+
+        if not constant_time_compare(hash, self.make_hash(self.data)):
+            raise forms.ValidationError('Tamper alert')
+
+        return hash
+
+    def make_hash(self, data):
+        m = hmac.new(key=force_bytes(settings.SECRET_KEY), digestmod=hashlib.sha1)
+        for item in [data['full_path'], data['line_no']]:
+            m.update(force_bytes(item))
+        return m.hexdigest()

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -645,6 +645,15 @@
 #djDebug .djdt-file span.djdt-highlight-line {
 	font-weight: bold;
 }
+#djDebug .djdt-file .djdt-line-no {
+	-webkit-touch-callout: none; /* iOS Safari */
+	-webkit-user-select: none; /* Safari */
+	-khtml-user-select: none; /* Konqueror HTML */
+	-moz-user-select: none; /* Firefox */
+	-ms-user-select: none; /* Internet Explorer/Edge */
+	user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
+	margin-right: 10px;
+}
 
 #djDebug .djdt-width-20 {
     width: 20%;

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -615,16 +615,35 @@
     margin-bottom: 3px;
     font-family:Consolas, Monaco, "Bitstream Vera Sans Mono", "Lucida Console", monospace;
 }
+#djDebug .djdt-stack {
+	white-space: normal;
+}
 #djDebug .djdt-stack span {
-    color: #000;
-    font-weight: bold;
+	color: #000;
+	font-weight: bold;
 }
 #djDebug .djdt-stack span.djdt-path {
-    color: #777;
-    font-weight: normal;
+	color: #777;
+	font-weight: normal;
 }
 #djDebug .djdt-stack span.djdt-code {
-    font-weight: normal;
+	font-weight: normal;
+	margin-left: 10px;
+}
+#djDebug .djdt-stack form {
+	display: inline;
+}
+
+#djDebug .djdt-file {
+	white-space: normal;
+	font-family: monospace;
+}
+#djDebug .djdt-file span.djdt-line {
+	white-space: pre;
+	font-family: inherit;
+}
+#djDebug .djdt-file span.djdt-highlight-line {
+	font-weight: bold;
 }
 
 #djDebug .djdt-width-20 {

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.file.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.file.js
@@ -1,0 +1,14 @@
+(function () {
+    var old_hash = location.hash,
+        djDebug = document.querySelector('#djDebug'),
+        targetLine = djDebug.querySelector('.djdt-highlight-line'),
+        scrollable = targetLine.closest('.djdt-scroll');
+
+    location.hash = "";
+    location.hash = '#' + targetLine.id;
+    location.hash = old_hash;
+
+    if (scrollable.scrollTop + scrollable.clientHeight < scrollable.scrollHeight) {
+        scrollable.scrollTo(0, scrollable.scrollTop - (scrollable.clientHeight / 2));
+    }
+})();

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -111,18 +111,14 @@
                 var name = this.tagName.toLowerCase();
                 var ajax_data = {};
 
-                if (name == 'button') {
+                if (name === 'button' || name === 'a') {
                     var form = this.closest('form');
-                    ajax_data.url = this.getAttribute('formaction');
+                    ajax_data.url = name === 'button' ? this.getAttribute('formaction') : this.getAttribute('href');
 
                     if (form) {
                         ajax_data.body = new FormData(form);
                         ajax_data.method = form.getAttribute('method') || 'POST';
                     }
-                }
-
-                if (name == 'a') {
-                    ajax_data.url = this.getAttribute('href');
                 }
 
                 ajax(ajax_data.url, ajax_data).then(function(body) {

--- a/debug_toolbar/templates/debug_toolbar/file.html
+++ b/debug_toolbar/templates/debug_toolbar/file.html
@@ -8,12 +8,15 @@
 	<div class="djdt-scroll">
 		<pre class="djdt-file">
 			{% for line in lines %}
-				{% if forloop.counter == line_no %}
-					<span class="djdt-line djdt-highlight-line" id="{{ hash }}">{{ line }}</span>
-				{% else %}
-					<span class="djdt-line">{{ line }}</span>
-				{% endif %}
-				<br/>
+                {% spaceless %}
+                    <span class="djdt-line djdt-line-no">{{ forloop.counter|ljust:lines_length }}</span>
+                    {% if forloop.counter == line_no %}
+                        <span class="djdt-line djdt-highlight-line" id="{{ hash }}">{{ line }}</span>
+                    {% else %}
+                        <span class="djdt-line">{{ line }}</span>
+                    {% endif %}
+                    <br/>
+                {% endspaceless %}
 			{% endfor %}
 		</pre>
 	</div>

--- a/debug_toolbar/templates/debug_toolbar/file.html
+++ b/debug_toolbar/templates/debug_toolbar/file.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{% load static %}
+<div class="djDebugPanelTitle">
+	<a class="djDebugClose djDebugBack" href=""></a>
+	<h3>{% trans "File" %}: {{ filename }}</h3>
+</div>
+<div class="djDebugPanelContent">
+	<div class="djdt-scroll">
+		<pre class="djdt-file">
+			{% for line in lines %}
+				{% if forloop.counter == line_no %}
+					<span class="djdt-line djdt-highlight-line" id="{{ hash }}">{{ line }}</span>
+				{% else %}
+					<span class="djdt-line">{{ line }}</span>
+				{% endif %}
+				<br/>
+			{% endfor %}
+		</pre>
+	</div>
+</div>
+
+<script src="{% static 'debug_toolbar/js/toolbar.file.js' %}"></script>

--- a/debug_toolbar/templates/debug_toolbar/stacktrace.html
+++ b/debug_toolbar/templates/debug_toolbar/stacktrace.html
@@ -1,0 +1,14 @@
+{% for frame in trace %}
+	<form method="post">
+		{% spaceless %}{{ frame.form }}{% endspaceless %}
+		<a href="{% url 'djdt:render_file' %}" class="remoteCall">
+			<span class="djdt-path">{{ frame.path }}/</span><span class="djdt-file">{{ frame.file }}</span>
+			in <span class="djdt-func">{{ frame.func }}</span> (<span class="djdt-lineno">{{ frame.line_no }}</span>)
+		</a>
+	</form>
+	<br/>
+	<span class="djdt-code">{{ frame.code }}</span>
+	{% if not forloop.last %}
+		<br/>
+	{% endif %}
+{% endfor %}

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -124,6 +124,7 @@ class DebugToolbar(object):
             # Global URLs
             urlpatterns = [
                 url(r'^render_panel/$', views.render_panel, name='render_panel'),
+                url(r'^render_file/$', views.render_file, name='render_file'),
             ]
             # Per-panel URLs
             for panel_class in cls.get_panel_classes():

--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.template.response import SimpleTemplateResponse
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
+from django.views.decorators.csrf import csrf_exempt
 
 from debug_toolbar.decorators import require_show_toolbar
 from debug_toolbar.toolbar import DebugToolbar
@@ -27,6 +28,7 @@ def render_panel(request):
     return HttpResponse(content)
 
 
+@csrf_exempt
 @require_show_toolbar
 def render_file(request):
     """Render content of given file"""
@@ -45,6 +47,7 @@ def render_file(request):
         'filename': os.path.basename(full_path),
         'lines': lines,
         'line_no': form.cleaned_data['line_no'],
+        'lines_length': len(str(len(lines))),
     }
 
     # Using SimpleTemplateResponse avoids running global context processors.

--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -1,11 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.http import HttpResponse
+import os
+
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.template.response import SimpleTemplateResponse
 from django.utils.html import escape
 from django.utils.translation import ugettext as _
 
 from debug_toolbar.decorators import require_show_toolbar
 from debug_toolbar.toolbar import DebugToolbar
+
+from .forms import ViewFileForm
 
 
 @require_show_toolbar
@@ -20,3 +25,27 @@ def render_panel(request):
         panel = toolbar.get_panel_by_id(request.GET['panel_id'])
         content = panel.content
     return HttpResponse(content)
+
+
+@require_show_toolbar
+def render_file(request):
+    """Render content of given file"""
+    form = ViewFileForm(request.POST)
+    if not form.is_valid():
+        return HttpResponseBadRequest('Form errors')
+
+    full_path = form.cleaned_data['full_path']
+
+    with open(full_path, 'r') as fid:
+        lines = fid.read().splitlines()
+
+    context = {
+        'hash': form.cleaned_data['hash'],
+        'full_path': full_path,
+        'filename': os.path.basename(full_path),
+        'lines': lines,
+        'line_no': form.cleaned_data['line_no'],
+    }
+
+    # Using SimpleTemplateResponse avoids running global context processors.
+    return SimpleTemplateResponse('debug_toolbar/file.html', context)


### PR DESCRIPTION
Added a way to view files from stacktrace. Useful when looking at SQL panel which allows to view code directly in debugging without having a need to jump to editor.

![image](https://user-images.githubusercontent.com/932940/45258914-3a068080-b38f-11e8-85ef-6ca636052b31.png)

![image](https://user-images.githubusercontent.com/932940/45317900-562e2d00-b509-11e8-82cb-8bd0924e4681.png)
