### PR TITLE
Remove deps from eslint tox target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ skip_install = true
 
 [testenv:eslint]
 commands = make eslint
+deps =
 skip_install = true
 
 [testenv:readme]


### PR DESCRIPTION
By default, the eslint inherits deps from the base target. Set to an
empty list to avoid install unnecessary packages to run eslint.