### PR TITLE
also instrument `chunked_cursor`

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -36,6 +36,7 @@ recording = state.recording  # export function
 def wrap_cursor(connection, panel):
     if not hasattr(connection, "_djdt_cursor"):
         connection._djdt_cursor = connection.cursor
+        connection._djdt_chunked_cursor = connection.chunked_cursor
 
         def cursor(*args, **kwargs):
             # Per the DB API cursor() does not accept any arguments. There's
@@ -48,7 +49,13 @@ def wrap_cursor(connection, panel):
                 connection._djdt_cursor(*args, **kwargs), connection, panel
             )
 
+        def chunked_cursor(*args, **kwargs):
+            return state.Wrapper(
+                connection._djdt_chunked_cursor(*args, **kwargs), connection, panel
+            )
+
         connection.cursor = cursor
+        connection.chunked_cursor = chunked_cursor
         return cursor
 
 
@@ -56,6 +63,7 @@ def unwrap_cursor(connection):
     if hasattr(connection, "_djdt_cursor"):
         del connection._djdt_cursor
         del connection.cursor
+        del connection.chunked_cursor
 
 
 class ExceptionCursorWrapper:

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -36,6 +36,17 @@ class SQLPanelTestCase(BaseTestCase):
         # ensure the stacktrace is populated
         self.assertTrue(len(query[1]["stacktrace"]) > 0)
 
+    @unittest.skipUnless(
+        connection.vendor == "postgresql", "Test valid only on PostgreSQL"
+    )
+    def test_recording_chunked_cursor(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        list(User.objects.all().iterator())
+
+        # ensure query was logged
+        self.assertEqual(len(self.panel._queries), 1)
+
     def test_generate_server_timing(self):
         self.assertEqual(len(self.panel._queries), 0)
 


### PR DESCRIPTION
In addition to wrapping `cursor`, also wrap `chunked_cursor` so that
queries using server side cursors get recorded.

Fixes #1041