### PR TITLE
Remove long deprecated settings and APIs

### DIFF
--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import warnings
-
 from django.template.loader import render_to_string
 
 from debug_toolbar import settings as dt_settings
@@ -218,10 +216,3 @@ class Panel(object):
 
         Does not return a value.
         """
-
-
-# Backward-compatibility for 1.0, remove in 2.0.
-class DebugPanel(Panel):
-    def __init__(self, *args, **kwargs):
-        warnings.warn("DebugPanel was renamed to Panel.", DeprecationWarning)
-        super(DebugPanel, self).__init__(*args, **kwargs)

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import warnings
-
 from django.conf import settings
 from django.utils import six
 from django.utils.lru_cache import lru_cache
@@ -50,69 +48,8 @@ CONFIG_DEFAULTS = {
 @lru_cache()
 def get_config():
     USER_CONFIG = getattr(settings, "DEBUG_TOOLBAR_CONFIG", {})
-
-    # Backward-compatibility for 1.0, remove in 2.0.
-    _RENAMED_CONFIG = {
-        "RESULTS_STORE_SIZE": "RESULTS_CACHE_SIZE",
-        "ROOT_TAG_ATTRS": "ROOT_TAG_EXTRA_ATTRS",
-        "HIDDEN_STACKTRACE_MODULES": "HIDE_IN_STACKTRACES",
-    }
-    for old_name, new_name in _RENAMED_CONFIG.items():
-        if old_name in USER_CONFIG:
-            warnings.warn(
-                "%r was renamed to %r. Update your DEBUG_TOOLBAR_CONFIG "
-                "setting." % (old_name, new_name),
-                DeprecationWarning,
-            )
-            USER_CONFIG[new_name] = USER_CONFIG.pop(old_name)
-
-    if "HIDE_DJANGO_SQL" in USER_CONFIG:
-        warnings.warn(
-            "HIDE_DJANGO_SQL was removed. Update your " "DEBUG_TOOLBAR_CONFIG setting.",
-            DeprecationWarning,
-        )
-        USER_CONFIG.pop("HIDE_DJANGO_SQL")
-
-    if "TAG" in USER_CONFIG:
-        warnings.warn(
-            "TAG was replaced by INSERT_BEFORE. Update your "
-            "DEBUG_TOOLBAR_CONFIG setting.",
-            DeprecationWarning,
-        )
-        USER_CONFIG["INSERT_BEFORE"] = "</%s>" % USER_CONFIG.pop("TAG")
-
     CONFIG = CONFIG_DEFAULTS.copy()
     CONFIG.update(USER_CONFIG)
-
-    if "INTERCEPT_REDIRECTS" in USER_CONFIG:
-        warnings.warn(
-            "INTERCEPT_REDIRECTS is deprecated. Please use the "
-            "DISABLE_PANELS config in the "
-            "DEBUG_TOOLBAR_CONFIG setting.",
-            DeprecationWarning,
-        )
-        if USER_CONFIG["INTERCEPT_REDIRECTS"]:
-            if (
-                "debug_toolbar.panels.redirects.RedirectsPanel"
-                in CONFIG["DISABLE_PANELS"]
-            ):
-                # RedirectsPanel should be enabled
-                try:
-                    CONFIG["DISABLE_PANELS"].remove(
-                        "debug_toolbar.panels.redirects.RedirectsPanel"
-                    )
-                except KeyError:
-                    # We wanted to remove it, but it didn't exist. This is fine
-                    pass
-        elif (
-            "debug_toolbar.panels.redirects.RedirectsPanel"
-            not in CONFIG["DISABLE_PANELS"]
-        ):
-            # RedirectsPanel should be disabled
-            CONFIG["DISABLE_PANELS"].add(
-                "debug_toolbar.panels.redirects.RedirectsPanel"
-            )
-
     return CONFIG
 
 
@@ -139,29 +76,4 @@ def get_panels():
         PANELS = list(settings.DEBUG_TOOLBAR_PANELS)
     except AttributeError:
         PANELS = PANELS_DEFAULTS
-    else:
-        # Backward-compatibility for 1.0, remove in 2.0.
-        _RENAMED_PANELS = {
-            "debug_toolbar.panels.version.VersionDebugPanel": "debug_toolbar.panels.versions.VersionsPanel",  # noqa
-            "debug_toolbar.panels.timer.TimerDebugPanel": "debug_toolbar.panels.timer.TimerPanel",  # noqa
-            "debug_toolbar.panels.settings_vars.SettingsDebugPanel": "debug_toolbar.panels.settings.SettingsPanel",  # noqa
-            "debug_toolbar.panels.headers.HeaderDebugPanel": "debug_toolbar.panels.headers.HeadersPanel",  # noqa
-            "debug_toolbar.panels.request_vars.RequestVarsDebugPanel": "debug_toolbar.panels.request.RequestPanel",  # noqa
-            "debug_toolbar.panels.sql.SQLDebugPanel": "debug_toolbar.panels.sql.SQLPanel",  # noqa
-            "debug_toolbar.panels.template.TemplateDebugPanel": "debug_toolbar.panels.templates.TemplatesPanel",  # noqa
-            "debug_toolbar.panels.cache.CacheDebugPanel": "debug_toolbar.panels.cache.CachePanel",  # noqa
-            "debug_toolbar.panels.signals.SignalDebugPanel": "debug_toolbar.panels.signals.SignalsPanel",  # noqa
-            "debug_toolbar.panels.logger.LoggingDebugPanel": "debug_toolbar.panels.logging.LoggingPanel",  # noqa
-            "debug_toolbar.panels.redirects.InterceptRedirectsDebugPanel": "debug_toolbar.panels.redirects.RedirectsPanel",  # noqa
-            "debug_toolbar.panels.profiling.ProfilingDebugPanel": "debug_toolbar.panels.profiling.ProfilingPanel",  # noqa
-        }
-        for index, old_panel in enumerate(PANELS):
-            new_panel = _RENAMED_PANELS.get(old_panel)
-            if new_panel is not None:
-                warnings.warn(
-                    "%r was renamed to %r. Update your DEBUG_TOOLBAR_PANELS "
-                    "setting." % (old_panel, new_panel),
-                    DeprecationWarning,
-                )
-                PANELS[index] = new_panel
     return PANELS

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,12 +1,27 @@
 Change log
 ==========
 
-UNRELEASED
-----------
+2.0 UNRELEASED
+--------------
 
 * Updated ``StaticFilesPanel`` to be compatible with Django 3.0.
 * The ``ProfilingPanel`` is now enabled but inactive by default.
 * Fixed toggling of table rows in the profiling panel UI.
+
+**Backwards incompatible changes**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The deprecated API, ``debug_toolbar.panels.DebugPanel``, has been removed.
+Third party panels should use ``debug_toolbar.panels.Panel`` instead.
+
+The following deprecated settings have been removed:
+
+* ``HIDDEN_STACKTRACE_MODULES``
+* ``HIDE_DJANGO_SQL``
+* ``INTERCEPT_REDIRECTS``
+* ``RESULTS_STORE_SIZE``
+* ``ROOT_TAG_ATTRS``
+* ``TAG``
 
 1.11 (2018-12-03)
 -----------------

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,6 @@ from debug_toolbar.toolbar import DebugToolbar
 def update_toolbar_config(**kwargs):
     if kwargs["setting"] == "DEBUG_TOOLBAR_CONFIG":
         dt_settings.get_config.cache_clear()
-        # This doesn't account for deprecated configuration options.
 
 
 @receiver(setting_changed)
@@ -20,4 +19,3 @@ def update_toolbar_panels(**kwargs):
         dt_settings.get_panels.cache_clear()
         DebugToolbar._panel_classes = None
         # Not implemented: invalidate debug_toolbar.urls.
-        # This doesn't account for deprecated panel names.


### PR DESCRIPTION
These settings and APIs have been deprecated for a significant amount of
time. Enough for maintained third party panels and projects to update
their configurations.