### PR TITLE
Replace `is_ajax` with `accepts`

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -77,11 +77,11 @@ class DebugToolbarMiddleware:
                 getattr(response, "streaming", False),
                 "gzip" in content_encoding,
                 content_type not in _HTML_TYPES,
-                request.is_ajax(),
+                not request.accepts("text/html"),
             )
         ):
             # If a AJAX or JSON request, render the toolbar for the history.
-            if request.is_ajax() or content_type == "application/json":
+            if not request.accepts("text/html") or content_type == "application/json":
                 toolbar.render_toolbar()
             return response
 


### PR DESCRIPTION
`django.http.request.HttpRequest.is_ajax` is deprecated. The documentation for version 3 indicated that instead of calling `is_ajax`, the code should check if the `text/html` MIME type is acceptable based on the request's `Accept` header.