### PR TITLE
Ignore flake8 warning W503

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -79,6 +79,6 @@ def is_middleware_class(middleware_class, middleware_path):
     except ImportError:
         return
     return (
-        inspect.isclass(middleware_cls) and
-        issubclass(middleware_cls, middleware_class)
+        inspect.isclass(middleware_cls)
+        and issubclass(middleware_cls, middleware_class)
     )

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -31,8 +31,8 @@ class Panel(object):
         # For that reason, replace .panel. in the path and check for that
         # value in the disabled panels as well.
         disable_panel = (
-            panel_path in disabled_panels or
-            panel_path.replace('.panel.', '.') in disabled_panels)
+            panel_path in disabled_panels
+            or panel_path.replace('.panel.', '.') in disabled_panels)
         if disable_panel:
             default = 'off'
         else:

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -41,8 +41,8 @@ def _request_context_bind_template(self, template):
 
     self.template = template
     # Set context processors according to the template engine's settings.
-    processors = (template.engine.template_context_processors +
-                  self._processors)
+    processors = (template.engine.template_context_processors
+                  + self._processors)
     self.context_processors = OrderedDict()
     updates = {}
     for processor in processors:
@@ -85,10 +85,16 @@ class TemplatesPanel(Panel):
         template, context = kwargs['template'], kwargs['context']
 
         # Skip templates that we are generating through the debug toolbar.
-        if (isinstance(template.name, six.string_types) and (
-            template.name.startswith('debug_toolbar/') or
-            template.name.startswith(
-                tuple(self.toolbar.config['SKIP_TEMPLATE_PREFIXES'])))):
+        is_debug_toolbar_template = (
+            isinstance(template.name, six.string_types)
+            and (
+                template.name.startswith('debug_toolbar/')
+                or template.name.startswith(
+                    tuple(self.toolbar.config['SKIP_TEMPLATE_PREFIXES'])
+                )
+            )
+        )
+        if is_debug_toolbar_template:
             return
 
         context_list = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 tag_svn_revision = false
 
 [flake8]
-ignore = W504, W601
+ignore = W503, W601
 max-line-length = 100
 
 [isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 tag_svn_revision = false
 
 [flake8]
-ignore = W601               ; # noqa doesn't silence this one
+ignore = W504, W601
 max-line-length = 100
 
 [isort]


### PR DESCRIPTION
Currently breaking tests with the latest flake8, which added a pair of competing rules, W503 and W504, for whether line breaks should be before or after a binary operator. `ignore` needs to ignore at least one of them, otherwise `flake8` can never be pleased.