### PR TITLE
Remove outdated tag_svn_revision from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[egg_info]
-tag_svn_revision = false
-
 [flake8]
 exclude = .tox,venv,conf.py
 ignore = E203,W503,W601


### PR DESCRIPTION
The project no longer uses SVN nor are eggs distributed (wheels are
instead).

This option was originally added in
302bb340c2abd4d666355752c15c1ca07f750275 (2008-12-09).