### PR TITLE
Update Black URL

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -85,7 +85,7 @@ SQLite.
 Style
 -----
 
-The Django Debug Toolbar uses `black <https://github.com/ambv/black>`__
+The Django Debug Toolbar uses `black <https://github.com/python/black>`__
 to format code and additionally uses flake8 and isort. You can reformat
 the code using::
 


### PR DESCRIPTION
> Black, your uncompromising #Python code formatter, was a project
> created with the community in mind from Day 1. Today we moved it under
> the PSF umbrella. It's now available on GitHub under
> https://github.com/python/black/ . You install and use it just like
> before.

https://twitter.com/llanga/status/1123980466292445190