### PR TITLE
Move recording() outside of the try block

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -128,8 +128,8 @@ class TemplatesPanel(Panel):
                                 value.__class__.__name__.lower(), model_name
                             )
                         else:
+                            recording(False)
                             try:
-                                recording(False)
                                 saferepr(value)  # this MAY trigger a db query
                             except SQLQueryTriggered:
                                 temp_layer[key] = "<<triggers database query>>"


### PR DESCRIPTION
The call to recording should not throw an exception. If it does, it
should be handled as a bug rather than silently skipped over.