### PR TITLE
WIP: Add proper failing testcase for binary data

### DIFF
--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -108,7 +108,7 @@ class SQLPanelTestCase(BaseTestCase):
         with connection.cursor() as cursor:
             cursor.execute(
                 "SELECT * FROM tests_binary WHERE field = %s",
-                [connection.Database.Binary(b"\xff")],
+                [connection.Database.Binary(b"\udc80\x04\xff")],
             )
 
         response = self.panel.process_request(self.request)


### PR DESCRIPTION
I noticed there was a hole in the tests for actual binary data. I came across this because I was trying to save a pickled pandas model in a `BinaryField`, but everytime I did, djdt would die. I've tracked it down to the binary containing the proposed change in this patch. 
It's currently a failing test case in mariadb/mysql and I haven't looked into how to fix it, any guidance on that would help and I'll also submit a fix