### PR TITLE
Remove duplicate width="100%" in profiling.html

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -1,5 +1,5 @@
 {% load i18n %}{% load static %}
-<table width="100%">
+<table>
 	<thead>
 		<tr>
 			<th>{% trans "Call" %}</th>


### PR DESCRIPTION
Tables already have a width specified in toolbar.css. Further, width
attribute on the table element has been deprecated so it is better to
use CSS anyway.