### PR TITLE
Replace usage of django-jinja with Django's own Jinja2 backend

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,7 +2,7 @@
 
 Django
 sqlparse
-django_jinja
+Jinja2
 
 # Testing
 

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -96,7 +96,7 @@ class JinjaTemplateTestCase(TestCase):
     def test_django_jinja2(self):
         r = self.client.get("/regular_jinja/foobar/")
         self.assertContains(r, "Test for foobar (Jinja)")
-        self.assertContains(r, "<h3>Templates (1 rendered)</h3>")
+        self.assertContains(r, "<h3>Templates (2 rendered)</h3>")
         self.assertContains(r, "<small>jinja2/basic.jinja</small>")
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,7 +24,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "debug_toolbar",
-    "django_jinja",
     "tests",
 ]
 
@@ -46,7 +45,7 @@ ROOT_URLCONF = "tests.urls"
 TEMPLATES = [
     {
         "NAME": "jinja2",
-        "BACKEND": "django_jinja.backend.Jinja2",
+        "BACKEND": "django.template.backends.jinja2.Jinja2",
         "APP_DIRS": True,
         "DIRS": [os.path.join(BASE_DIR, "tests", "templates", "jinja2")],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     dj22: Django>=2.2,<3.0
     djmaster: https://github.com/django/django/archive/master.tar.gz
     coverage
-    django_jinja
+    Jinja2
     html5lib
     selenium<4.0
     sqlparse
@@ -33,7 +33,7 @@ commands = make coverage TEST_ARGS='{posargs:tests}'
 deps =
     Django>=2.1,<2.2
     coverage
-    django_jinja
+    Jinja2
     html5lib
     psycopg2-binary
     selenium<4.0
@@ -49,7 +49,7 @@ commands = make coverage TEST_ARGS='{posargs:tests}'
 deps =
     Django>=2.1,<2.2
     coverage
-    django_jinja
+    Jinja2
     html5lib
     mysqlclient<1.4
     selenium<4.0


### PR DESCRIPTION
The django-jinja package still depends on API which will not be
available in the upcoming Django 3.0 release anymore.

Also makes tests pass on Django@master again, hopefully.