### PR TITLE
Add cache's missing touch method

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -84,6 +84,10 @@ class CacheStatTracker(BaseCache):
         return self.cache.set(*args, **kwargs)
 
     @send_signal
+    def touch(self, *args, **kwargs):
+        return self.cache.touch(*args, **kwargs)
+
+    @send_signal
     def delete(self, *args, **kwargs):
         return self.cache.delete(*args, **kwargs)
 
@@ -153,6 +157,7 @@ class CachePanel(Panel):
                 ("add", 0),
                 ("get", 0),
                 ("set", 0),
+                ("touch", 0),
                 ("delete", 0),
                 ("clear", 0),
                 ("get_many", 0),

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -11,9 +11,12 @@ class CachePanelTestCase(BaseTestCase):
         cache.cache.set("foo", "bar")
         cache.cache.get("foo")
         cache.cache.delete("foo")
+        self.assertFalse(cache.cache.touch("foo"))
+        cache.cache.set("foo", "bar")
+        self.assertTrue(cache.cache.touch("foo"))
         # Verify that the cache has a valid clear method.
         cache.cache.clear()
-        self.assertEqual(len(self.panel.calls), 4)
+        self.assertEqual(len(self.panel.calls), 7)
 
     def test_recording_caches(self):
         self.assertEqual(len(self.panel.calls), 0)


### PR DESCRIPTION
Add cache's missing touch method to prevent "NotImplemented" error of base class