### PR TITLE
Bump black target Python version to 3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 style:
 	isort -rc debug_toolbar example tests
-	black --target-version=py34 debug_toolbar example tests setup.py
+	black --target-version=py35 debug_toolbar example tests setup.py
 	flake8 debug_toolbar example tests
 
 style_check:

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ skip_install = true
 basepython = python3
 commands = make style_check
 deps =
-    black
+    black>=19.10b0
     flake8
     isort
 skip_install = true


### PR DESCRIPTION
django-debug-toolbar's minimum supported Python is 3.5. Match this
target in the black command invocation.

This was previously using Python 3.4 to workaround an upstream bug in
black (see 58f374a426a6b10dcf86554f6d9c71226b4b350f), but this has been
fixed in version 19.10b0.