### PR TITLE
Remove use of deprecated Signal.providing_args

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -20,9 +20,7 @@ from debug_toolbar.utils import (
     tidy_stacktrace,
 )
 
-cache_called = Signal(
-    providing_args=["time_taken", "name", "return_value", "args", "kwargs", "trace"]
-)
+cache_called = Signal()
 
 
 def send_signal(method):

--- a/debug_toolbar/panels/signals.py
+++ b/debug_toolbar/panels/signals.py
@@ -38,7 +38,7 @@ class SignalsPanel(Panel):
 
     def nav_subtitle(self):
         signals = self.get_stats()["signals"]
-        num_receivers = sum(len(s[2]) for s in signals)
+        num_receivers = sum(len(receivers) for name, receivers in signals)
         num_signals = len(signals)
         # here we have to handle a double count translation, hence the
         # hard coding of one signal
@@ -85,6 +85,6 @@ class SignalsPanel(Panel):
                 else:
                     text = receiver_name
                 receivers.append(text)
-            signals.append((name, signal, receivers))
+            signals.append((name, receivers))
 
         self.record_stats({"signals": signals})

--- a/debug_toolbar/templates/debug_toolbar/panels/signals.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/signals.html
@@ -3,15 +3,13 @@
 	<thead>
 		<tr>
 			<th>{% trans "Signal" %}</th>
-			<th>{% trans "Providing" %}</th>
 			<th>{% trans "Receivers" %}</th>
 		</tr>
 	</thead>
 	<tbody>
-		{% for name, signal, receivers in signals %}
+		{% for name, receivers in signals %}
 			<tr>
 				<td>{{ name|escape }}</td>
-				<td>{{ signal.providing_args|join:", " }}</td>
 				<td>{{ receivers|join:", " }}</td>
 			</tr>
 		{% endfor %}


### PR DESCRIPTION
The attribute was deprecated in upstream commit
https://github.com/django/django/commit/769cee525222bb155735aba31d6174d73c271f3c.