### PR TITLE
Comment out unused Sphinx 'html_static_path' configuration option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
Fixes Sphinx warning:

    WARNING: html_static_path entry '_static' does not exist