### PR TITLE
Make ProfilingPanal enabled but inactive by default

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -15,7 +15,10 @@ from django.utils.lru_cache import lru_cache
 
 CONFIG_DEFAULTS = {
     # Toolbar options
-    "DISABLE_PANELS": {"debug_toolbar.panels.redirects.RedirectsPanel"},
+    "DISABLE_PANELS": {
+        "debug_toolbar.panels.profiling.ProfilingPanel",
+        "debug_toolbar.panels.redirects.RedirectsPanel",
+    },
     "INSERT_BEFORE": "</body>",
     "RENDER_PANELS": None,
     "RESULTS_CACHE_SIZE": 10,
@@ -126,6 +129,7 @@ PANELS_DEFAULTS = [
     "debug_toolbar.panels.signals.SignalsPanel",
     "debug_toolbar.panels.logging.LoggingPanel",
     "debug_toolbar.panels.redirects.RedirectsPanel",
+    "debug_toolbar.panels.profiling.ProfilingPanel",
 ]
 
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ UNRELEASED
 ----------
 
 * Updated ``StaticFilesPanel`` to be compatible with Django 3.0.
+* The ``ProfilingPanel`` is now enabled but inactive by default.
 
 1.11 (2018-12-03)
 -----------------

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -105,12 +105,6 @@ Since this behavior is annoying when you aren't debugging a redirect, this
 panel is included but inactive by default. You can activate it by default with
 the ``DISABLE_PANELS`` configuration option.
 
-Non-default built-in panels
----------------------------
-
-The following panels are disabled by default. You must add them to the
-``DEBUG_TOOLBAR_PANELS`` setting to enable them.
-
 .. _profiling-panel:
 
 Profiling
@@ -120,13 +114,16 @@ Path: ``debug_toolbar.panels.profiling.ProfilingPanel``
 
 Profiling information for the processing of the request.
 
+This panel is included but inactive by default. You can activate it by default
+with the ``DISABLE_PANELS`` configuration option.
+
 If the ``debug_toolbar.middleware.DebugToolbarMiddleware`` is first in
 ``MIDDLEWARE_CLASSES`` then the other middlewares' ``process_view`` methods
 will not be executed. This is because ``ProfilingPanel.process_view`` will
 return a ``HttpResponse`` which causes the other middlewares'
 ``process_view`` methods to be skipped.
 
-If you run into this issues, then you should either disable the
+If you run into this issues, then you should either deactivate the
 ``ProfilingPanel`` or move ``DebugToolbarMiddleware`` to the end of
 ``MIDDLEWARE_CLASSES``. If you do the latter, then the debug toolbar won't
 track the execution of other middleware.

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -21,13 +21,13 @@ you see errors, try a hard browser refresh or clearing your cache.
 Middleware isn't working correctly
 ----------------------------------
 
-Using the Debug Toolbar in its default configuration and with the profiling
-panel will cause middlewares after
+Using the Debug Toolbar in its default configuration with the profiling panel
+active will cause middlewares after
 ``debug_toolbar.middleware.DebugToolbarMiddleware`` to not execute their
 ``process_view`` functions. This can be resolved by disabling the profiling
 panel or moving the ``DebugToolbarMiddleware`` to the end of
-``MIDDLEWARE_CLASSES``. Read more about it at
-:ref:`ProfilingPanel <profiling-panel>`
+``MIDDLEWARE_CLASSES``. Read more about it at :ref:`ProfilingPanel
+<profiling-panel>`
 
 Performance considerations
 --------------------------

--- a/example/settings.py
+++ b/example/settings.py
@@ -95,23 +95,4 @@ if os.environ.get("DJANGO_DATABASE_ENGINE", "").lower() == "mysql":
         }
     }
 
-
-# django-debug-toolbar
-
-DEBUG_TOOLBAR_PANELS = [
-    "debug_toolbar.panels.versions.VersionsPanel",
-    "debug_toolbar.panels.timer.TimerPanel",
-    "debug_toolbar.panels.settings.SettingsPanel",
-    "debug_toolbar.panels.headers.HeadersPanel",
-    "debug_toolbar.panels.request.RequestPanel",
-    "debug_toolbar.panels.sql.SQLPanel",
-    "debug_toolbar.panels.templates.TemplatesPanel",
-    "debug_toolbar.panels.staticfiles.StaticFilesPanel",
-    "debug_toolbar.panels.cache.CachePanel",
-    "debug_toolbar.panels.signals.SignalsPanel",
-    "debug_toolbar.panels.logging.LoggingPanel",
-    "debug_toolbar.panels.redirects.RedirectsPanel",
-    "debug_toolbar.panels.profiling.ProfilingPanel",
-]
-
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "example", "static")]


### PR DESCRIPTION
I believe the ProfilingPanal is disabled by default to avoid interfering
with other middleware and panels during profiling. The same can be
achieved by making the panel inactive. This makes it easier for users to
access the panel without additional configuration but continues to avoid
profiling interference.