### PR TITLE
Remove unnecessary guard for empty data-toggle-id value

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -139,9 +139,6 @@
                 var self = this;
                 var id = this.dataset.toggleId;
                 var open_me = this.textContent == this.dataset.toggleOpen;
-                if (id === '' || !id) {
-                    return;
-                }
                 var name = this.dataset.toggleName;
                 var container = this.closest('.djDebugPanelContent').querySelector('#' + name + '_' + id);
                 container.querySelectorAll('.djDebugCollapsed').forEach(function(e) {


### PR DESCRIPTION
data-toggle-id is always defined on djToggleSwitch, so the guard is
unnecessary. The JavaScript can expect correctly constructed HTML.