### PR TITLE
Enable Python warnings during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ coverage:
 	python --version
 	coverage erase
 	DJANGO_SETTINGS_MODULE=tests.settings \
-		coverage run -m django test -v2 $${TEST_ARGS:-tests}
+		python -b -W always -m coverage run -m django test -v2 $${TEST_ARGS:-tests}
 	coverage report
 	coverage html
 


### PR DESCRIPTION
Helps show deprecation warnings early as well as general programming
edge cases.