### PR TITLE
Avoid duplicate rendering of templates in tests

### DIFF
--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -34,8 +34,9 @@ class CachePanelTestCase(BaseTestCase):
         self.assertNotIn("café", self.panel.content)
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
-        self.assertIn("café", self.panel.content)
-        self.assertValidHTML(self.panel.content)
+        content = self.panel.content
+        self.assertIn("café", content)
+        self.assertValidHTML(content)
 
     def test_generate_server_timing(self):
         self.assertEqual(len(self.panel.calls), 0)

--- a/tests/panels/test_logging.py
+++ b/tests/panels/test_logging.py
@@ -63,8 +63,9 @@ class LoggingPanelTestCase(BaseTestCase):
         self.assertNotIn("café", self.panel.content)
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
-        self.assertIn("café", self.panel.content)
-        self.assertValidHTML(self.panel.content)
+        content = self.panel.content
+        self.assertIn("café", content)
+        self.assertValidHTML(content)
 
     def test_failing_formatting(self):
         class BadClass:

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -32,19 +32,17 @@ class ProfilingPanelTestCase(BaseTestCase):
         self.assertNotIn("regular_view", self.panel.content)
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
-        self.assertIn("regular_view", self.panel.content)
-        self.assertValidHTML(self.panel.content)
+        content = self.panel.content
+        self.assertIn("regular_view", content)
+        self.assertValidHTML(content)
 
     def test_listcomp_escaped(self):
         self._get_response = lambda request: listcomp_view(request)
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
-        self.assertNotIn(
-            '<span class="djdt-func"><listcomp></span>', self.panel.content
-        )
-        self.assertIn(
-            '<span class="djdt-func">&lt;listcomp&gt;</span>', self.panel.content
-        )
+        content = self.panel.content
+        self.assertNotIn('<span class="djdt-func"><listcomp></span>', content)
+        self.assertIn('<span class="djdt-func">&lt;listcomp&gt;</span>', content)
 
     def test_generate_stats_no_profiler(self):
         """

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -8,8 +8,7 @@ class RequestPanelTestCase(BaseTestCase):
         self.request.session = {"où": "où"}
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
-        content = self.panel.content
-        self.assertIn("où", content)
+        self.assertIn("où", self.panel.content)
 
     def test_object_with_non_ascii_repr_in_request_params(self):
         self.request.path = "/non_ascii_request/"
@@ -28,5 +27,6 @@ class RequestPanelTestCase(BaseTestCase):
         self.assertNotIn("nôt åscíì", self.panel.content)
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
-        self.assertIn("nôt åscíì", self.panel.content)
-        self.assertValidHTML(self.panel.content)
+        content = self.panel.content
+        self.assertIn("nôt åscíì", content)
+        self.assertValidHTML(content)

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -242,8 +242,9 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertNotIn("café", self.panel.content)
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
-        self.assertIn("café", self.panel.content)
-        self.assertValidHTML(self.panel.content)
+        content = self.panel.content
+        self.assertIn("café", content)
+        self.assertValidHTML(content)
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"ENABLE_STACKTRACES_LOCALS": True})
     def test_insert_locals(self):
@@ -256,9 +257,10 @@ class SQLPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, response)
         self.assertIn("local_var", self.panel.content)
         # Verify the escape logic works
-        self.assertNotIn("<script>alert", self.panel.content)
-        self.assertIn("&lt;script&gt;alert", self.panel.content)
-        self.assertIn("djdt-locals", self.panel.content)
+        content = self.panel.content
+        self.assertNotIn("<script>alert", content)
+        self.assertIn("&lt;script&gt;alert", content)
+        self.assertIn("djdt-locals", content)
 
     def test_not_insert_locals(self):
         """

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -9,13 +9,12 @@ class StaticFilesPanelTestCase(BaseTestCase):
     def test_default_case(self):
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
+        content = self.panel.content
         self.assertIn(
-            "django.contrib.staticfiles.finders." "AppDirectoriesFinder",
-            self.panel.content,
+            "django.contrib.staticfiles.finders." "AppDirectoriesFinder", content
         )
         self.assertIn(
-            "django.contrib.staticfiles.finders." "FileSystemFinder (2 files)",
-            self.panel.content,
+            "django.contrib.staticfiles.finders." "FileSystemFinder (2 files)", content
         )
         self.assertEqual(self.panel.num_used, 0)
         self.assertNotEqual(self.panel.num_found, 0)
@@ -39,8 +38,8 @@ class StaticFilesPanelTestCase(BaseTestCase):
         )
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
+        content = self.panel.content
         self.assertIn(
-            "django.contrib.staticfiles.finders." "AppDirectoriesFinder",
-            self.panel.content,
+            "django.contrib.staticfiles.finders." "AppDirectoriesFinder", content
         )
-        self.assertValidHTML(self.panel.content)
+        self.assertValidHTML(content)

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -74,8 +74,9 @@ class TemplatesPanelTestCase(BaseTestCase):
         self.assertNotIn("nôt åscíì", self.panel.content)
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
-        self.assertIn("nôt åscíì", self.panel.content)
-        self.assertValidHTML(self.panel.content)
+        content = self.panel.content
+        self.assertIn("nôt åscíì", content)
+        self.assertValidHTML(content)
 
     def test_custom_context_processor(self):
         response = self.panel.process_request(self.request)


### PR DESCRIPTION
Panel.content is a property. When accessed it renders a template. In
tests, store the rendered value in an intermediate variable when the
property is accessed on multiple lines in a row without the result
changing. This saves a small amount of duplicate processing in tests.