### PR TITLE
Move common, repetitive test setup to BaseTestCase

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -13,7 +13,10 @@ rf = RequestFactory()
 
 
 class BaseTestCase(TestCase):
+    panel_id = None
+
     def setUp(self):
+        super(BaseTestCase, self).setUp()
         request = rf.get("/")
         response = HttpResponse()
         toolbar = DebugToolbar(request)
@@ -26,6 +29,17 @@ class BaseTestCase(TestCase):
         self.response = response
         self.toolbar = toolbar
         self.toolbar.stats = {}
+
+        if self.panel_id:
+            self.panel = self.toolbar.get_panel_by_id(self.panel_id)
+            self.panel.enable_instrumentation()
+        else:
+            self.panel = None
+
+    def tearDown(self):
+        if self.panel:
+            self.panel.disable_instrumentation()
+        super(BaseTestCase, self).tearDown()
 
     def assertValidHTML(self, content, msg=None):
         parser = html5lib.HTMLParser()

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -8,14 +8,7 @@ from ..base import BaseTestCase
 
 
 class CachePanelTestCase(BaseTestCase):
-    def setUp(self):
-        super(CachePanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("CachePanel")
-        self.panel.enable_instrumentation()
-
-    def tearDown(self):
-        self.panel.disable_instrumentation()
-        super(CachePanelTestCase, self).tearDown()
+    panel_id = "CachePanel"
 
     def test_recording(self):
         self.assertEqual(len(self.panel.calls), 0)

--- a/tests/panels/test_logging.py
+++ b/tests/panels/test_logging.py
@@ -13,9 +13,10 @@ from ..base import BaseTestCase
 
 
 class LoggingPanelTestCase(BaseTestCase):
+    panel_id = "LoggingPanel"
+
     def setUp(self):
         super(LoggingPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("LoggingPanel")
         self.logger = logging.getLogger(__name__)
         collector.clear_collection()
 

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -16,9 +16,7 @@ from ..views import listcomp_view, regular_view
     DEBUG_TOOLBAR_PANELS=["debug_toolbar.panels.profiling.ProfilingPanel"]
 )
 class ProfilingPanelTestCase(BaseTestCase):
-    def setUp(self):
-        super(ProfilingPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("ProfilingPanel")
+    panel_id = "ProfilingPanel"
 
     def test_regular_view(self):
         self.panel.process_view(self.request, regular_view, ("profiling",), {})

--- a/tests/panels/test_redirects.py
+++ b/tests/panels/test_redirects.py
@@ -9,9 +9,7 @@ from ..base import BaseTestCase
 
 
 class RedirectsPanelTestCase(BaseTestCase):
-    def setUp(self):
-        super(RedirectsPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("RedirectsPanel")
+    panel_id = "RedirectsPanel"
 
     def test_regular_response(self):
         response = self.panel.process_response(self.request, self.response)

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -8,9 +8,7 @@ from ..base import BaseTestCase
 
 
 class RequestPanelTestCase(BaseTestCase):
-    def setUp(self):
-        super(RequestPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("RequestPanel")
+    panel_id = "RequestPanel"
 
     def test_non_ascii_session(self):
         self.request.session = {"où": "où"}

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -16,14 +16,7 @@ from ..base import BaseTestCase
 
 
 class SQLPanelTestCase(BaseTestCase):
-    def setUp(self):
-        super(SQLPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("SQLPanel")
-        self.panel.enable_instrumentation()
-
-    def tearDown(self):
-        self.panel.disable_instrumentation()
-        super(SQLPanelTestCase, self).tearDown()
+    panel_id = "SQLPanel"
 
     def test_disabled(self):
         config = {"DISABLE_PANELS": {"debug_toolbar.panels.sql.SQLPanel"}}

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -8,9 +8,7 @@ from ..base import BaseTestCase
 
 
 class StaticFilesPanelTestCase(BaseTestCase):
-    def setUp(self):
-        super(StaticFilesPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("StaticFilesPanel")
+    panel_id = "StaticFilesPanel"
 
     def test_default_case(self):
         self.panel.process_request(self.request)

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -11,16 +11,15 @@ from ..models import NonAsciiRepr
 
 
 class TemplatesPanelTestCase(BaseTestCase):
+    panel_id = "TemplatesPanel"
+
     def setUp(self):
         super(TemplatesPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("TemplatesPanel")
-        self.panel.enable_instrumentation()
         self.sql_panel = self.toolbar.get_panel_by_id("SQLPanel")
         self.sql_panel.enable_instrumentation()
 
     def tearDown(self):
         self.sql_panel.disable_instrumentation()
-        self.panel.disable_instrumentation()
         super(TemplatesPanelTestCase, self).tearDown()
 
     def test_queryset_hook(self):

--- a/tests/panels/test_versions.py
+++ b/tests/panels/test_versions.py
@@ -12,9 +12,7 @@ version_info_t = namedtuple(
 
 
 class VersionsPanelTestCase(BaseTestCase):
-    def setUp(self):
-        super(VersionsPanelTestCase, self).setUp()
-        self.panel = self.toolbar.get_panel_by_id("VersionsPanel")
+    panel_id = "VersionsPanel"
 
     def test_app_version_from_get_version_fn(self):
         class FakeApp:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,7 +10,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core import signing
 from django.core.checks import Warning, run_checks
 from django.template.loader import get_template
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
 from debug_toolbar.middleware import DebugToolbarMiddleware, show_toolbar
@@ -360,7 +360,7 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
 
 
 @override_settings(DEBUG=True)
-class DebugToolbarSystemChecksTestCase(BaseTestCase):
+class DebugToolbarSystemChecksTestCase(SimpleTestCase):
     @override_settings(
         MIDDLEWARE=[
             "django.contrib.messages.middleware.MessageMiddleware",


### PR DESCRIPTION
The subclass now only needs to define the class attribute "panel_id" and
BaseTestCase handles the finding it and enabling it.