### PR TITLE
Remove end of life Djangos from the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,6 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-dj111
     - python: 3.5
-      env: TOXENV=py35-dj20
-    - python: 3.6
-      env: TOXENV=py36-dj20
-    - python: 3.7
-      env: TOXENV=py37-dj20
-    - python: 3.5
-      env: TOXENV=py35-dj21
-    - python: 3.6
-      env: TOXENV=py36-dj21
-    - python: 3.7
-      env: TOXENV=py37-dj21
-    - python: 3.5
       env: TOXENV=py35-dj22
     - python: 3.6
       env: TOXENV=py36-dj22

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+UNRELEASED
+----------
+
+* Removed support for end of life Django 2.0 and 2.1.
+
 2.1 (2019-11-12)
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ envlist =
     style
     readme
     py{35,36,37}-dj111
-    py{35,36,37}-dj20
-    py{35,36,37}-dj21
     py{35,36,37}-dj22
     py{36,37}-dj30
     py{36,37}-djmaster
@@ -15,8 +13,6 @@ envlist =
 [testenv]
 deps =
     dj111: Django==1.11.*
-    dj20: Django==2.0.*
-    dj21: Django==2.1.*
     dj22: Django==2.2.*
     dj30: Django>=3.0b1,<3.1
     djmaster: https://github.com/django/django/archive/master.tar.gz
@@ -33,7 +29,7 @@ commands = make coverage TEST_ARGS='{posargs:tests}'
 
 [testenv:postgresql]
 deps =
-    Django==2.1.*
+    Django==1.11.*
     coverage
     Jinja2
     html5lib
@@ -49,7 +45,7 @@ commands = make coverage TEST_ARGS='{posargs:tests}'
 
 [testenv:mariadb]
 deps =
-    Django==2.1.*
+    Django==2.2.*
     coverage
     Jinja2
     html5lib


### PR DESCRIPTION
Django 2.0 went end of life April 1, 2019.

Django 2.1 went end of life December 2, 2019.

These version are no longer receiving bug fixes include for security
issues. Their use is not recommended.

By removing these version it will reduce total time to run the full test
matrix, allowing for faster developing.