### PR TITLE
Adding a refrence to djdt.init to the window

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -322,6 +322,7 @@
     window.djdt = {
         show_toolbar: djdt.show_toolbar,
         hide_toolbar: djdt.hide_toolbar,
+        init: djdt.init,
         close: djdt.hide_one_level,
         cookie: djdt.cookie,
         applyStyle: djdt.applyStyle


### PR DESCRIPTION
fix for #1179  - it's not reasonable to expect debug-toolbar to support all javascript use cases, but if the init function is exposed I can manually reinitialize after a page transition.  