### PR TITLE
Remove use of deprecated request.is_ajax()

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -5,6 +5,7 @@ Debug Toolbar middleware
 import re
 from functools import lru_cache
 
+import django
 from django.conf import settings
 from django.utils.module_loading import import_string
 
@@ -48,7 +49,11 @@ class DebugToolbarMiddleware:
         # Decide whether the toolbar is active for this request. Don't render
         # the toolbar during AJAX requests.
         show_toolbar = get_show_toolbar()
-        if not show_toolbar(request) or request.is_ajax():
+        if not show_toolbar(request) or (
+            request.is_ajax()
+            if django.VERSION < (3, 1)
+            else not request.accepts("text/html")
+        ):
             return self.get_response(request)
 
         toolbar = DebugToolbar(request, self.get_response)


### PR DESCRIPTION
The method was deprecated in upstream commit
https://github.com/django/django/commit/e348ab0d4382b0d7cb0cab9d1261c916c3d0ce6c.

Refs #1032