### PR TITLE
Handle SQL commands executed using as psycopg2 Composed object

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -135,6 +135,10 @@ class NormalCursorWrapper:
             conn = self.db.connection
             vendor = getattr(conn, "vendor", "unknown")
 
+            # Sql might be an object (such as psycopg Composed).
+            # For logging purposes, make sure it's str.
+            sql = str(sql)
+
             params = {
                 "vendor": vendor,
                 "alias": alias,


### PR DESCRIPTION
The Composed object is the recommended way of composing SQL statements.
The SQL panel is currently expecting an string sql. Executing a composed
sql command will cause the following exception:

```
======================================================================
ERROR: test_execute_with_psycopg2_composed_sql (tests.panels.test_sql.SQLPanelTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/haki/src/django-debug-toolbar/tests/panels/test_sql.py", line 228, in test_execute_with_psycopg2_composed_sql
    cursor.execute(command)
  File "/home/haki/src/django-debug-toolbar/debug_toolbar/panels/sql/tracking.py", line 184, in execute
    return self._record(self.cursor.execute, sql, params)
  File "/home/haki/src/django-debug-toolbar/debug_toolbar/panels/sql/tracking.py", line 156, in _record
    "is_select": sql.lower().strip().startswith("select"),
AttributeError: 'Composed' object has no attribute 'lower'
```

The solution is to cast the sql to string. If it's already string - no harm. If it's a
`Composable` object, it will return the composed SQL as str.