### PR TITLE
Fix toggling of table rows in the profiling panel UI

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -12,11 +12,11 @@
 	</thead>
 	<tbody>
 		{% for call in func_list %}
-			<tr class="{% cycle 'djDebugOdd' 'djDebugEven' %} djDebugProfileRow{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" depth="{{ call.depth }}">
+			<tr class="{% cycle 'djDebugOdd' 'djDebugEven' %} djDebugProfileRow{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" depth="{{ call.depth }}" id="profilingMain_{{ call.id }}">
 				<td>
 					<div data-padding-left="{{ call.indent }}px">
 						{% if call.has_subfuncs %}
-							<a class="djProfileToggleDetails djToggleSwitch" data-toggle-id="{{ call.id }}" data-toggle-open="+" data-toggle-close="-" href>-</a>
+							<a class="djProfileToggleDetails djToggleSwitch" data-toggle-name="profilingMain" data-toggle-id="{{ call.id }}" data-toggle-open="+" data-toggle-close="-" href>-</a>
 						{% else %}
 							<span class="djNoToggleSwitch"></span>
 						{% endif %}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
 * Updated ``StaticFilesPanel`` to be compatible with Django 3.0.
 * The ``ProfilingPanel`` is now enabled but inactive by default.
+* Fixed toggling of table rows in the profiling panel UI.
 
 1.11 (2018-12-03)
 -----------------


### PR DESCRIPTION
Fixes JS error. The error in Firefox was:

    TypeError: container is null

        init http://localhost:8000/static/debug_toolbar/js/toolbar.js:147
        on http://localhost:8000/static/debug_toolbar/js/toolbar.js:7