### PR TITLE
Fix displaying RawQuerySet in sql_explain view

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -124,7 +124,7 @@ class NormalCursorWrapper(object):
                 stacktrace = []
             _params = ''
             try:
-                _params = json.dumps([self._decode(p) for p in params])
+                _params = json.dumps(self._decode(params))
             except TypeError:
                 pass  # object not JSON serializable
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -91,6 +91,17 @@ if os.environ.get("DJANGO_DATABASE_ENGINE") == "postgresql":
             'NAME': 'debug-toolbar',
         }
     }
+elif os.environ.get('DJANGO_DATABASE_ENGINE') == 'mysql':
+    # % mysql
+    # mysql> CREATE USER 'debug_toolbar'@'localhost' IDENTIFIED BY '';
+    # mysql> GRANT ALL PRIVILEGES ON debug_toolbar.* TO 'test_debug_toolbar'@'localhost';
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'debug_toolbar',
+            'USER': 'debug_toolbar',
+        }
+    }
 else:
     DATABASES = {
         'default': {


### PR DESCRIPTION
This problem may be a regression from #309, but I'm not 100% sure.

Trying to do sql_explain on raw query with dictionary for params causes a crash.

```
ERROR Internal Server Error: /__debug__/sql_explain/
Traceback (most recent call last):
  File "../site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "../site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "../site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "../site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "../site-packages/debug_toolbar/decorators.py", line 15, in inner
    return view(request, *args, **kwargs)
  File "../site-packages/debug_toolbar/panels/sql/views.py", line 61, in sql_explain
    cursor.execute("EXPLAIN %s" % (sql,), params)
  File "../site-packages/debug_toolbar/panels/sql/tracking.py", line 188, in execute
    return self._record(self.cursor.execute, sql, params)
  File "../site-packages/debug_toolbar/panels/sql/tracking.py", line 121, in _record
    return method(sql, params)
  File "../site-packages/django/db/backends/utils.py", line 79, in execute
    return super(CursorDebugWrapper, self).execute(sql, params)
  File "../site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "../site-packages/django/db/backends/mysql/base.py", line 101, in execute
    return self.cursor.execute(query, args)
  File "../site-packages/MySQLdb/cursors.py", line 159, in execute
    query = query % db.literal(args)
TypeError: format requires a mapping
```

The reason is because `params` is not dictionary, but list.

The core of the issue is caused by `panels/sql/traking.py`
```
    _params = json.dumps([self._decode(p) for p in params])
```
This forces only dictionary keys to be send over sql_explain view.

My change is going to preserve the initial params structure.
```
    _params = json.dumps(self._decode(params))
```

Now, because dictionary params are not supported by the SQLite backend.
My test is going to be skipped for this vendor.