### PR TITLE
Remove invalid href attribute from span elements

### DIFF
--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -24,8 +24,8 @@ def reformat_sql(sql, with_toggle=False):
     if not with_toggle:
         return formatted
     simple = simplify(parse_sql(sql, aligned_indent=False))
-    uncollapsed = '<span class="djDebugUncollapsed" href="#">{}</span>'.format(simple)
-    collapsed = '<span class="djDebugCollapsed" href="#">{}</span>'.format(formatted)
+    uncollapsed = '<span class="djDebugUncollapsed">{}</span>'.format(simple)
+    collapsed = '<span class="djDebugCollapsed">{}</span>'.format(formatted)
     return collapsed + uncollapsed
 
 

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -354,13 +354,11 @@
 
 #djDebug .djDebugCollapsed {
     display: none;
-    text-decoration: none;
     color: #333;
 }
 
 #djDebug .djDebugUncollapsed {
     color: #333;
-    text-decoration: none;
 }
 
 #djDebug .djUnselected {


### PR DESCRIPTION
This was once an anchor, but was changed in
ef9ac33a6a11d69d1b1220da5514609524ebb0bd.