### PR TITLE
Explicitly set the 'box-sizing' property of the .djDebugClose to 'content-box'.

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -316,6 +316,7 @@
     font-weight: 900;
     font-size: 20px;
     text-decoration: none;
+    box-sizing: content-box;
 }
 
 #djDebug .djdt-panelContent .djDebugClose:hover {


### PR DESCRIPTION
It is common for some CSS and reset frameworks[1] to use set the 'box-sizing' to 'border-box' to all elements on the page. This causes the close button inside each panel to show up in the wrong way [2].

This set the 'box-sizing' attribute of the .djDebugClose class to always be  'content-box' [3].

[1] <img width="250" alt="Screen Shot 2020-08-10 at 16 12 11" src="https://user-images.githubusercontent.com/16993/89792950-86334000-db25-11ea-93b3-26dac85a6bb7.png">

[2] <img width="250" alt="Screen Shot 2020-08-10 at 16 11 52" src="https://user-images.githubusercontent.com/16993/89792971-8d5a4e00-db25-11ea-84d9-65f4034e04e6.png">

[3]  <img width="80" alt="Screen Shot 2020-08-10 at 16 22 00" src="https://user-images.githubusercontent.com/16993/89793046-a82cc280-db25-11ea-922e-f47c808dd556.png">


