### PR TITLE
Log a warning when django static files settings are misconfigured.

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -74,7 +74,18 @@ def check_middleware(app_configs, **kwargs):
                 id="debug_toolbar.W003",
             )
         )
+    return errors
 
+
+@register
+def check_panel_configs(app_configs, **kwargs):
+    """Allow each panel to check the toolbar's integration for their its own purposes."""
+    from debug_toolbar.toolbar import DebugToolbar
+
+    errors = []
+    for panel_class in DebugToolbar.get_panel_classes():
+        for check_message in panel_class.run_checks():
+            errors.append(check_message)
     return errors
 
 

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -211,3 +211,15 @@ class Panel:
 
         Does not return a value.
         """
+
+    @classmethod
+    def run_checks(cls):
+        """
+        Check that the integration is configured correctly for the panel.
+
+        This will be called as a part of the Django checks system when the
+        application is being setup.
+
+        Return a list of :class: `django.core.checks.CheckMessage` instances.
+        """
+        return []

--- a/debug_toolbar/panels/history/panel.py
+++ b/debug_toolbar/panels/history/panel.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import sys
 from collections import OrderedDict
 
@@ -13,8 +12,6 @@ from django.utils.translation import gettext_lazy as _
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.history import views
 from debug_toolbar.panels.history.forms import HistoryStoreForm
-
-logger = logging.getLogger(__name__)
 
 
 class HistoryPanel(Panel):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,10 @@ Change log
 * Started running Selenium tests on Travis CI.
 * Added a system check which prevents using django-debug-toolbar without
   any enabled panels.
+* Added  :func:`Panel.run_checks <debug_toolbar.panels.Panel.run_checks>`
+  for panels to verify the configuration before the application starts.
+* Validate the static file paths specified in ``STATICFILES_DIRS``
+  exist via :class:`StaticFilesPanel <debug_toolbar.panels.staticfiles.StaticFilesPanel>`
 
 
 3.1 (2020-09-21)

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -352,6 +352,8 @@ unauthorized access. There is no public CSS API at this time.
 
     .. automethod:: debug_toolbar.panels.Panel.generate_stats
 
+    .. automethod:: debug_toolbar.panels.Panel.run_checks
+
 .. _javascript-api:
 
 JavaScript API

--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -1,6 +1,16 @@
+import os
+
+from django.conf import settings
 from django.contrib.staticfiles import finders
+from django.core.checks import Warning
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from debug_toolbar.panels.staticfiles import StaticFilesPanel
 
 from ..base import BaseTestCase
+
+PATH_DOES_NOT_EXIST = os.path.join(settings.BASE_DIR, "tests", "invalid_static")
 
 
 class StaticFilesPanelTestCase(BaseTestCase):
@@ -11,10 +21,10 @@ class StaticFilesPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, response)
         content = self.panel.content
         self.assertIn(
-            "django.contrib.staticfiles.finders." "AppDirectoriesFinder", content
+            "django.contrib.staticfiles.finders.AppDirectoriesFinder", content
         )
         self.assertIn(
-            "django.contrib.staticfiles.finders." "FileSystemFinder (2 files)", content
+            "django.contrib.staticfiles.finders.FileSystemFinder (2 files)", content
         )
         self.assertEqual(self.panel.num_used, 0)
         self.assertNotEqual(self.panel.num_found, 0)
@@ -33,13 +43,58 @@ class StaticFilesPanelTestCase(BaseTestCase):
         response = self.panel.process_request(self.request)
         # ensure the panel does not have content yet.
         self.assertNotIn(
-            "django.contrib.staticfiles.finders." "AppDirectoriesFinder",
+            "django.contrib.staticfiles.finders.AppDirectoriesFinder",
             self.panel.content,
         )
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders correctly.
         content = self.panel.content
         self.assertIn(
-            "django.contrib.staticfiles.finders." "AppDirectoriesFinder", content
+            "django.contrib.staticfiles.finders.AppDirectoriesFinder", content
         )
         self.assertValidHTML(content)
+
+    @override_settings(
+        STATICFILES_DIRS=[PATH_DOES_NOT_EXIST] + settings.STATICFILES_DIRS,
+        STATIC_ROOT=PATH_DOES_NOT_EXIST,
+    )
+    def test_finder_directory_does_not_exist(self):
+        """Misconfigure the static files settings and verify the toolbar runs.
+
+        The test case is that the STATIC_ROOT is in STATICFILES_DIRS and that
+        the directory of STATIC_ROOT does not exist.
+        """
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        content = self.panel.content
+        self.assertIn(
+            "django.contrib.staticfiles.finders.AppDirectoriesFinder", content
+        )
+        self.assertNotIn(
+            "django.contrib.staticfiles.finders.FileSystemFinder (2 files)", content
+        )
+        self.assertEqual(self.panel.num_used, 0)
+        self.assertNotEqual(self.panel.num_found, 0)
+        self.assertEqual(
+            self.panel.get_staticfiles_apps(), ["django.contrib.admin", "debug_toolbar"]
+        )
+        self.assertEqual(
+            self.panel.get_staticfiles_dirs(), finders.FileSystemFinder().locations
+        )
+
+
+@override_settings(DEBUG=True)
+class StaticFilesPanelChecksTestCase(SimpleTestCase):
+    @override_settings(STATICFILES_DIRS=[PATH_DOES_NOT_EXIST])
+    def test_run_checks(self):
+        messages = StaticFilesPanel.run_checks()
+        self.assertEqual(
+            messages,
+            [
+                Warning(
+                    "debug_toolbar requires the STATICFILES_DIRS directories to exist.",
+                    hint="Running manage.py collectstatic may help uncover the issue.",
+                    id="debug_toolbar.staticfiles.W001",
+                )
+            ],
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,6 +3,7 @@ import re
 import unittest
 
 import html5lib
+from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core import signing
 from django.core.checks import Warning, run_checks
@@ -27,6 +28,7 @@ except ImportError:
     webdriver = None
 
 
+PATH_DOES_NOT_EXIST = os.path.join(settings.BASE_DIR, "tests", "invalid_static")
 rf = RequestFactory()
 
 
@@ -522,4 +524,20 @@ class DebugToolbarSystemChecksTestCase(SimpleTestCase):
                 id="debug_toolbar.W004",
             ),
             messages,
+        )
+
+    @override_settings(
+        STATICFILES_DIRS=[PATH_DOES_NOT_EXIST],
+    )
+    def test_panel_check_errors(self):
+        messages = run_checks()
+        self.assertEqual(
+            messages,
+            [
+                Warning(
+                    "debug_toolbar requires the STATICFILES_DIRS directories to exist.",
+                    hint="Running manage.py collectstatic may help uncover the issue.",
+                    id="debug_toolbar.staticfiles.W001",
+                )
+            ],
         )


### PR DESCRIPTION
If the django static files are misconfigured in some way or a
directory doesn't exist, the toolbar should still run, but
attempt to alert the user to the issue.

Fixes #1318