### PR TITLE
Replace MIDDLEWARE_CLASSES references to MIDDLEWARE

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,8 +16,8 @@ DEBUG_TOOLBAR_PANELS
 --------------------
 
 This setting specifies the full Python path to each panel that you want
-included in the toolbar. It works like Django's ``MIDDLEWARE_CLASSES``
-setting. The default value is::
+included in the toolbar. It works like Django's ``MIDDLEWARE`` setting. The
+default value is::
 
     DEBUG_TOOLBAR_PANELS = [
         'debug_toolbar.panels.versions.VersionsPanel',

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -39,8 +39,8 @@ This panels shows the HTTP request and response headers, as well as a
 selection of values from the WSGI environment.
 
 Note that headers set by middleware placed before the debug toolbar middleware
-in ``MIDDLEWARE_CLASSES`` won't be visible in the panel. The WSGI server
-itself may also add response headers such as ``Date`` and ``Server``.
+in ``MIDDLEWARE`` won't be visible in the panel. The WSGI server itself may
+also add response headers such as ``Date`` and ``Server``.
 
 Request
 ~~~~~~~
@@ -118,15 +118,15 @@ This panel is included but inactive by default. You can activate it by default
 with the ``DISABLE_PANELS`` configuration option.
 
 If the ``debug_toolbar.middleware.DebugToolbarMiddleware`` is first in
-``MIDDLEWARE_CLASSES`` then the other middlewares' ``process_view`` methods
-will not be executed. This is because ``ProfilingPanel.process_view`` will
-return a ``HttpResponse`` which causes the other middlewares'
-``process_view`` methods to be skipped.
+``MIDDLEWARE`` then the other middlewares' ``process_view`` methods will not be
+executed. This is because ``ProfilingPanel.process_view`` will return a
+``HttpResponse`` which causes the other middlewares' ``process_view`` methods
+to be skipped.
 
 If you run into this issues, then you should either deactivate the
 ``ProfilingPanel`` or move ``DebugToolbarMiddleware`` to the end of
-``MIDDLEWARE_CLASSES``. If you do the latter, then the debug toolbar won't
-track the execution of other middleware.
+``MIDDLEWARE``. If you do the latter, then the debug toolbar won't track the
+execution of other middleware.
 
 Third-party panels
 ------------------

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -25,9 +25,8 @@ Using the Debug Toolbar in its default configuration with the profiling panel
 active will cause middlewares after
 ``debug_toolbar.middleware.DebugToolbarMiddleware`` to not execute their
 ``process_view`` functions. This can be resolved by disabling the profiling
-panel or moving the ``DebugToolbarMiddleware`` to the end of
-``MIDDLEWARE_CLASSES``. Read more about it at :ref:`ProfilingPanel
-<profiling-panel>`
+panel or moving the ``DebugToolbarMiddleware`` to the end of ``MIDDLEWARE``.
+Read more about it at :ref:`ProfilingPanel <profiling-panel>`
 
 Performance considerations
 --------------------------


### PR DESCRIPTION
`MIDDLEWARE_CLASSES` is deprecated and removed in Django 2.0, so refer to
`MIDDLEWARE` by default.