### PR TITLE
Add tip about browser caching.

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -14,6 +14,10 @@ requests and return responses. Putting the debug toolbar middleware *after*
 the Flatpage middleware, for example, means the toolbar will not show up on
 flatpages.
 
+Browsers have become more aggressive with caching static assets, such as
+JavaScript and CSS files. Check your browser's development console, and if
+you see errors, try a hard browser refresh or clearing your cache.
+
 Middleware isn't working correctly
 ----------------------------------
 


### PR DESCRIPTION
More than once, I've spent time tweaking settings, when all I really needed to do was a hard refresh after an upgrade to force the JavaScript to reload. Mentioning this in the documentation.