### PR TITLE
Remove undocumented djdt.init() from the exported namespace

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -296,7 +296,6 @@
     window.djdt = {
         show_toolbar: djdt.show_toolbar,
         hide_toolbar: djdt.hide_toolbar,
-        init: djdt.init,
         close: djdt.hide_one_level,
         cookie: djdt.cookie,
     };


### PR DESCRIPTION
The function is not documented and there is no reason a third party
panel would need to call init() a 2nd time.