### PR TITLE
Support SQL Select and Explain actions for Postgres JSON fields.

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -8,3 +8,14 @@ class NonAsciiRepr:
 
 class Binary(models.Model):
     field = models.BinaryField()
+
+
+try:
+    from django.contrib.postgres.fields import JSONField
+
+    class PostgresJSON(models.Model):
+        field = JSONField()
+
+
+except ImportError:
+    pass


### PR DESCRIPTION
Closes #1133

I'm not sure of a good way to dynamically import the postgres members. I'm definitely open to other methods.