### PR TITLE
Remove unused djdt-clearfix CSS class.

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -1,13 +1,3 @@
-/* http://www.positioniseverything.net/easyclearing.html */
-#djDebug .djdt-clearfix:after {
-    content: ".";
-    display: block;
-    height: 0;
-    clear: both;
-    visibility: hidden;
-}
-#djDebug .djdt-clearfix {display: block;}
-
 /* Debug Toolbar CSS Reset, adapted from Eric Meyer's CSS Reset */
 #djDebug {color: #000;background: #FFF;}
 #djDebug, #djDebug div, #djDebug span, #djDebug applet, #djDebug object, #djDebug iframe,

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -1,24 +1,22 @@
 {% load i18n l10n %}
-<div class="djdt-clearfix">
-  <ul>
-    {% for alias, info in databases %}
-      <li>
-        <strong><span style="background-color:rgb({{ info.rgb_color|join:', ' }})" class="djdt-color">&#160;</span> {{ alias }}</strong>
-        {{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
-        {% if info.similar_count %}
-          {% blocktrans with count=info.similar_count trimmed %}
-            including <abbr title="Similar queries are queries with the same SQL, but potentially different parameters.">{{ count }} similar</abbr>
+<ul>
+  {% for alias, info in databases %}
+    <li>
+      <strong><span style="background-color:rgb({{ info.rgb_color|join:', ' }})" class="djdt-color">&#160;</span> {{ alias }}</strong>
+      {{ info.time_spent|floatformat:"2" }} ms ({% blocktrans count info.num_queries as num %}{{ num }} query{% plural %}{{ num }} queries{% endblocktrans %}
+      {% if info.similar_count %}
+        {% blocktrans with count=info.similar_count trimmed %}
+          including <abbr title="Similar queries are queries with the same SQL, but potentially different parameters.">{{ count }} similar</abbr>
+        {% endblocktrans %}
+        {% if info.duplicate_count %}
+          {% blocktrans with dupes=info.duplicate_count trimmed %}
+            and <abbr title="Duplicate queries are identical to each other: they execute exactly the same SQL and parameters.">{{ dupes }} duplicates</abbr>
           {% endblocktrans %}
-          {% if info.duplicate_count %}
-            {% blocktrans with dupes=info.duplicate_count trimmed %}
-              and <abbr title="Duplicate queries are identical to each other: they execute exactly the same SQL and parameters.">{{ dupes }} duplicates</abbr>
-            {% endblocktrans %}
-          {% endif %}
-        {% endif %})
-      </li>
-    {% endfor %}
-  </ul>
-</div>
+        {% endif %}
+      {% endif %})
+    </li>
+  {% endfor %}
+</ul>
 
 {% if queries %}
   <table>


### PR DESCRIPTION
Since commit 83a01d9b2c502dca4c96e4e6420d229d10887416, the SQL panel HTML does
not include any floats, so there is nothing to clear.

Simplifies the HTML and CSS.

Sorry for missing this simplification in the previous PR.