### PR TITLE
Remove unsupported Python 3.4 references from additional places

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 style:
 	isort -rc debug_toolbar example tests
-	black debug_toolbar example tests setup.py
+	black --target-version=py35 debug_toolbar example tests setup.py
 	flake8 debug_toolbar example tests
 
 style_check:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ style:
 
 style_check:
 	isort -rc -c debug_toolbar example tests
-	black --target-version=py34 --check debug_toolbar example tests setup.py
+	black --target-version=py35 --check debug_toolbar example tests setup.py
 
 flake8:
 	flake8 debug_toolbar example tests

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 
 style:
 	isort -rc debug_toolbar example tests
-	black --target-version=py35 debug_toolbar example tests setup.py
+	black --target-version py35 debug_toolbar example tests setup.py
 	flake8 debug_toolbar example tests
 
 style_check:
 	isort -rc -c debug_toolbar example tests
-	black --target-version=py35 --check debug_toolbar example tests setup.py
+	black --target-version py35 --check debug_toolbar example tests setup.py
 
 flake8:
 	flake8 debug_toolbar example tests

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 
 style:
 	isort -rc debug_toolbar example tests
-	black --target-version py35 debug_toolbar example tests setup.py
+	black --target-version=py34 debug_toolbar example tests setup.py
 	flake8 debug_toolbar example tests
 
 style_check:
 	isort -rc -c debug_toolbar example tests
-	black --target-version py35 --check debug_toolbar example tests setup.py
+	black --target-version=py34 --check debug_toolbar example tests setup.py
 
 flake8:
 	flake8 debug_toolbar example tests

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -180,7 +180,7 @@ class CachePanel(Panel):
         trace=None,
         template_info=None,
         backend=None,
-        **kw
+        **kw,
     ):
         if name == "get":
             if return_value is None:

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -180,7 +180,7 @@ class CachePanel(Panel):
         trace=None,
         template_info=None,
         backend=None,
-        **kw,
+        **kw
     ):
         if name == "get":
             if return_value is None:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     download_url="https://pypi.org/project/django-debug-toolbar/",
     license="BSD",
     packages=find_packages(exclude=("tests.*", "tests", "example")),
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     install_requires=["Django>=1.11", "sqlparse>=0.2.0"],
     include_package_data=True,
     zip_safe=False,  # because we're including static files
@@ -40,7 +40,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Support for Python 3.4 was dropped in 733986f541de72e8718ce7f502fafc95e6139465 but a few references remained.