### PR TITLE
Financial Contributors from Open Collective

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,12 @@ Django Debug Toolbar
 .. image:: https://requires.io/github/jazzband/django-debug-toolbar/requirements.svg?branch=master
      :target: https://requires.io/github/jazzband/django-debug-toolbar/requirements/?branch=master
      :alt: Requirements Status
+     
+.. image:: https://opencollective.com/jazzband/all/badge.svg?label=financial+contributors
+    :alt: Financial Contributors on Open Collective
+    :target: https://opencollective.com/jazzband
+
+
 
 The Django Debug Toolbar is a configurable set of panels that display various
 debug information about the current request/response and when clicked, display
@@ -44,3 +50,35 @@ The Django Debug Toolbar was originally created by Rob Hudson <rob@cogit8.org>
 in August 2008 and was further developed by many contributors_.
 
 .. _contributors: https://github.com/jazzband/django-debug-toolbar/graphs/contributors
+
+Contributors
++++++++
+
+Code Contributors
+------------------
+
+This project exists thanks to all the people who contribute. 
+
+.. image:: https://opencollective.com/jazzband/contributors.svg?width=890&button=false 
+
+Financial Contributors
+------------------
+
+Become a financial contributor and help us sustain our community. Contribute_
+
+Individuals
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: https://opencollective.com/jazzband/individuals.svg?width=890
+    :target: https://opencollective.com/jazzband
+
+Organizations
+
+~~~~~~~~~~~~~~~~~~~~~~
+
+Support this project with your organization. Your logo will show up here with a link to your website. Contribute_
+
+.. image:: https://opencollective.com/jazzband/organization/0/avatar.svg
+    :target: https://opencollective.com/jazzband/organization/0/website
+
+.. _Contribute: https://opencollective.com/jazzband


### PR DESCRIPTION
Hi, I'm making updates for Open Collective. Either you or another core contributor signed this repository up for Open Collective. This pull request adds financial contributors from your Open Collective https://opencollective.com/jazzband ❤️

  What it does:
  - adds a badge to show the latest number of financial contributors
  - adds a banner displaying contributors to the project on GitHub -- note: there are too many right now, and it does not show in preview. I did not know this was an issue - haven't seen it before. The image shows at the link.
  - adds a banner displaying all individuals contributing financially on Open Collective
  - adds a section displaying all organizations contributing financially on Open Collective, with their logo and a link to their website

P.S: As with any pull request, feel free to comment or suggest changes.

  Thank you for your great contribution to the Open Source community. You are awesome! 🙌
  And welcome to the Open Collective community! 😊

  Come chat with us in the #opensource channel on https://slack.opencollective.com - great place to ask questions and share best practices with other Open Source sustainers!