### PR TITLE
Run the fast style check targets first in the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ cache: pip
 matrix:
   fast_finish: true
   include:
+    - env: TOXENV=flake8
+    - python: 3.7
+      env: TOXENV=style
+    - python: 3.7
+      env: TOXENV=readme
     - python: 3.5
       env: TOXENV=py35-dj111
     - python: 3.6
@@ -48,11 +53,6 @@ matrix:
         - mysql -u root -e "CREATE DATABASE debug_toolbar;"
         - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%';";
         - tox -v
-    - env: TOXENV=flake8
-    - python: 3.7
-      env: TOXENV=style
-    - python: 3.7
-      env: TOXENV=readme
   allow_failures:
     - env: TOXENV=py36-djmaster
     - env: TOXENV=py37-djmaster

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist =
+    flake8
+    style
+    readme
     py{35,36,37}-dj111
     py{35,36,37}-dj20
     py{35,36,37}-dj21
     py{35,36,37}-dj22
     py{36,37}-djmaster
-    postgresql,
-    mariadb,
-    flake8,
-    style,
-    readme
+    postgresql
+    mariadb
 
 [testenv]
 deps =


### PR DESCRIPTION
Relative to the tests, the style checks run very first. When running the
full test suite, it is useful to get fast early feedback rather than
wait for multiple tests to run only to realize double quotes should have
been used or there is an unused import.