### PR TITLE
Replace deprecated django.conf.urls.url() with path() and re_path()

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from copy import copy
 from pprint import saferepr
 
-from django.conf.urls import url
 from django.db import connections
+from django.urls import path
 from django.utils.translation import gettext_lazy as _, ngettext_lazy as __
 
 from debug_toolbar.panels import Panel
@@ -128,9 +128,9 @@ class SQLPanel(Panel):
     @classmethod
     def get_urls(cls):
         return [
-            url(r"^sql_select/$", views.sql_select, name="sql_select"),
-            url(r"^sql_explain/$", views.sql_explain, name="sql_explain"),
-            url(r"^sql_profile/$", views.sql_profile, name="sql_profile"),
+            path("sql_select/", views.sql_select, name="sql_select"),
+            path("sql_explain/", views.sql_explain, name="sql_explain"),
+            path("sql_profile/", views.sql_profile, name="sql_profile"),
         ]
 
     def enable_instrumentation(self):

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -4,12 +4,12 @@ from os.path import normpath
 from pprint import pformat, saferepr
 
 from django import http
-from django.conf.urls import url
 from django.core import signing
 from django.db.models.query import QuerySet, RawQuerySet
 from django.template import RequestContext, Template
 from django.test.signals import template_rendered
 from django.test.utils import instrumented_test_render
+from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
 from debug_toolbar.panels import Panel
@@ -161,9 +161,7 @@ class TemplatesPanel(Panel):
 
     @classmethod
     def get_urls(cls):
-        return [
-            url(r"^template_source/$", views.template_source, name="template_source")
-        ]
+        return [path("template_source/", views.template_source, name="template_source")]
 
     def enable_instrumentation(self):
         template_rendered.connect(self._store_template_info)

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -6,10 +6,10 @@ import uuid
 from collections import OrderedDict
 
 from django.apps import apps
-from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
+from django.urls import path
 from django.utils.module_loading import import_string
 
 from debug_toolbar import settings as dt_settings
@@ -128,7 +128,7 @@ class DebugToolbar:
             # Load URLs in a temporary variable for thread safety.
             # Global URLs
             urlpatterns = [
-                url(r"^render_panel/$", views.render_panel, name="render_panel")
+                path("render_panel/", views.render_panel, name="render_panel")
             ]
             # Per-panel URLs
             for panel_class in cls.get_panel_classes():

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,17 +46,12 @@ Setting up URLconf
 Add the Debug Toolbar's URLs to your project's URLconf as follows::
 
     from django.conf import settings
-    from django.conf.urls import include, url  # For django versions before 2.0
-    from django.urls import include, path  # For django versions from 2.0 and up
+    from django.urls import include, path
 
     if settings.DEBUG:
         import debug_toolbar
         urlpatterns = [
             path('__debug__/', include(debug_toolbar.urls)),
-
-            # For django versions before 2.0:
-            # url(r'^__debug__/', include(debug_toolbar.urls)),
-
         ] + urlpatterns
 
 This example uses the ``__debug__`` prefix, but you can use any prefix that

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,17 +1,17 @@
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path
 from django.views.generic import TemplateView
 
 urlpatterns = [
-    url(r"^$", TemplateView.as_view(template_name="index.html")),
-    url(r"^jquery/$", TemplateView.as_view(template_name="jquery/index.html")),
-    url(r"^mootools/$", TemplateView.as_view(template_name="mootools/index.html")),
-    url(r"^prototype/$", TemplateView.as_view(template_name="prototype/index.html")),
-    url(r"^admin/", admin.site.urls),
+    path("", TemplateView.as_view(template_name="index.html")),
+    path("jquery/", TemplateView.as_view(template_name="jquery/index.html")),
+    path("mootools/", TemplateView.as_view(template_name="mootools/index.html")),
+    path("prototype/", TemplateView.as_view(template_name="prototype/index.html")),
+    path("admin/", admin.site.urls),
 ]
 
 if settings.DEBUG:
     import debug_toolbar
 
-    urlpatterns += [url(r"^__debug__/", include(debug_toolbar.urls))]
+    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 
 import debug_toolbar
 
@@ -6,16 +6,18 @@ from . import views
 from .models import NonAsciiRepr
 
 urlpatterns = [
-    url(r"^resolving1/(.+)/(.+)/$", views.resolving_view, name="positional-resolving"),
-    url(r"^resolving2/(?P<arg1>.+)/(?P<arg2>.+)/$", views.resolving_view),
-    url(r"^resolving3/(.+)/$", views.resolving_view, {"arg2": "default"}),
-    url(r"^regular/(?P<title>.*)/$", views.regular_view),
-    url(r"^template_response/(?P<title>.*)/$", views.template_response_view),
-    url(r"^regular_jinja/(?P<title>.*)/$", views.regular_jinjia_view),
-    url(r"^non_ascii_request/$", views.regular_view, {"title": NonAsciiRepr()}),
-    url(r"^new_user/$", views.new_user),
-    url(r"^execute_sql/$", views.execute_sql),
-    url(r"^cached_view/$", views.cached_view),
-    url(r"^redirect/$", views.redirect_view),
-    url(r"^__debug__/", include(debug_toolbar.urls)),
+    re_path(
+        r"^resolving1/(.+)/(.+)/$", views.resolving_view, name="positional-resolving"
+    ),
+    re_path(r"^resolving2/(?P<arg1>.+)/(?P<arg2>.+)/$", views.resolving_view),
+    re_path(r"^resolving3/(.+)/$", views.resolving_view, {"arg2": "default"}),
+    re_path(r"^regular/(?P<title>.*)/$", views.regular_view),
+    re_path(r"^template_response/(?P<title>.*)/$", views.template_response_view),
+    re_path(r"^regular_jinja/(?P<title>.*)/$", views.regular_jinjia_view),
+    path("non_ascii_request/", views.regular_view, {"title": NonAsciiRepr()}),
+    path("new_user/", views.new_user),
+    path("execute_sql/", views.execute_sql),
+    path("cached_view/", views.cached_view),
+    path("redirect/", views.redirect_view),
+    path("__debug__/", include(debug_toolbar.urls)),
 ]


### PR DESCRIPTION
django.urls.path() and re_path() have been available since Django 2.0.

django.conf.urls.url() is deprecated in Django 3.1. When testing against
Django 3.1, fixes warning of the form:

    RemovedInDjango40Warning: django.conf.urls.url() is deprecated in
    favor of django.urls.re_path().