### PR TITLE
Restructure the Panel class to execute more like the MIDDLEWARE

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -23,14 +23,8 @@ def check_middleware(app_configs, **kwargs):
     gzip_index = None
     debug_toolbar_indexes = []
 
-    setting = getattr(settings, "MIDDLEWARE", None)
-    setting_name = "MIDDLEWARE"
-    if setting is None:
-        setting = settings.MIDDLEWARE_CLASSES
-        setting_name = "MIDDLEWARE_CLASSES"
-
     # Determine the indexes which gzip and/or the toolbar are installed at
-    for i, middleware in enumerate(setting):
+    for i, middleware in enumerate(settings.MIDDLEWARE):
         if is_middleware_class(GZipMiddleware, middleware):
             gzip_index = i
         elif is_middleware_class(DebugToolbarMiddleware, middleware):
@@ -41,9 +35,9 @@ def check_middleware(app_configs, **kwargs):
         errors.append(
             Warning(
                 "debug_toolbar.middleware.DebugToolbarMiddleware is missing "
-                "from %s." % setting_name,
+                "from MIDDLEWARE.",
                 hint="Add debug_toolbar.middleware.DebugToolbarMiddleware to "
-                "%s." % setting_name,
+                "MIDDLEWARE.",
                 id="debug_toolbar.W001",
             )
         )
@@ -52,9 +46,9 @@ def check_middleware(app_configs, **kwargs):
         errors.append(
             Warning(
                 "debug_toolbar.middleware.DebugToolbarMiddleware occurs "
-                "multiple times in %s." % setting_name,
+                "multiple times in MIDDLEWARE.",
                 hint="Load debug_toolbar.middleware.DebugToolbarMiddleware only "
-                "once in %s." % setting_name,
+                "once in MIDDLEWARE.",
                 id="debug_toolbar.W002",
             )
         )
@@ -63,9 +57,9 @@ def check_middleware(app_configs, **kwargs):
         errors.append(
             Warning(
                 "debug_toolbar.middleware.DebugToolbarMiddleware occurs before "
-                "django.middleware.gzip.GZipMiddleware in %s." % setting_name,
+                "django.middleware.gzip.GZipMiddleware in MIDDLEWARE.",
                 hint="Move debug_toolbar.middleware.DebugToolbarMiddleware to "
-                "after django.middleware.gzip.GZipMiddleware in %s." % setting_name,
+                "after django.middleware.gzip.GZipMiddleware in MIDDLEWARE.",
                 id="debug_toolbar.W003",
             )
         )

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -13,8 +13,9 @@ class Panel(object):
     Base class for panels.
     """
 
-    def __init__(self, toolbar):
+    def __init__(self, toolbar, get_response):
         self.toolbar = toolbar
+        self.get_response = get_response
 
     # Private panel properties
 
@@ -129,8 +130,7 @@ class Panel(object):
         This is the opposite of :meth:`enable_instrumentation`.
 
         Unless the toolbar or this panel is disabled, this method will be
-        called late in :class:`DebugToolbarMiddleware.process_response`. It
-        should be idempotent.
+        called late in the middleware. It should be idempotent.
         """
 
     # Store and retrieve stats (shared between panels for no good reason)
@@ -168,40 +168,21 @@ class Panel(object):
 
     def process_request(self, request):
         """
-        Like process_request in Django's middleware.
+        Like __call__ in Django's middleware.
 
         Write panel logic related to the request there. Save data with
         :meth:`record_stats`.
-        """
 
