### PR TITLE
Remove support for HTML in panel titles

### DIFF
--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -24,7 +24,7 @@ class SettingsPanel(Panel):
     nav_title = _("Settings")
 
     def title(self):
-        return _("Settings from <code>%s</code>") % settings.SETTINGS_MODULE
+        return _("Settings from %s") % settings.SETTINGS_MODULE
 
     def generate_stats(self, request, response):
         self.record_stats(

--- a/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
+++ b/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
@@ -4,7 +4,7 @@
   <div id="{{ panel.panel_id }}" class="djdt-panelContent">
     <div class="djDebugPanelTitle">
       <a href="" class="djDebugClose">×</a>
-      <h3>{{ panel.title|safe }}</h3>
+      <h3>{{ panel.title }}</h3>
     </div>
     <div class="djDebugPanelContent">
       {% if toolbar.store_id %}
@@ -16,4 +16,3 @@
     </div>
   </div>
 {% endif %}
-

--- a/tests/panels/test_custom.py
+++ b/tests/panels/test_custom.py
@@ -1,0 +1,46 @@
+from django.test import override_settings
+
+from debug_toolbar.panels import Panel
+
+from ..base import IntegrationTestCase
+
+
+class CustomPanel(Panel):
+    def title(self):
+        return "Title with special chars &\"'<>"
+
+
+@override_settings(
+    DEBUG=True, DEBUG_TOOLBAR_PANELS=["tests.panels.test_custom.CustomPanel"]
+)
+class CustomPanelTestCase(IntegrationTestCase):
+    def test_escapes_panel_title(self):
+        response = self.client.get("/regular/basic/")
+        self.assertContains(
+            response,
+            """
+            <li class="djDebugPanelButton djdt-CustomPanel">
+            <input type="checkbox" checked title="Disable for next and successive requests" data-cookie="djdtCustomPanel">
+            <a class="CustomPanel" href="#" title="Title with special chars &amp;&quot;&#39;&lt;&gt;">
+            Title with special chars &amp;&quot;&#39;&lt;&gt;
+            </a>
+            </li>
+            """,
+            html=True,
+        )
+        self.assertContains(
+            response,
+            """
+            <div id="CustomPanel" class="djdt-panelContent">
+            <div class="djDebugPanelTitle">
+            <a href="" class="djDebugClose">×</a>
+            <h3>Title with special chars &amp;&quot;&#39;&lt;&gt;</h3>
+            </div>
+            <div class="djDebugPanelContent">
+            <img class="djdt-loader" src="/static/debug_toolbar/img/ajax-loader.gif" alt="loading">
+            <div class="djdt-scroll"></div>
+            </div>
+            </div>
+            """,
+            html=True,
+        )

--- a/tests/panels/test_settings.py
+++ b/tests/panels/test_settings.py
@@ -1,0 +1,37 @@
+from django.test import override_settings
+
+from ..base import IntegrationTestCase
+
+
+@override_settings(DEBUG=True)
+class SettingsIntegrationTestCase(IntegrationTestCase):
+    def test_panel_title(self):
+        response = self.client.get("/regular/basic/")
+        # The settings module is None due to using Django's UserSettingsHolder
+        # in tests.
+        self.assertContains(
+            response,
+            """
+            <li class="djDebugPanelButton djdt-SettingsPanel">
+            <input type="checkbox" checked title="Disable for next and successive requests" data-cookie="djdtSettingsPanel">
+            <a class="SettingsPanel" href="#" title="Settings from None">Settings</a>
+            </li>
+            """,
+            html=True,
+        )
+        self.assertContains(
+            response,
+            """
+            <div id="SettingsPanel" class="djdt-panelContent">
+            <div class="djDebugPanelTitle">
+            <a href="" class="djDebugClose">×</a>
+            <h3>Settings from None</h3>
+            </div>
+            <div class="djDebugPanelContent">
+            <img class="djdt-loader" src="/static/debug_toolbar/img/ajax-loader.gif" alt="loading">
+            <div class="djdt-scroll"></div>
+            </div>
+            </div>
+            """,
+            html=True,
+        )


### PR DESCRIPTION
This features was used by a single panel only and has the potential for
mistakenly introducing XSS vulnerabilities.

Support for HTML in titles first appeared in
5015057cfe3448028ff79ca36a96f1baa4224226.
