### PR TITLE
Remove py35-djmaster test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
       env: TOXENV=py37-dj21
       dist: xenial
       sudo: true
-    - python: 3.5
-      env: TOXENV=py35-djmaster
     - python: 3.6
       env: TOXENV=py36-djmaster
     - python: 3.7
@@ -46,7 +44,6 @@ matrix:
     - env: TOXENV=isort
     - env: TOXENV=readme
   allow_failures:
-    - env: TOXENV=py35-djmaster
     - env: TOXENV=py36-djmaster
     - env: TOXENV=py37-djmaster
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{27,34,35,36}-dj111
     py{34,35,36,37}-dj20
     py{35,36,37}-dj21
-    py{35,36,37}-djmaster
+    py{36,37}-djmaster
     postgresql,
     flake8,
     isort,


### PR DESCRIPTION
Failing on Travis ([example](https://travis-ci.org/jazzband/django-debug-toolbar/jobs/446114199)) with:

> Downloading archive: https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/14.04/x86_64/python-3.5.tar.bz2
> $ curl -sSf -o python-3.5.tar.bz2 ${archive_url}
> curl: (56) SSL read: error:00000000:lib(0):func(0):reason(0), errno 104
> Unable to download 3.5 archive. The archive may not exist. Please consider a different version.

It looks like they removed the package so it can't be used any more.