-    def process_view(self, request, view_func, view_args, view_kwargs):
+        Return the existing response or overwrite it.
         """
-        Like process_view in Django's middleware.
-
-        Write panel logic related to the view there. Save data with
-        :meth:`record_stats`.
-        """
-
-    def process_response(self, request, response):
-        """
-        Like process_response in Django's middleware. This is similar to
-        :meth:`generate_stats <debug_toolbar.panels.Panel.generate_stats>`,
-        but will be executed on every request. It should be used when either
-        the logic needs to be executed on every request or it needs to change
-        the response entirely, such as :class:`RedirectsPanel`.
-
-        Write panel logic related to the response there. Post-process data
-        gathered while the view executed. Save data with :meth:`record_stats`.
-
-        Return a response to overwrite the existing response.
-        """
+        return self.get_response(request)
 
     def generate_stats(self, request, response):
         """
-        Similar to :meth:`process_response
-        <debug_toolbar.panels.Panel.process_response>`,
-        but may not be executed on every request. This will only be called if
-        the toolbar will be inserted into the request.
+        Called after :meth:`process_request
+        <debug_toolbar.panels.Panel.process_request>`, but may not be executed
+        on every request. This will only be called if the toolbar will be
+        inserted into the request.
 
         Write panel logic related to the response there. Post-process data
         gathered while the view executed. Save data with :meth:`record_stats`.

--- a/debug_toolbar/panels/headers.py
+++ b/debug_toolbar/panels/headers.py
@@ -51,6 +51,7 @@ class HeadersPanel(Panel):
         self.record_stats(
             {"request_headers": self.request_headers, "environ": self.environ}
         )
+        return super(HeadersPanel, self).process_request(request)
 
     def generate_stats(self, request, response):
         self.response_headers = OrderedDict(sorted(response.items()))

--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -76,6 +76,7 @@ class LoggingPanel(Panel):
 
     def process_request(self, request):
         collector.clear_collection()
+        return super(LoggingPanel, self).process_request(request)
 
     def generate_stats(self, request, response):
         records = collector.get_collection()

--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -154,10 +154,11 @@ class ProfilingPanel(Panel):
 
     template = "debug_toolbar/panels/profiling.html"
 
-    def process_view(self, request, view_func, view_args, view_kwargs):
+    def process_request(self, request):
         self.profiler = cProfile.Profile()
-        args = (request,) + view_args
-        return self.profiler.runcall(view_func, *args, **view_kwargs)
+        return self.profiler.runcall(
+            super(ProfilingPanel, self).process_request, request
+        )
 
     def add_node(self, func_list, func, max_depth, cum_time=0.1):
         func_list.append(func)

--- a/debug_toolbar/panels/redirects.py
+++ b/debug_toolbar/panels/redirects.py
@@ -15,7 +15,8 @@ class RedirectsPanel(Panel):
 
     nav_title = _("Intercept redirects")
 
-    def process_response(self, request, response):
+    def process_request(self, request):
+        response = super(RedirectsPanel, self).process_request(request)
         if 300 <= int(response.status_code) < 400:
             redirect_to = response.get("Location", None)
             if redirect_to:

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -116,6 +116,7 @@ class StaticFilesPanel(panels.Panel):
 
     def process_request(self, request):
         collector.clear_collection()
+        return super(StaticFilesPanel, self).process_request(request)
 
     def generate_stats(self, request, response):
         used_paths = collector.get_collection()

--- a/debug_toolbar/panels/timer.py
+++ b/debug_toolbar/panels/timer.py
@@ -57,6 +57,7 @@ class TimerPanel(Panel):
         self._start_time = time.time()
         if self.has_content:
             self._start_rusage = resource.getrusage(resource.RUSAGE_SELF)
+        return super(TimerPanel, self).process_request(request)
 
     def generate_stats(self, request, response):
         stats = {}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,19 @@ UNRELEASED
 * Updated ``StaticFilesPanel`` to be compatible with Django 3.0.
 * The ``ProfilingPanel`` is now enabled but inactive by default.
 * Fixed toggling of table rows in the profiling panel UI.
+* The ``ProfilingPanel`` no longer skips remaining panels or middlewares.
+
+**Backwards incompatible changes**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Removed support for Django's deprecated ``MIDDLEWARE_CLASSES`` setting.
+* Restructured ``Panel`` to execute more like the new-style Django MIDDLEWARE.
+  The ``Panel.__init__()`` method is now passed ``get_response`` as the first
+  positional argument. The ``Panel.process_request()`` method must now always
+  return a response. Usually this is the response returned by
+  ``get_response()`` but the panel may also return a different response as is
+  the case in the ``RedirectsPanel``. Third party panels must adjust to this
+  new architecture. ``Panel.process_response()`` and ``Panel.process_view()``
+  have been removed as a result of this change.
 
 1.11 (2018-12-03)
 -----------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -75,20 +75,11 @@ settings module as follows::
         # ...
     ]
 
-Old-style middleware::
-
-    MIDDLEWARE_CLASSES = [
-        # ...
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-        # ...
-    ]
-
 .. warning::
 
-    The order of ``MIDDLEWARE`` and ``MIDDLEWARE_CLASSES`` is important. You
-    should include the Debug Toolbar middleware as early as possible in the
-    list. However, it must come after any other middleware that encodes the
-    response's content, such as
+    The order of ``MIDDLEWARE`` is important. You should include the Debug
+    Toolbar middleware as early as possible in the list. However, it must come
+    after any other middleware that encodes the response's content, such as
     :class:`~django.middleware.gzip.GZipMiddleware`.
 
 Configuring Internal IPs

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -117,17 +117,6 @@ Profiling information for the processing of the request.
 This panel is included but inactive by default. You can activate it by default
 with the ``DISABLE_PANELS`` configuration option.
 
-If the ``debug_toolbar.middleware.DebugToolbarMiddleware`` is first in
-``MIDDLEWARE`` then the other middlewares' ``process_view`` methods will not be
-executed. This is because ``ProfilingPanel.process_view`` will return a
-``HttpResponse`` which causes the other middlewares' ``process_view`` methods
-to be skipped.
-
-If you run into this issues, then you should either deactivate the
-``ProfilingPanel`` or move ``DebugToolbarMiddleware`` to the end of
-``MIDDLEWARE``. If you do the latter, then the debug toolbar won't track the
-execution of other middleware.
-
 Third-party panels
 ------------------
 
@@ -341,10 +330,6 @@ unauthorized access. There is no public CSS API at this time.
     .. automethod:: debug_toolbar.panels.Panel.get_stats
 
     .. automethod:: debug_toolbar.panels.Panel.process_request
-
-    .. automethod:: debug_toolbar.panels.Panel.process_view
-
-    .. automethod:: debug_toolbar.panels.Panel.process_response
 
     .. automethod:: debug_toolbar.panels.Panel.generate_stats
 

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -18,16 +18,6 @@ Browsers have become more aggressive with caching static assets, such as
 JavaScript and CSS files. Check your browser's development console, and if
 you see errors, try a hard browser refresh or clearing your cache.
 
-Middleware isn't working correctly
-----------------------------------
-
-Using the Debug Toolbar in its default configuration with the profiling panel
-active will cause middlewares after
-``debug_toolbar.middleware.DebugToolbarMiddleware`` to not execute their
-``process_view`` functions. This can be resolved by disabling the profiling
-panel or moving the ``DebugToolbarMiddleware`` to the end of ``MIDDLEWARE``.
-Read more about it at :ref:`ProfilingPanel <profiling-panel>`
-
 Performance considerations
 --------------------------
 

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -30,13 +30,13 @@ class CachePanelTestCase(BaseTestCase):
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and
-        not the process_response.
+        not the process_request.
         """
         cache.cache.get("café")
