### PR TITLE
Remove "quick setup" notes from profiling panel docs

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -126,9 +126,6 @@ will not be executed. This is because ``ProfilingPanel.process_view`` will
 return a ``HttpResponse`` which causes the other middlewares'
 ``process_view`` methods to be skipped.
 
-Note that the quick setup creates this situation, as it inserts
-``DebugToolbarMiddleware`` first in ``MIDDLEWARE_CLASSES``.
-
 If you run into this issues, then you should either disable the
 ``ProfilingPanel`` or move ``DebugToolbarMiddleware`` to the end of
 ``MIDDLEWARE_CLASSES``. If you do the latter, then the debug toolbar won't


### PR DESCRIPTION
Support for automatic or quick setup was removed in fe74d9b4bf1fceca70ec2d28482295aba782e05d. This mention should also be removed.