### PR TITLE
 Simplify isort config using 'profile = black'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: flake8 example test coverage translatable_strings update_translations
 
 style:
-	isort debug_toolbar example tests
+	isort .
 	black --target-version=py35 debug_toolbar example tests setup.py
 	flake8 debug_toolbar example tests
 
 style_check:
-	isort -c debug_toolbar example tests
+	isort -c .
 	black --target-version=py34 --check debug_toolbar example tests setup.py
 
 flake8:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,8 @@
 # serve to show the default.
 
 import datetime
-import sys
 import os
+import sys
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'example.settings'
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,4 @@ max-line-length = 88
 
 [isort]
 combine_as_imports = true
-default_section = THIRDPARTY
-include_trailing_comma = true
-known_first_party = debug_toolbar
-multi_line_output = 3
-line_length = 88
+profile = black

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands = make style_check
 deps =
     black>=19.10b0
     flake8
-    isort>=5
+    isort>=5.0.2
 skip_install = true
 
 [testenv:eslint]


### PR DESCRIPTION
isort now has builtin support for black through its "profiles" feature.

https://timothycrosley.github.io/isort/docs/configuration/profiles/#black