### PR TITLE
middleware: process_request: skip with already installed instance

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -58,8 +58,16 @@ class DebugToolbarMiddleware(MiddlewareMixin):
         if request.is_ajax():
             return
 
+        # Check if it is used for the current request already.
+        # This allows for having it multiple times in MIDDLEWARE, where the
+        # SHOW_TOOLBAR_CALLBACK can decide multiple times if it should be
+        # shown.
+        thread_ident = threading.current_thread().ident
+        if self.__class__.debug_toolbars.get(thread_ident) is not None:
+            return
+
         toolbar = DebugToolbar(request)
-        self.__class__.debug_toolbars[threading.current_thread().ident] = toolbar
+        self.__class__.debug_toolbars[thread_ident] = toolbar
 
         # Activate instrumentation ie. monkey-patch.
         for panel in toolbar.enabled_panels:

--- a/tests/base.py
+++ b/tests/base.py
@@ -26,6 +26,9 @@ class BaseTestCase(TestCase):
         self.toolbar = toolbar
         self.toolbar.stats = {}
 
+    def tearDown(self):
+        DebugToolbarMiddleware.debug_toolbars.pop(threading.current_thread().ident, None)
+
     def assertValidHTML(self, content, msg=None):
         parser = html5lib.HTMLParser()
         parser.parseFragment(self.panel.content)


### PR DESCRIPTION
Ref: https://github.com/jazzband/django-debug-toolbar/issues/1102#issuecomment-420981302

This would allow to remove the `debug_toolbar.W002` warning, but it might make sense to leave it anyway.

TODO:

- [ ] test