### PR TITLE
Handle removed staticfiles.templatetags in Django 3.0

### DIFF
--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -5,7 +5,6 @@ from os.path import join, normpath
 
 from django.conf import settings
 from django.contrib.staticfiles import finders, storage
-from django.contrib.staticfiles.templatetags import staticfiles
 from django.core.files.storage import get_storage_class
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import LazyObject
@@ -97,14 +96,10 @@ class StaticFilesPanel(panels.Panel):
         self._paths = {}
 
     def enable_instrumentation(self):
-        storage.staticfiles_storage = (
-            staticfiles.staticfiles_storage
-        ) = DebugConfiguredStorage()
+        storage.staticfiles_storage = DebugConfiguredStorage()
 
     def disable_instrumentation(self):
-        storage.staticfiles_storage = (
-            staticfiles.staticfiles_storage
-        ) = _original_storage
+        storage.staticfiles_storage = _original_storage
 
     @property
     def num_used(self):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Change log
 UNRELEASED
 ----------
 
+* Updated ``StaticFilesPanel`` to be compatible with Django 3.0.
+
 1.11 (2018-12-03)
 -----------------
 


### PR DESCRIPTION
django.contrib.staticfiles.templatetags.staticfiles was deprecated in Django 2.1:

https://docs.djangoproject.com/en/dev/releases/2.1/#id2

> `{% load staticfiles %}` and `{% load admin_static %}` are deprecated in favor of `{% load static %}`, which works the same.

And will be removed in Django 3.0:

https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0

> The `staticfiles` and `admin_static` template tag libraries are removed.

Catch and ignore an `ImportError` as the module may not exist. Fixes tests against the Django master branch.