### PR TITLE
Add Django 2.2a1 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-dj21
     - python: 3.5
+      env: TOXENV=py35-dj22
+    - python: 3.6
+      env: TOXENV=py36-dj22
+    - python: 3.7
+      env: TOXENV=py37-dj22
+    - python: 3.5
       env: TOXENV=py35-djmaster
     - python: 3.6
       env: TOXENV=py36-djmaster

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{27,34,35,36,37}-dj111
     py{34,35,36,37}-dj20
     py{35,36,37}-dj21
+    py{35,36,37}-dj22
     py{35,36,37}-djmaster
     postgresql,
     mariadb,
@@ -15,6 +16,7 @@ deps =
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2a1,<2.3
     djmaster: https://github.com/django/django/archive/master.tar.gz
     coverage
     django_jinja


### PR DESCRIPTION
Django 2.2 alpha 1 was released on January 17, 2019.

https://www.djangoproject.com/weblog/2019/jan/17/django-22-alpha-1/