### PR TITLE
Rename postgresql_psycopg2 backend to postgresql in example

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -78,7 +78,7 @@ if os.environ.get("DJANGO_DATABASE_ENGINE", "").lower() == "postgresql":
     # % createdb debug_toolbar -O debug_toolbar
     DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "ENGINE": "django.db.backends.postgresql",
             "NAME": "debug_toolbar",
             "USER": "debug_toolbar",
         }


### PR DESCRIPTION
Django renamed this backup in upstream commit:
https://github.com/django/django/commit/ec9004728ee136e3b7e2b7cd2610203e16b6ce9b

Released as part of Django 1.9.