### PR TITLE
Cleanup/simplify .get(…, None) pattern

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -19,10 +19,7 @@ def show_toolbar(request):
     """
     Default function to determine whether to show the toolbar on a given page.
     """
-    return (
-        settings.DEBUG
-        and request.META.get("REMOTE_ADDR", None) in settings.INTERNAL_IPS
-    )
+    return settings.DEBUG and request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS
 
 
 @lru_cache()
@@ -99,7 +96,7 @@ class DebugToolbarMiddleware:
 
             bits[-2] += toolbar.render_toolbar()
             response.content = insert_before.join(bits)
-            if response.get("Content-Length", None):
+            if "Content-Length" in response:
                 response["Content-Length"] = len(response.content)
         return response
 

--- a/debug_toolbar/panels/redirects.py
+++ b/debug_toolbar/panels/redirects.py
@@ -16,7 +16,7 @@ class RedirectsPanel(Panel):
     def process_request(self, request):
         response = super().process_request(request)
         if 300 <= response.status_code < 400:
-            redirect_to = response.get("Location", None)
+            redirect_to = response.get("Location")
             if redirect_to:
                 status_line = "{} {}".format(
                     response.status_code, response.reason_phrase

--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -32,8 +32,7 @@ class SQLSelectForm(forms.Form):
     hash = forms.CharField()
 
     def __init__(self, *args, **kwargs):
-        initial = kwargs.get("initial", None)
-
+        initial = kwargs.get("initial")
         if initial is not None:
             initial["hash"] = self.make_hash(initial)
 

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -176,7 +176,7 @@ class TemplatesPanel(Panel):
         for template_data in self.templates:
             info = {}
             # Clean up some info about templates
-            template = template_data.get("template", None)
+            template = template_data["template"]
             if hasattr(template, "origin") and template.origin and template.origin.name:
                 template.origin_name = template.origin.name
                 template.origin_hash = signing.dumps(template.origin.name)

--- a/debug_toolbar/panels/templates/views.py
+++ b/debug_toolbar/panels/templates/views.py
@@ -14,7 +14,7 @@ def template_source(request):
     Return the source of a template, syntax-highlighted by Pygments if
     it's available.
     """
-    template_origin_name = request.GET.get("template_origin", None)
+    template_origin_name = request.GET.get("template_origin")
     if template_origin_name is None:
         return HttpResponseBadRequest('"template_origin" key is required')
     try:


### PR DESCRIPTION
- `.get()` defaults to returning None for missing keys, it does not need
  to be re-specified.
- For checking if a key exists, use the `in` operator instead.
- If the key is known to always exist, use direct indexing instead.