### PR TITLE
Add info about IP addresses to Tips documentation page

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -82,6 +82,8 @@ settings module as follows::
     after any other middleware that encodes the response's content, such as
     :class:`~django.middleware.gzip.GZipMiddleware`.
 
+.. _internal-ips:
+
 Configuring Internal IPs
 ------------------------
 

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -5,9 +5,11 @@ The toolbar isn't displayed!
 ----------------------------
 
 The Debug Toolbar will only display when ``DEBUG = True`` in your project's
-settings. It will also only display if the mimetype of the response is
-either ``text/html`` or ``application/xhtml+xml`` and contains a closing
-``</body>`` tag.
+settings (see :ref:`Show Toolbar Callback <SHOW_TOOLBAR_CALLBACK>`) and your
+IP address must also match an entry in your project's ``INTERNAL_IPS`` setting
+(see :ref:`internal-ips`).  It will also only display if the mimetype of the
+response is either ``text/html`` or ``application/xhtml+xml`` and contains a
+closing ``</body>`` tag.
 
 Be aware of middleware ordering and other middleware that may intercept
 requests and return responses. Putting the debug toolbar middleware *after*


### PR DESCRIPTION
This documents the need for IP addresses to match the INTERNAL_IPS
setting to the 'tips' page (linking back to source material elsewhere
in the docs).

Also, the recent docs changes (eg a PR I made a while ago) don't appear in the docs -- seems that RTD hasn't made a build in 5 months (https://readthedocs.org/projects/django-debug-toolbar/builds/).  There were some changes required between GitHub/RTD recently so perhaps the hooks need checking.