### PR TITLE
Always deterministically close files in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,18 @@ from io import open
 
 from setuptools import find_packages, setup
 
+
+def readall(path):
+    with open(path, encoding="utf-8") as fp:
+        return fp.read()
+
+
 setup(
     name="django-debug-toolbar",
     version="1.10.1",
     description="A configurable set of panels that display various debug "
     "information about the current request/response.",
-    long_description=open("README.rst", encoding="utf-8").read(),
+    long_description=readall("README.rst"),
     author="Rob Hudson",
     author_email="rob@cogit8.org",
     url="https://github.com/jazzband/django-debug-toolbar",


### PR DESCRIPTION
When running Python with warnings enabled, fixes warning:

```
setup.py:12: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='r' encoding='utf-8'>
  long_description=open("README.rst", encoding="utf-8").read(),
```