### PR TITLE
Move setup information to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,47 @@
+[metadata]
+name = django-debug-toolbar
+version = 2.2
+description = A configurable set of panels that display various debug information about the current request/response.
+long_description = file: README.rst
+author = Rob Hudson
+author_email = rob@cogit8.org
+url = https://github.com/jazzband/django-debug-toolbar
+download_url = https://pypi.org/project/django-debug-toolbar/
+license = BSD
+license_files = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Web Environment
+    Framework :: Django
+    Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[options]
+python_requires = >=3.5
+install_requires =
+    Django >= 2.2
+    sqlparse >= 0.2.0
+packages = find:
+include_package_data = true
+zip_safe = false
+
+[options.packages.find]
+exclude =
+    example
+    tests
+    tests.*
+
 [flake8]
 exclude = .tox,venv,conf.py
 ignore = E203,W503,W601

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,5 @@
 #!/usr/bin/env python3
 
-from io import open
+from setuptools import setup
 
-from setuptools import find_packages, setup
-
-
-def readall(path):
-    with open(path, encoding="utf-8") as fp:
-        return fp.read()
-
-
-setup(
-    name="django-debug-toolbar",
-    version="2.2",
-    description="A configurable set of panels that display various debug "
-    "information about the current request/response.",
-    long_description=readall("README.rst"),
-    author="Rob Hudson",
-    author_email="rob@cogit8.org",
-    url="https://github.com/jazzband/django-debug-toolbar",
-    download_url="https://pypi.org/project/django-debug-toolbar/",
-    license="BSD",
-    license_files=["LICENSE"],
-    packages=find_packages(exclude=("tests.*", "tests", "example")),
-    python_requires=">=3.5",
-    install_requires=["Django>=2.2", "sqlparse>=0.2.0"],
-    include_package_data=True,
-    zip_safe=False,  # because we're including static files
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Web Environment",
-        "Framework :: Django",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-)
+setup()


### PR DESCRIPTION
Use a declarative syntax to avoid mixing code and configuration.
Simplifies handling of long description file by reducing some
boilerplate.

For details on this setuptools feature, see:
https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files

Django also uses supet.cfg, see commit:
https://github.com/django/django/commit/85efc14a2edac532df1a9ad4dd9b6d4a4dcf583e