### PR TITLE
Fix HTML5 validation warnings and errors in redirect.html

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/redirect.html
+++ b/debug_toolbar/templates/debug_toolbar/redirect.html
@@ -1,7 +1,8 @@
 {% load i18n static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <title>Django Debug Toolbar Redirects Panel: {{ status_line }}</title>
   </head>
   <body>
     <h1>{{ status_line }}</h1>


### PR DESCRIPTION
Using the W3C validator at https://validator.w3.org/, fixes the warnings
and errors:

    Warning: Consider adding a lang attribute to the html start tag to
    declare the language of this document.

    Error: Element head is missing a required instance of child element
    title.