### PR TITLE
Remove unnecessary guard

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -93,7 +93,7 @@ class TemplatesPanel(Panel):
 
         context_list = []
         for context_layer in context.dicts:
-            if hasattr(context_layer, "items") and context_layer:
+            if context_layer:
                 # Refs GitHub issue #910
                 # If we can find this layer in our pseudo-cache then find the
                 # matching prettified version in the associated list.


### PR DESCRIPTION
All `dicts` in a context have an `.items()` method. The `Context` class is a
subclass of `dict`.