### PR TITLE
Remove support for end-of-life Django 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ matrix:
     - env: TOXENV=style
     - env: TOXENV=readme
     - python: 3.5
-      env: TOXENV=py35-dj111-sqlite
-    - python: 3.6
-      env: TOXENV=py36-dj111-sqlite
-    - python: 3.7
-      env: TOXENV=py37-dj111-sqlite
-    - python: 3.5
       env: TOXENV=py35-dj22-sqlite
     - python: 3.6
       env: TOXENV=py36-dj22-sqlite
@@ -33,10 +27,6 @@ matrix:
       env: TOXENV=py37-djmaster-sqlite
     - python: 3.8
       env: TOXENV=py38-djmaster-sqlite
-    - python: 3.7
-      env: TOXENV=py37-dj111-postgresql
-      addons:
-        postgresql: "9.5"
     - python: 3.8
       env: TOXENV=py38-dj22-postgresql
       addons:
@@ -45,17 +35,6 @@ matrix:
       env: TOXENV=py38-dj30-postgresql
       addons:
         postgresql: "9.5"
-    - python: 3.7
-      env: TOXENV=py37-dj111-mariadb
-      addons:
-        mariadb: "10.3"
-      script:
-        # working around https://travis-ci.community/t/mariadb-build-error-with-xenial/3160
-        - mysql -u root -e "DROP USER IF EXISTS 'travis'@'%';"
-        - mysql -u root -e "CREATE USER 'travis'@'%';"
-        - mysql -u root -e "CREATE DATABASE debug_toolbar;"
-        - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%';";
-        - tox -v
     - python: 3.8
       env: TOXENV=py38-dj22-mariadb
       addons:

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ In addition to the built-in panels, a number of third-party panels are
 contributed by the community.
 
 The current stable version of the Debug Toolbar is 2.2. It works on
-Django ≥ 1.11.
+Django ≥ 2.2.
 
 Documentation, including installation and configuration instructions, is
 available at https://django-debug-toolbar.readthedocs.io/.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,11 @@ UNRELEASED
 * Added support for Django 3.1a1.
 * Pruned unused CSS and removed hacks for ancient browsers.
 
+**Backwards incompatible changes**
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Removed support for end of life Django 1.11. The minimum supported Django is
+  now 2.2.
 
 2.2 (2020-01-31)
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,13 @@ setup(
     license_files=["LICENSE"],
     packages=find_packages(exclude=("tests.*", "tests", "example")),
     python_requires=">=3.5",
-    install_requires=["Django>=1.11", "sqlparse>=0.2.0"],
+    install_requires=["Django>=2.2", "sqlparse>=0.2.0"],
     include_package_data=True,
     zip_safe=False,  # because we're including static files
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,13 @@ envlist =
     flake8
     style
     readme
-    py{35,36,37}-dj111-sqlite
     py{35,36,37,38}-dj22-sqlite
     py{36,37,38}-dj30-sqlite
     py{36,37,38}-djmaster-sqlite
-    py37-dj111-{postgresql,mariadb}
     py{37,38}-dj{22,30}-{postgresql,mariadb}
 
 [testenv]
 deps =
-    dj111: Django==1.11.*
     dj22: Django==2.2.*
     dj30: Django==3.0.*
     sqlite: mock


### PR DESCRIPTION
Django 1.11 went end of life on April 1, 2020. It is no longer receiving
bug fixes, including for security issues.

Removing support will reduce testing resources and avoid the need for
future contributions to consider compatibility with unmaintained
versions of Django.

For a complete list of supported Django versions, see:
https://www.djangoproject.com/download/#supported-versions