### PR TITLE
Remove unnecessary "type" attribute from <link> elements

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,6 +1,6 @@
 {% load i18n %}{% load static %}
-<link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" type="text/css" media="print">
-<link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}" type="text/css">
+<link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" media="print">
+<link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}">
 <script src="{% static 'debug_toolbar/js/toolbar.js' %}" defer></script>
 <div id="djDebug" class="djdt-hidden" dir="ltr"
      {% if toolbar.store_id %}


### PR DESCRIPTION
Per the MDN docs:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-type

> … given that CSS is the only stylesheet language used on the web, not
> only is it possible to omit the type attribute, but is actually now
> recommended practice.

Follow this recommended practice.