### PR TITLE
Remove unnecessary '{% load static %}' template tags

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static %}
+{% load i18n %}
 <table>
 	<thead>
 		<tr>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -1,4 +1,4 @@
-{% load i18n l10n %}{% load static %}
+{% load i18n l10n %}
 <div class="djdt-clearfix">
 	<ul class="djdt-stats">
 		{% for alias, info in databases %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static %}
+{% load i18n %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose" href="">»</a>
 	<h3>{% trans "SQL explained" %}</h3>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static %}
+{% load i18n %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose" href="">»</a>
 	<h3>{% trans "SQL profiled" %}</h3>

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static %}
+{% load i18n %}
 <div class="djDebugPanelTitle">
 	<a class="djDebugClose" href="">»</a>
 	<h3>{% trans "SQL selected" %}</h3>

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load static %}
+{% load i18n %}
 <h4>{% blocktrans count template_dirs|length as template_count %}Template path{% plural %}Template paths{% endblocktrans %}</h4>
 {% if template_dirs %}
 	<ol>


### PR DESCRIPTION
These templates do not use the {% static ... %} template tag.