### PR TITLE
Use defer attribute on all script tags, remove inline JS

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/redirect.js
+++ b/debug_toolbar/static/debug_toolbar/js/redirect.js
@@ -1,3 +1,1 @@
-document.addEventListener('DOMContentLoaded', function () {
-  document.getElementById('redirect_to').focus();
-});
+document.getElementById('redirect_to').focus();

--- a/debug_toolbar/static/debug_toolbar/js/redirect.js
+++ b/debug_toolbar/static/debug_toolbar/js/redirect.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.getElementById('redirect_to').focus();
+});

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% load static %}
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" type="text/css" media="print">
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css">
-<script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.js' %}" defer></script>
 <div id="djDebug" class="djdt-hidden" dir="ltr"
      {% if toolbar.store_id %}
      data-store-id="{{ toolbar.store_id }}"

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -33,4 +33,4 @@
 	</tbody>
 </table>
 
-<script src="{% static 'debug_toolbar/js/toolbar.profiling.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.profiling.js' %}" defer></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -114,4 +114,4 @@
 	<p>{% trans "No SQL queries were recorded during this request." %}</p>
 {% endif %}
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}" defer></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -34,4 +34,4 @@
 	</div>
 </div>
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}" defer></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -41,4 +41,4 @@
 	</div>
 </div>
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}" defer></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -38,4 +38,4 @@
 	</div>
 </div>
 
-<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.sql.js' %}" defer></script>

--- a/debug_toolbar/templates/debug_toolbar/panels/timer.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/timer.html
@@ -41,4 +41,4 @@
 		</tbody>
 	</table>
 </div>
-<script src="{% static 'debug_toolbar/js/toolbar.timer.js' %}"></script>
+<script src="{% static 'debug_toolbar/js/toolbar.timer.js' %}" defer></script>

--- a/debug_toolbar/templates/debug_toolbar/redirect.html
+++ b/debug_toolbar/templates/debug_toolbar/redirect.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n static %}
 <!DOCTYPE html>
 <html>
 <head>
@@ -9,8 +9,6 @@
 <p class="notice">
 	{% trans "The Django Debug Toolbar has intercepted a redirect to the above URL for debug viewing purposes. You can click the above link to continue with the redirect as normal." %}
 </p>
-<script type="text/javascript">
-    document.getElementById('redirect_to').focus();
-</script>
+<script src="{% static 'debug_toolbar/js/redirect.js' %}" defer></script>
 </body>
 </html>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Change log
 UNRELEASED
 ----------
 
+* Use ``defer`` on all ``<script>`` tags to avoid blocking HTML parsing.
+
 1.10.1 (2018-09-11)
 -------------------
 


### PR DESCRIPTION
I'm deploying the experimental `Feature-Policy` on my site. I tried disabling the `sync-script` policy, which blocks HTML-parse-blocking JavaScript, and django-debug-toolbar broke because its script tags aren't async or deferred.

There's a bit more information about this feature, and a demo at https://feature-policy-demos.appspot.com/sync-script.html?on

I've added `defer` to all the `<script>` tags, which makes them execute after HTML parsing has finished, in order. There was also one inline script for redirects which I've extracted - this would break for `sync-script` but also for use of `Content-Security-Policy` blocking inline JavaScript, which has been supported since #704 but it seems this was missed.

Tested by using the `example` app, redirect interception worked and every panel loaded and looked right.