### PR TITLE
Replaced a link to Line Profiler Third-party panel.

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -172,7 +172,7 @@ to.
 Line Profiler
 ~~~~~~~~~~~~~
 
-URL: https://github.com/dmclain/django-debug-toolbar-line-profiler
+URL: https://github.com/mikekeda/django-debug-toolbar-line-profiler
 
 Path: ``debug_toolbar_line_profiler.panel.ProfilingPanel``
 


### PR DESCRIPTION
https://github.com/dmclain/django-debug-toolbar-line-profiler is abandoned (last commit was 5years ago)
It doesn't work with django 3 and django-debug-toolbar 2
Changes - https://github.com/dmclain/django-debug-toolbar-line-profiler/pull/21/files

This fork works with Django 3.1 and django-debug-toolbar 2.2