-        self.panel.process_response(self.request, self.response)
+        response = self.panel.process_request(self.request)
         # ensure the panel does not have content yet.
         self.assertNotIn("café", self.panel.content)
-        self.panel.generate_stats(self.request, self.response)
+        self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
         self.assertIn("café", self.panel.content)
         self.assertValidHTML(self.panel.content)
@@ -49,8 +49,9 @@ class CachePanelTestCase(BaseTestCase):
 
         self.assertEqual(len(self.panel.calls), 3)
 
-        self.panel.generate_stats(self.request, self.response)
-        self.panel.generate_server_timing(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        self.panel.generate_server_timing(self.request, response)
 
         stats = self.panel.get_stats()
 

--- a/tests/panels/test_redirects.py
+++ b/tests/panels/test_redirects.py
@@ -12,18 +12,22 @@ class RedirectsPanelTestCase(BaseTestCase):
     panel_id = "RedirectsPanel"
 
     def test_regular_response(self):
-        response = self.panel.process_response(self.request, self.response)
-        self.assertTrue(response is self.response)
+        not_redirect = HttpResponse()
+        self._get_response = lambda request: not_redirect
+        response = self.panel.process_request(self.request)
+        self.assertTrue(response is not_redirect)
 
     def test_not_a_redirect(self):
-        redirect = HttpResponse(status=304)  # not modified
-        response = self.panel.process_response(self.request, redirect)
+        redirect = HttpResponse(status=304)
+        self._get_response = lambda request: redirect
+        response = self.panel.process_request(self.request)
         self.assertTrue(response is redirect)
 
     def test_redirect(self):
         redirect = HttpResponse(status=302)
         redirect["Location"] = "http://somewhere/else/"
-        response = self.panel.process_response(self.request, redirect)
+        self._get_response = lambda request: redirect
+        response = self.panel.process_request(self.request)
         self.assertFalse(response is redirect)
         self.assertContains(response, "302 Found")
         self.assertContains(response, "http://somewhere/else/")
@@ -37,7 +41,8 @@ class RedirectsPanelTestCase(BaseTestCase):
         with self.settings(TEMPLATES=TEMPLATES):
             redirect = HttpResponse(status=302)
             redirect["Location"] = "http://somewhere/else/"
-            response = self.panel.process_response(self.request, redirect)
+            self._get_response = lambda request: redirect
+            response = self.panel.process_request(self.request)
             self.assertFalse(response is redirect)
             self.assertContains(response, "302 Found")
             self.assertContains(response, "http://somewhere/else/")
@@ -45,22 +50,25 @@ class RedirectsPanelTestCase(BaseTestCase):
     def test_unknown_status_code(self):
         redirect = HttpResponse(status=369)
         redirect["Location"] = "http://somewhere/else/"
-        response = self.panel.process_response(self.request, redirect)
+        self._get_response = lambda request: redirect
+        response = self.panel.process_request(self.request)
         self.assertContains(response, "369 Unknown Status Code")
 
     def test_unknown_status_code_with_reason(self):
         redirect = HttpResponse(status=369, reason="Look Ma!")
         redirect["Location"] = "http://somewhere/else/"
-        response = self.panel.process_response(self.request, redirect)
+        self._get_response = lambda request: redirect
+        response = self.panel.process_request(self.request)
         self.assertContains(response, "369 Look Ma!")
 
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and
-        not the process_response.
+        not the process_request.
         """
         redirect = HttpResponse(status=304)
-        response = self.panel.process_response(self.request, redirect)
+        self._get_response = lambda request: redirect
+        response = self.panel.process_request(self.request)
         self.assertIsNotNone(response)
         response = self.panel.generate_stats(self.request, redirect)
         self.assertIsNone(response)

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -14,9 +14,8 @@ class RequestPanelTestCase(BaseTestCase):
         self.request.session = {"où": "où"}
         if not six.PY3:
             self.request.session["là".encode("utf-8")] = "là".encode("utf-8")
-        self.panel.process_request(self.request)
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
         content = self.panel.content
         if six.PY3:
             self.assertIn("où", content)
@@ -26,21 +25,20 @@ class RequestPanelTestCase(BaseTestCase):
 
     def test_object_with_non_ascii_repr_in_request_params(self):
         self.request.path = "/non_ascii_request/"
-        self.panel.process_request(self.request)
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
         self.assertIn("nôt åscíì", self.panel.content)
 
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and
-        not the process_response.
+        not the process_request.
         """
         self.request.path = "/non_ascii_request/"
-        self.panel.process_response(self.request, self.response)
+        response = self.panel.process_request(self.request)
         # ensure the panel does not have content yet.
         self.assertNotIn("nôt åscíì", self.panel.content)
-        self.panel.generate_stats(self.request, self.response)
+        self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
         self.assertIn("nôt åscíì", self.panel.content)
         self.assertValidHTML(self.panel.content)

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -45,9 +45,9 @@ class SQLPanelTestCase(BaseTestCase):
 
         list(User.objects.all())
 
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
-        self.panel.generate_server_timing(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        self.panel.generate_server_timing(self.request, response)
 
         # ensure query was logged
         self.assertEqual(len(self.panel._queries), 1)
@@ -74,8 +74,8 @@ class SQLPanelTestCase(BaseTestCase):
         list(User.objects.filter(username="café".encode("utf-8")))
         self.assertEqual(len(self.panel._queries), 3)
 
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
 
         # ensure the panel renders correctly
         self.assertIn("café", self.panel.content)
@@ -95,8 +95,8 @@ class SQLPanelTestCase(BaseTestCase):
         )
         list(User.objects.filter(date_joined=datetime.datetime(2017, 12, 22, 16, 7, 1)))
 
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
 
         # ensure query was logged
         self.assertEqual(len(self.panel._queries), 3)
@@ -115,8 +115,8 @@ class SQLPanelTestCase(BaseTestCase):
                 [connection.Database.Binary(b"\xff")],
             )
 
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
 
         self.assertEqual(len(self.panel._queries), 1)
         self.assertIn(
@@ -166,8 +166,8 @@ class SQLPanelTestCase(BaseTestCase):
             )
         )
 
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
 
         # ensure query was logged
         self.assertEqual(len(self.panel._queries), 2)
