### PR TITLE
Remove 'font-variant: small-caps' CSS property

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -141,7 +141,6 @@
     color: #999;
     font-style: normal;
     text-decoration: none;
-    font-variant: small-caps;
 }
 
 #djDebug #djDebugToolbarHandle {


### PR DESCRIPTION
The capitalization of text is misleading. For example, the URL `/LOGIN/` and
`/login/` are different and should be read differently. Another example, the
view `LOGINVIEW` and LoginView` are different.

For the most accurate display of the information, drop the small-caps property.