### PR TITLE
Remove dead branch from get_name_from_obj()

### DIFF
--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -137,10 +137,8 @@ def get_template_source_from_exception_info(node, context):
 def get_name_from_obj(obj):
     if hasattr(obj, "__name__"):
         name = obj.__name__
-    elif hasattr(obj, "__class__") and hasattr(obj.__class__, "__name__"):
-        name = obj.__class__.__name__
     else:
-        name = "<unknown>"
+        name = obj.__class__.__name__
 
     if hasattr(obj, "__module__"):
         module = obj.__module__


### PR DESCRIPTION
In Python 3, all objects have a `__class__` attribute and the `__class__`
attribute always has a `__name__`.

django-debug-toolbar has been Python 3 only since 3ee10e822ae495dcec0eacc8af612d2b461a1901.