### PR TITLE
Remove py35-djmaster from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ matrix:
       env: TOXENV=py36-dj22
     - python: 3.7
       env: TOXENV=py37-dj22
-    - python: 3.5
-      env: TOXENV=py35-djmaster
     - python: 3.6
       env: TOXENV=py36-djmaster
     - python: 3.7
@@ -55,7 +53,6 @@ matrix:
     - python: 3.7
       env: TOXENV=readme
   allow_failures:
-    - env: TOXENV=py35-djmaster
     - env: TOXENV=py36-djmaster
     - env: TOXENV=py37-djmaster
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{34,35,36,37}-dj20
     py{35,36,37}-dj21
     py{35,36,37}-dj22
-    py{35,36,37}-djmaster
+    py{36,37}-djmaster
     postgresql,
     mariadb,
     flake8,


### PR DESCRIPTION
Django removed support for Python 3.5 in commit:
https://github.com/django/django/commit/7e6b214ed34f5562dbd83cf54924a5b589a29715