@@ -190,13 +190,13 @@ class SQLPanelTestCase(BaseTestCase):
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and
-        not the process_response.
+        not the process_request.
         """
         list(User.objects.filter(username="café".encode("utf-8")))
-        self.panel.process_response(self.request, self.response)
+        response = self.panel.process_request(self.request)
         # ensure the panel does not have content yet.
         self.assertNotIn("café", self.panel.content)
-        self.panel.generate_stats(self.request, self.response)
+        self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
         self.assertIn("café", self.panel.content)
         self.assertValidHTML(self.panel.content)

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -11,9 +11,8 @@ class StaticFilesPanelTestCase(BaseTestCase):
     panel_id = "StaticFilesPanel"
 
     def test_default_case(self):
-        self.panel.process_request(self.request)
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
         self.assertIn(
             "django.contrib.staticfiles.finders." "AppDirectoriesFinder",
             self.panel.content,
@@ -34,16 +33,15 @@ class StaticFilesPanelTestCase(BaseTestCase):
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and
-        not the process_response.
+        not the process_request.
         """
-        self.panel.process_request(self.request)
-        self.panel.process_response(self.request, self.response)
+        response = self.panel.process_request(self.request)
         # ensure the panel does not have content yet.
         self.assertNotIn(
             "django.contrib.staticfiles.finders." "AppDirectoriesFinder",
             self.panel.content,
         )
