### PR TITLE
Remove unnecessary coerce to int

### DIFF
--- a/debug_toolbar/panels/redirects.py
+++ b/debug_toolbar/panels/redirects.py
@@ -15,7 +15,7 @@ class RedirectsPanel(Panel):
 
     def process_request(self, request):
         response = super().process_request(request)
-        if 300 <= int(response.status_code) < 400:
+        if 300 <= response.status_code < 400:
             redirect_to = response.get("Location", None)
             if redirect_to:
                 status_line = "{} {}".format(


### PR DESCRIPTION
Since Django commit
https://github.com/django/django/commit/190d2ff4a7a392adfe0b12552bd71871791d87aa
HttpResponse.status_code is always an int.