### PR TITLE
Add Python 3.8 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-dist: xenial
 language: python
 cache: pip
 matrix:
   fast_finish: true
   include:
     - env: TOXENV=flake8
-    - python: 3.7
-      env: TOXENV=style
-    - python: 3.7
-      env: TOXENV=readme
+    - env: TOXENV=style
+    - env: TOXENV=readme
     - python: 3.5
       env: TOXENV=py35-dj111
     - python: 3.6
@@ -33,20 +30,24 @@ matrix:
       env: TOXENV=py36-dj22
     - python: 3.7
       env: TOXENV=py37-dj22
+    - python: 3.8
+      env: TOXENV=py38-dj22
     - python: 3.6
       env: TOXENV=py36-dj30
     - python: 3.7
       env: TOXENV=py37-dj30
+    - python: 3.8
+      env: TOXENV=py38-dj30
     - python: 3.6
       env: TOXENV=py36-djmaster
     - python: 3.7
       env: TOXENV=py37-djmaster
-    - python: 3.7
-      env: TOXENV=postgresql
+    - python: 3.8
+      env: TOXENV=py38-djmaster
+    - env: TOXENV=postgresql
       addons:
         postgresql: "9.5"
-    - python: 3.7
-      env: TOXENV=mariadb
+    - env: TOXENV=mariadb
       addons:
         mariadb: "10.3"
       script:
@@ -59,6 +60,7 @@ matrix:
   allow_failures:
     - env: TOXENV=py36-djmaster
     - env: TOXENV=py37-djmaster
+    - env: TOXENV=py38-djmaster
 
 install:
   - pip install tox codecov

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+UNRELEASED
+----------
+
+* Added support for Python 3.8.
+
 2.1 (2019-11-12)
 ----------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ envlist =
     py{35,36,37}-dj111
     py{35,36,37}-dj20
     py{35,36,37}-dj21
-    py{35,36,37}-dj22
-    py{36,37}-dj30
-    py{36,37}-djmaster
+    py{35,36,37,38}-dj22
+    py{36,37,38}-dj30
+    py{36,37,38}-djmaster
     postgresql
     mariadb
 
@@ -18,7 +18,7 @@ deps =
     dj20: Django==2.0.*
     dj21: Django==2.1.*
     dj22: Django==2.2.*
-    dj30: Django>=3.0b1,<3.1
+    dj30: Django==3.0.*
     djmaster: https://github.com/django/django/archive/master.tar.gz
     coverage
     Jinja2


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019.

Also:

- Remove 'dist: xenial' from Travis configuration, it is now the
  default.
- Remove Python version from some Travis entires. Travis now defaults to
  Python 3.
- Update Django 3.0 version string. It was released December 2, 2019.