-        self.panel.generate_stats(self.request, self.response)
+        self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
         self.assertIn(
             "django.contrib.staticfiles.finders." "AppDirectoriesFinder",

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -40,37 +40,35 @@ class TemplatesPanelTestCase(BaseTestCase):
         self.assertIn("<<triggers database query>>", ctx)
 
     def test_object_with_non_ascii_repr_in_context(self):
-        self.panel.process_request(self.request)
+        response = self.panel.process_request(self.request)
         t = Template("{{ object }}")
         c = Context({"object": NonAsciiRepr()})
         t.render(c)
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        self.panel.generate_stats(self.request, response)
         self.assertIn("nôt åscíì", self.panel.content)
 
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and
-        not the process_response.
+        not the process_request.
         """
         t = Template("{{ object }}")
         c = Context({"object": NonAsciiRepr()})
         t.render(c)
-        self.panel.process_response(self.request, self.response)
+        response = self.panel.process_request(self.request)
         # ensure the panel does not have content yet.
         self.assertNotIn("nôt åscíì", self.panel.content)
-        self.panel.generate_stats(self.request, self.response)
+        self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
         self.assertIn("nôt åscíì", self.panel.content)
         self.assertValidHTML(self.panel.content)
 
     def test_custom_context_processor(self):
-        self.panel.process_request(self.request)
+        response = self.panel.process_request(self.request)
         t = Template("{{ content }}")
         c = RequestContext(self.request, processors=[context_processor])
         t.render(c)
-        self.panel.process_response(self.request, self.response)
-        self.panel.generate_stats(self.request, self.response)
+        self.panel.generate_stats(self.request, response)
         self.assertIn(
             "tests.panels.test_template.context_processor", self.panel.content
         )


### PR DESCRIPTION
This allows the `ProfilingPanel` to no longer skip remaining panels or middlewares.

This change is backwards incompatible. Third party panels will need to adjust to use this new architecture. It removes support for Django 1.11's deprecated `MIDDLEWARE_CLASSES` setting.

The `Panel.__init__()` method is now passed a get_response argument. The `Panel.process_request()` method must now always return a response. Usually this is the response returned by `get_response()` but may also return a different response as is the case in the `RedirectsPanel`.

`Panel.process_response()` and `Panel.process_view()` have been removed.

Fixes #1135