### PR TITLE
fix postgis explain

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -121,7 +121,9 @@ class NormalCursorWrapper(object):
     def _record(self, method, sql, params):
         start_time = time()
         try:
-            params = [param[19:-9] if type(param) == str and len(param) > 20 and param[:15] == "ST_GeomFromEWKB" else param for param in params]
+            # fix postgis types (TODO: make it work for type(params) == null and dict, and param ~= 'geography' and 'raster')
+            if type(params) == list:
+                params = [param[19:-9] if type(param) == str and len(param) > 20 and param[:15] == "ST_GeomFromEWKB" else param for param in params]
             return method(sql, params)
         finally:
             stop_time = time()


### PR DESCRIPTION
This fixes the error that arises when trying to explain a query that involves a geometry field when using django's GEOManager

the arises from this django line of code https://github.com/django/django/blob/b9cf764be62e77b4777b3a75ec256f6209a57671/django/contrib/gis/db/backends/postgis/adapter.py#L59
that executes only when using postgis backend.

This fixes a related issue that was closed without a fix https://github.com/jazzband/django-debug-toolbar/issues/423