### PR TITLE
Patch for store_id: MultiValueDictKeyError

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -81,10 +81,10 @@
                         store_id = djDebug.getAttribute('data-store-id');
                     if (store_id && inner.children.length === 0) {
                         var url = djDebug.getAttribute('data-render-panel-url');
-                        url += '?' + new URLSearchParams({
-                            store_id: store_id,
-                            panel_id: this.className
-                        })
+                        var url_params = new URLSearchParams();
+                        url_params.append('store_id', store_id);
+                        url_params.append('panel_id', this.className);
+                        url += '?' + url_params.toString();
                         ajax(url).then(function(body) {
                             inner.previousElementSibling.remove();  // Remove AJAX loader
                             inner.innerHTML = body;


### PR DESCRIPTION
Fixes issue found in https://github.com/jazzband/django-debug-toolbar/issues/816

Mozilla's documentation shows that strings are meant to be parsed in the constructor and the support of parsing a dictionary is not guaranteed to work across browsers.  
https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams

This updates toolbar.js to be compliant with the current spec.   