### PR TITLE
Remove invalid, unused HTML attribute "depth"

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -12,7 +12,7 @@
 	</thead>
 	<tbody>
 		{% for call in func_list %}
-			<tr class="{% cycle 'djDebugOdd' 'djDebugEven' %} djDebugProfileRow{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" depth="{{ call.depth }}" id="profilingMain_{{ call.id }}">
+			<tr class="{% cycle 'djDebugOdd' 'djDebugEven' %} djDebugProfileRow{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" id="profilingMain_{{ call.id }}">
 				<td>
 					<div data-padding-left="{{ call.indent }}px">
 						{% if call.has_subfuncs %}


### PR DESCRIPTION
"depth" is not an HTML attribute of the `<tr>` element. Further, it is
unused. Introduced in 3929bf2066e108695546e2dd8db14579a8710126.