### PR TITLE
Run eslint during CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 6
+    },
+    "rules": {
+        "curly": ["error", "all"],
+        "dot-notation": "error",
+        "eqeqeq": "error",
+        "no-eval": "error",
+        "semi": "error"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ example/db.sqlite3
 htmlcov
 .tox
 node_modules
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: pip
 matrix:
   fast_finish: true
   include:
+    - env: TOXENV=eslint
     - env: TOXENV=flake8
     - env: TOXENV=style
     - env: TOXENV=readme

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ flake8:
 example:
 	python example/manage.py runserver
 
-jshint: node_modules/jshint/bin/jshint
-	./node_modules/jshint/bin/jshint debug_toolbar/static/debug_toolbar/js/*.js
+eslint: package-lock.json
+	npx eslint --ignore-path .gitignore .
 
-node_modules/jshint/bin/jshint:
-	npm install jshint --prefix .
+package-lock.json: package.json
+	npm install
 
 test:
 	DJANGO_SETTINGS_MODULE=tests.settings \

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -152,8 +152,10 @@
                         e.classList.add('djUnselected');
                         self.textContent = self.dataset.toggleOpen;
                     }
-                    var switch_ = e.querySelector('.djToggleSwitch')
-                    if (switch_) switch_.textContent = self.textContent;
+                    var switch_ = e.querySelector('.djToggleSwitch');
+                    if (switch_) {
+                        switch_.textContent = self.textContent;
+                    }
                 });
             });
 
@@ -267,7 +269,9 @@
         },
         cookie: {
             get: function(key){
-                if (document.cookie.indexOf(key) === -1) return null;
+                if (document.cookie.indexOf(key) === -1) {
+                    return null;
+                }
 
                 var cookieArray = document.cookie.split('; '),
                     cookies = {};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "eslint": "^6.7.2"
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    eslint
     flake8
     style
     readme
@@ -47,9 +48,8 @@ deps =
     isort
 skip_install = true
 
-[testenv:jshint]
-basepython = python3
-commands = make jshint
+[testenv:eslint]
+commands = make eslint
 skip_install = true
 
 [testenv:readme]


### PR DESCRIPTION
ESLint is a tool for linting JavaScript code, with the goal of making
code more consistent and avoiding bugs. In many ways, it is similar to
flake8, but for JavaScript.

This replaces the previous use of JSHint, which was not checked during
CI. ESLint is the more popular choice in the JavaScript community and
offers more rules and features.

https://eslint.org/