### PR TITLE
Drop redundant type attribute from <script> tags

### DIFF
--- a/example/templates/jquery/index.html
+++ b/example/templates/jquery/index.html
@@ -7,7 +7,7 @@
 	.hide {display:none;}
 	</style>
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-	<script type="text/javascript">
+	<script>
 		$(document).ready(function() {
 			$('p.hide').show();
 			$('#v').text($.fn.jquery);

--- a/example/templates/mootools/index.html
+++ b/example/templates/mootools/index.html
@@ -7,7 +7,7 @@
 	.hide {display:none;}
 	</style>
 	<script src="//ajax.googleapis.com/ajax/libs/mootools/1.6.0/mootools.min.js"></script>
-	<script type="text/javascript">
+	<script>
 		window.addEvent('domready', function() {
 			$$('p.hide').setStyle('display', 'block');
 			$('v').set('text', MooTools.version);

--- a/example/templates/prototype/index.html
+++ b/example/templates/prototype/index.html
@@ -7,7 +7,7 @@
 	.hide {display:none;}
 	</style>
 	<script src="//ajax.googleapis.com/ajax/libs/prototype/1.7.3.0/prototype.js"></script>
-	<script type="text/javascript">
+	<script>
 		document.observe('dom:loaded', function() {
 			$('showme').removeClassName('hide');
 			$('v').textContent = Prototype.Version;


### PR DESCRIPTION
Since HTML5, script tags default to JavaScript when the type attribute
is omitted. The HTML5 specification urges authors to omit the attribute
rather than provide a redundant MIME type.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type