### PR TITLE
Add LICENSE metadata to Python package distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     url="https://github.com/jazzband/django-debug-toolbar",
     download_url="https://pypi.org/project/django-debug-toolbar/",
     license="BSD",
+    license_files=["LICENSE"],
     packages=find_packages(exclude=("tests.*", "tests", "example")),
     python_requires=">=3.5",
     install_requires=["Django>=1.11", "sqlparse>=0.2.0"],


### PR DESCRIPTION
Currently [pip-licenses](https://github.com/raimon49/pip-licenses) can't include the LICENSE file for this project because the correct metadata is not setup.

This PR sets up the metadata correctly so the LICENSE file is properly included/linked to in source and wheel distributions.