### PR TITLE
Display indented SQL queries in expanded views.

### DIFF
--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -77,7 +77,7 @@ class SQLSelectForm(forms.Form):
         return hash
 
     def reformat_sql(self):
-        return reformat_sql(self.cleaned_data["sql"])
+        return reformat_sql(self.cleaned_data["sql"], with_toggle=False)
 
     def make_hash(self, data):
         m = hmac.new(key=force_bytes(settings.SECRET_KEY), digestmod=hashlib.sha1)

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -213,7 +213,7 @@ class SQLPanel(Panel):
                 query["form"] = SQLSelectForm(auto_id=None, initial=copy(query))
 
                 if query["sql"]:
-                    query["sql"] = reformat_sql(query["sql"])
+                    query["sql"] = reformat_sql(query["sql"], with_toggle=True)
                 query["rgb_color"] = self._databases[alias]["rgb_color"]
                 try:
                     query["width_ratio"] = (query["duration"] / self._sql_time) * 100


### PR DESCRIPTION
This reuses the query details toggle to display the indented version: the default view does not change.

This uses `&nbsp;` and `<br/>` to convert `sqlparse.format` from text to html visual indentation, it has a small visual glitch with the `+` button to toggle details on the `SELECT` first line, but hopefully it's OK for everyone.

Also, use expanded form in SQL select/explain/profile views to profit from the indented formatting.

Result:
![screenshot_20181123_194110](https://user-images.githubusercontent.com/1730297/48957267-d20c1300-ef57-11e8-81c2-c378b1cf51cf.png)
![screenshot_20181123_194130](https://user-images.githubusercontent.com/1730297/48957268-d2a4a980-ef57-11e8-8ee9-b96b0505c139.png)
