### PR TITLE
Introduce Prettier to format JavaScript and CSS files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 cache: pip
 matrix:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 .PHONY: flake8 example test coverage translatable_strings update_translations
 
-style:
+PRETTIER_TARGETS = '**/*.(css|js)'
+
+style: package-lock.json
 	isort .
 	black --target-version=py35 .
 	flake8
+	npx prettier --ignore-path .gitignore --write $(PRETTIER_TARGETS)
 
-style_check:
+style_check: package-lock.json
 	isort -c .
 	black --target-version=py35 --check .
+	npx prettier --loglevel debug --ignore-path .gitignore --check $(PRETTIER_TARGETS)
 
 flake8:
 	flake8

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -1,14 +1,69 @@
 /* Debug Toolbar CSS Reset, adapted from Eric Meyer's CSS Reset */
-#djDebug {color: #000;background: #FFF;}
-#djDebug, #djDebug div, #djDebug span, #djDebug applet, #djDebug object, #djDebug iframe,
-#djDebug h1, #djDebug h2, #djDebug h3, #djDebug h4, #djDebug h5, #djDebug h6, #djDebug p, #djDebug blockquote, #djDebug pre,
-#djDebug a, #djDebug abbr, #djDebug acronym, #djDebug address, #djDebug big, #djDebug cite, #djDebug code,
-#djDebug del, #djDebug dfn, #djDebug em, #djDebug font, #djDebug img, #djDebug ins, #djDebug kbd, #djDebug q, #djDebug s, #djDebug samp,
-#djDebug small, #djDebug strike, #djDebug strong, #djDebug sub, #djDebug sup, #djDebug tt, #djDebug var,
-#djDebug b, #djDebug u, #djDebug i, #djDebug center,
-#djDebug dl, #djDebug dt, #djDebug dd, #djDebug ol, #djDebug ul, #djDebug li,
-#djDebug fieldset, #djDebug form, #djDebug label, #djDebug legend,
-#djDebug table, #djDebug caption, #djDebug tbody, #djDebug tfoot, #djDebug thead, #djDebug tr, #djDebug th, #djDebug td,
+#djDebug {
+    color: #000;
+    background: #fff;
+}
+#djDebug,
+#djDebug div,
+#djDebug span,
+#djDebug applet,
+#djDebug object,
+#djDebug iframe,
+#djDebug h1,
+#djDebug h2,
+#djDebug h3,
+#djDebug h4,
+#djDebug h5,
+#djDebug h6,
+#djDebug p,
+#djDebug blockquote,
+#djDebug pre,
+#djDebug a,
+#djDebug abbr,
+#djDebug acronym,
+#djDebug address,
+#djDebug big,
+#djDebug cite,
+#djDebug code,
+#djDebug del,
+#djDebug dfn,
+#djDebug em,
+#djDebug font,
+#djDebug img,
+#djDebug ins,
+#djDebug kbd,
+#djDebug q,
+#djDebug s,
+#djDebug samp,
+#djDebug small,
+#djDebug strike,
+#djDebug strong,
+#djDebug sub,
+#djDebug sup,
+#djDebug tt,
+#djDebug var,
+#djDebug b,
+#djDebug u,
+#djDebug i,
+#djDebug center,
+#djDebug dl,
+#djDebug dt,
+#djDebug dd,
+#djDebug ol,
+#djDebug ul,
+#djDebug li,
+#djDebug fieldset,
+#djDebug form,
+#djDebug label,
+#djDebug legend,
+#djDebug table,
+#djDebug caption,
+#djDebug tbody,
+#djDebug tfoot,
+#djDebug thead,
+#djDebug tr,
+#djDebug th,
+#djDebug td,
 #djDebug button {
     margin: 0;
     padding: 0;
@@ -28,7 +83,8 @@
     transition: none;
 }
 
-#djDebug button, #djDebug a.button {
+#djDebug button,
+#djDebug a.button {
     background-color: #eee;
     background-image: linear-gradient(to bottom, #eee, #cccccc);
     border: 1px solid #ccc;
@@ -41,7 +97,8 @@
     text-shadow: 0 1px 0 #eee;
 }
 
-#djDebug button:hover, #djDebug a.button:hover {
+#djDebug button:hover,
+#djDebug a.button:hover {
     background-color: #ddd;
     background-image: linear-gradient(to bottom, #ddd, #bbb);
     border-color: #bbb;
@@ -50,7 +107,8 @@
     text-shadow: 0 1px 0 #ddd;
 }
 
-#djDebug button:active, #djDebug a.button:active {
+#djDebug button:active,
+#djDebug a.button:active {
     border: 1px solid #aaa;
     border-bottom: 1px solid #888;
     box-shadow: inset 0 0 5px 2px #aaa, 0 1px 0 0 #eee;
@@ -90,13 +148,13 @@
     width: auto;
 }
 
-#djDebug #djDebugToolbar input[type=checkbox] {
+#djDebug #djDebugToolbar input[type="checkbox"] {
     float: right;
     margin: 10px;
 }
 
-#djDebug #djDebugToolbar li>a,
-#djDebug #djDebugToolbar li>div.djdt-contentless  {
+#djDebug #djDebugToolbar li > a,
+#djDebug #djDebugToolbar li > div.djdt-contentless {
     font-weight: normal;
     font-style: normal;
     text-decoration: none;
@@ -105,7 +163,7 @@
     padding: 10px 10px 5px 25px;
     color: #fff;
 }
-#djDebug #djDebugToolbar li>div.djdt-disabled {
+#djDebug #djDebugToolbar li > div.djdt-disabled {
     font-style: italic;
     color: #999;
 }
@@ -169,7 +227,7 @@
     background-color: #111;
     border-color: #ffe761;
     cursor: move;
-    opacity: 1.0;
+    opacity: 1;
 }
 
 #djDebug #djShowToolBarD {
@@ -184,7 +242,8 @@
 
 #djDebug code {
     display: block;
-    font-family: Consolas, Monaco, "Bitstream Vera Sans Mono", "Lucida Console", monospace;
+    font-family: Consolas, Monaco, "Bitstream Vera Sans Mono", "Lucida Console",
+        monospace;
     font-size: 12px;
     white-space: pre;
     overflow: auto;
@@ -243,8 +302,12 @@
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
 }
 
 #djDebug .djDebugPanelContent .djdt-scroll {
@@ -298,7 +361,7 @@
     width: 12em;
     text-align: right;
     color: #666;
-    padding-right: .5em;
+    padding-right: 0.5em;
 }
 
 #djDebug .djTemplateContext {
@@ -329,7 +392,8 @@
     background: #c0695d;
 }
 
-#djDebug .djdt-panelContent dt, #djDebug .djdt-panelContent dd {
+#djDebug .djdt-panelContent dt,
+#djDebug .djdt-panelContent dd {
     display: block;
 }
 
@@ -353,7 +417,6 @@
     color: #ffe761;
     border-radius: 3px;
 }
-
 
 #djDebug .djDebugSqlWrap {
     position: relative;
@@ -402,25 +465,68 @@
     background-color: #900;
 }
 
-#djDebug .highlight  { color: #000; }
-#djDebug .highlight .err { color: #000; } /* Error */
-#djDebug .highlight .g { color: #000; } /* Generic */
-#djDebug .highlight .k { color: #000; font-weight: bold } /* Keyword */
-#djDebug .highlight .o { color: #000; } /* Operator */
-#djDebug .highlight .n { color: #000; } /* Name */
-#djDebug .highlight .mi { color: #000; font-weight: bold } /* Literal.Number.Integer */
-#djDebug .highlight .l { color: #000; } /* Literal */
-#djDebug .highlight .x { color: #000; } /* Other */
-#djDebug .highlight .p { color: #000; } /* Punctuation */
-#djDebug .highlight .m { color: #000; font-weight: bold } /* Literal.Number */
-#djDebug .highlight .s { color: #333 } /* Literal.String */
-#djDebug .highlight .w { color: #888888 } /* Text.Whitespace */
-#djDebug .highlight .il { color: #000; font-weight: bold } /* Literal.Number.Integer.Long */
-#djDebug .highlight .na { color: #333 } /* Name.Attribute */
-#djDebug .highlight .nt { color: #000; font-weight: bold } /* Name.Tag */
-#djDebug .highlight .nv { color: #333 } /* Name.Variable */
-#djDebug .highlight .s2 { color: #333 } /* Literal.String.Double */
-#djDebug .highlight .cp { color: #333 } /* Comment.Preproc */
+#djDebug .highlight {
+    color: #000;
+}
+#djDebug .highlight .err {
+    color: #000;
+} /* Error */
+#djDebug .highlight .g {
+    color: #000;
+} /* Generic */
+#djDebug .highlight .k {
+    color: #000;
+    font-weight: bold;
+} /* Keyword */
+#djDebug .highlight .o {
+    color: #000;
+} /* Operator */
+#djDebug .highlight .n {
+    color: #000;
+} /* Name */
+#djDebug .highlight .mi {
+    color: #000;
+    font-weight: bold;
+} /* Literal.Number.Integer */
+#djDebug .highlight .l {
+    color: #000;
+} /* Literal */
+#djDebug .highlight .x {
+    color: #000;
+} /* Other */
+#djDebug .highlight .p {
+    color: #000;
+} /* Punctuation */
+#djDebug .highlight .m {
+    color: #000;
+    font-weight: bold;
+} /* Literal.Number */
+#djDebug .highlight .s {
+    color: #333;
+} /* Literal.String */
+#djDebug .highlight .w {
+    color: #888888;
+} /* Text.Whitespace */
+#djDebug .highlight .il {
+    color: #000;
+    font-weight: bold;
+} /* Literal.Number.Integer.Long */
+#djDebug .highlight .na {
+    color: #333;
+} /* Name.Attribute */
+#djDebug .highlight .nt {
+    color: #000;
+    font-weight: bold;
+} /* Name.Tag */
+#djDebug .highlight .nv {
+    color: #333;
+} /* Name.Variable */
+#djDebug .highlight .s2 {
+    color: #333;
+} /* Literal.String.Double */
+#djDebug .highlight .cp {
+    color: #333;
+} /* Comment.Preproc */
 
 #djDebug .djdt-timeline {
     width: 30%;
@@ -489,7 +595,8 @@
     overflow: auto;
     padding: 2px 3px;
     margin-bottom: 3px;
-    font-family: Consolas, Monaco, "Bitstream Vera Sans Mono", "Lucida Console", monospace;
+    font-family: Consolas, Monaco, "Bitstream Vera Sans Mono", "Lucida Console",
+        monospace;
 }
 #djDebug .djdt-stack span {
     color: #000;

--- a/debug_toolbar/static/debug_toolbar/js/redirect.js
+++ b/debug_toolbar/static/debug_toolbar/js/redirect.js
@@ -1,1 +1,1 @@
-document.getElementById('redirect_to').focus();
+document.getElementById("redirect_to").focus();

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -1,32 +1,32 @@
 const $$ = {
-    on: function(root, eventName, selector, fn) {
-        root.addEventListener(eventName, function(event) {
+    on: function (root, eventName, selector, fn) {
+        root.addEventListener(eventName, function (event) {
             const target = event.target.closest(selector);
             if (root.contains(target)) {
                 fn.call(target, event);
             }
         });
     },
-    show: function(element) {
-        element.classList.remove('djdt-hidden');
+    show: function (element) {
+        element.classList.remove("djdt-hidden");
     },
-    hide: function(element) {
-        element.classList.add('djdt-hidden');
+    hide: function (element) {
+        element.classList.add("djdt-hidden");
     },
-    toggle: function(element, value) {
+    toggle: function (element, value) {
         if (value) {
             $$.show(element);
         } else {
             $$.hide(element);
         }
     },
-    visible: function(element) {
-        element.classList.contains('djdt-hidden');
+    visible: function (element) {
+        element.classList.contains("djdt-hidden");
     },
-    executeScripts: function(scripts) {
-        scripts.forEach(function(script) {
-            const el = document.createElement('script');
-            el.type = 'module';
+    executeScripts: function (scripts) {
+        scripts.forEach(function (script) {
+            const el = document.createElement("script");
+            el.type = "module";
             el.src = script;
             el.async = true;
             document.head.appendChild(el);
@@ -34,20 +34,25 @@ const $$ = {
     },
 };
 
-const onKeyDown = function(event) {
+const onKeyDown = function (event) {
     if (event.keyCode === 27) {
         djdt.hide_one_level();
     }
 };
 
-const ajax = function(url, init) {
-    init = Object.assign({credentials: 'same-origin'}, init);
-    return fetch(url, init).then(function(response) {
+const ajax = function (url, init) {
+    init = Object.assign({ credentials: "same-origin" }, init);
+    return fetch(url, init).then(function (response) {
         if (response.ok) {
             return response.json();
         } else {
-            const win = document.querySelector('#djDebugWindow');
-            win.innerHTML = '<div class="djDebugPanelTitle"><a class="djDebugClose" href="">»</a><h3>'+response.status+': '+response.statusText+'</h3></div>';
+            const win = document.querySelector("#djDebugWindow");
+            win.innerHTML =
+                '<div class="djDebugPanelTitle"><a class="djDebugClose" href="">»</a><h3>' +
+                response.status +
+                ": " +
+                response.statusText +
+                "</h3></div>";
             $$.show(win);
             return Promise.reject();
         }
@@ -56,58 +61,74 @@ const ajax = function(url, init) {
 
 const djdt = {
     handleDragged: false,
-    init: function() {
-        const djDebug = document.querySelector('#djDebug');
+    init: function () {
+        const djDebug = document.querySelector("#djDebug");
         $$.show(djDebug);
-        $$.on(djDebug.querySelector('#djDebugPanelList'), 'click', 'li a', function(event) {
-            event.preventDefault();
-            if (!this.className) {
-                return;
-            }
-            const current = djDebug.querySelector('#' + this.className);
-            if ($$.visible(current)) {
-                djdt.hide_panels();
-            } else {
-                djdt.hide_panels();
+        $$.on(
+            djDebug.querySelector("#djDebugPanelList"),
+            "click",
+            "li a",
+            function (event) {
+                event.preventDefault();
+                if (!this.className) {
+                    return;
+                }
+                const current = djDebug.querySelector("#" + this.className);
+                if ($$.visible(current)) {
+                    djdt.hide_panels();
+                } else {
+                    djdt.hide_panels();
 
-                $$.show(current);
-                this.parentElement.classList.add('djdt-active');
+                    $$.show(current);
+                    this.parentElement.classList.add("djdt-active");
 
-                const inner = current.querySelector('.djDebugPanelContent .djdt-scroll'),
-                      store_id = djDebug.dataset.storeId;
-                if (store_id && inner.children.length === 0) {
-                    let url = djDebug.dataset.renderPanelUrl;
-                    const url_params = new URLSearchParams();
-                    url_params.append('store_id', store_id);
-                    url_params.append('panel_id', this.className);
-                    url += '?' + url_params.toString();
-                    ajax(url).then(function(data) {
-                        inner.previousElementSibling.remove();  // Remove AJAX loader
-                        inner.innerHTML = data.content;
-                        $$.executeScripts(data.scripts);
-                    });
+                    const inner = current.querySelector(
+                            ".djDebugPanelContent .djdt-scroll"
+                        ),
+                        store_id = djDebug.dataset.storeId;
+                    if (store_id && inner.children.length === 0) {
+                        let url = djDebug.dataset.renderPanelUrl;
+                        const url_params = new URLSearchParams();
+                        url_params.append("store_id", store_id);
+                        url_params.append("panel_id", this.className);
+                        url += "?" + url_params.toString();
+                        ajax(url).then(function (data) {
+                            inner.previousElementSibling.remove(); // Remove AJAX loader
+                            inner.innerHTML = data.content;
+                            $$.executeScripts(data.scripts);
+                        });
+                    }
                 }
             }
-        });
-        $$.on(djDebug, 'click', 'a.djDebugClose', function(event) {
+        );
+        $$.on(djDebug, "click", "a.djDebugClose", function (event) {
             event.preventDefault();
             djdt.hide_one_level();
         });
-        $$.on(djDebug, 'click', '.djDebugPanelButton input[type=checkbox]', function() {
-            djdt.cookie.set(this.dataset.cookie, this.checked ? 'on' : 'off', {
-                path: '/',
-                expires: 10
-            });
-        });
+        $$.on(
+            djDebug,
+            "click",
+            ".djDebugPanelButton input[type=checkbox]",
+            function () {
+                djdt.cookie.set(
+                    this.dataset.cookie,
+                    this.checked ? "on" : "off",
+                    {
+                        path: "/",
+                        expires: 10,
+                    }
+                );
+            }
+        );
 
         // Used by the SQL and template panels
-        $$.on(djDebug, 'click', '.remoteCall', function(event) {
+        $$.on(djDebug, "click", ".remoteCall", function (event) {
             event.preventDefault();
 
             const ajax_data = {};
 
-            if (this.tagName === 'BUTTON') {
-                const form = this.closest('form');
+            if (this.tagName === "BUTTON") {
+                const form = this.closest("form");
                 ajax_data.url = this.formAction;
 
                 if (form) {
@@ -116,65 +137,74 @@ const djdt = {
                 }
             }
 
-            if (this.tagName === 'A') {
+            if (this.tagName === "A") {
                 ajax_data.url = this.href;
             }
 
-            ajax(ajax_data.url, ajax_data).then(function(data) {
-                const win = djDebug.querySelector('#djDebugWindow');
+            ajax(ajax_data.url, ajax_data).then(function (data) {
+                const win = djDebug.querySelector("#djDebugWindow");
                 win.innerHTML = data.content;
                 $$.show(win);
             });
         });
 
         // Used by the history panel
-        $$.on(djDebug, 'click', '.switchHistory', function(event) {
+        $$.on(djDebug, "click", ".switchHistory", function (event) {
             event.preventDefault();
             const ajax_data = {};
             const newStoreId = this.dataset.storeId;
-            const form = this.closest('form');
-            const tbody = this.closest('tbody');
+            const form = this.closest("form");
+            const tbody = this.closest("tbody");
 
-            ajax_data.url = this.getAttribute('formaction');
+            ajax_data.url = this.getAttribute("formaction");
 
             if (form) {
                 ajax_data.body = new FormData(form);
-                ajax_data.method = form.getAttribute('method') || 'POST';
+                ajax_data.method = form.getAttribute("method") || "POST";
             }
 
-            tbody.querySelector('.djdt-highlighted').classList.remove('djdt-highlighted');
-            this.closest('tr').classList.add('djdt-highlighted');
+            tbody
+                .querySelector(".djdt-highlighted")
+                .classList.remove("djdt-highlighted");
+            this.closest("tr").classList.add("djdt-highlighted");
 
-            ajax(ajax_data.url, ajax_data).then(function(data) {
-                djDebug.setAttribute('data-store-id', newStoreId);
+            ajax(ajax_data.url, ajax_data).then(function (data) {
+                djDebug.setAttribute("data-store-id", newStoreId);
                 Object.keys(data).map(function (panelId) {
-                    if (djDebug.querySelector('#'+panelId)) {
-                        djDebug.querySelector('#'+panelId).outerHTML = data[panelId].content;
-                        djDebug.querySelector('#djdt-'+panelId).outerHTML = data[panelId].button;
+                    if (djDebug.querySelector("#" + panelId)) {
+                        djDebug.querySelector("#" + panelId).outerHTML =
+                            data[panelId].content;
+                        djDebug.querySelector("#djdt-" + panelId).outerHTML =
+                            data[panelId].button;
                     }
                 });
             });
         });
 
         // Used by the history panel
-        $$.on(djDebug, 'click', '.refreshHistory', function(event) {
+        $$.on(djDebug, "click", ".refreshHistory", function (event) {
             event.preventDefault();
             const ajax_data = {};
-            const form = this.closest('form');
-            const container = djDebug.querySelector('#djdtHistoryRequests');
+            const form = this.closest("form");
+            const container = djDebug.querySelector("#djdtHistoryRequests");
 
-            ajax_data.url = this.getAttribute('formaction');
+            ajax_data.url = this.getAttribute("formaction");
 
             if (form) {
                 ajax_data.body = new FormData(form);
-                ajax_data.method = form.getAttribute('method') || 'POST';
+                ajax_data.method = form.getAttribute("method") || "POST";
             }
 
-            ajax(ajax_data.url, ajax_data).then(function(data) {
+            ajax(ajax_data.url, ajax_data).then(function (data) {
                 if (data.requests.constructor === Array) {
-                    data.requests.map(function(request) {
-                        if (!container.querySelector('[data-store-id="'+request.id+'"]')) {
-                            container.innerHTML = request.content + container.innerHTML;
+                    data.requests.map(function (request) {
+                        if (
+                            !container.querySelector(
+                                '[data-store-id="' + request.id + '"]'
+                            )
+                        ) {
+                            container.innerHTML =
+                                request.content + container.innerHTML;
                         }
                     });
                 }
@@ -182,49 +212,61 @@ const djdt = {
         });
 
         // Used by the cache, profiling and SQL panels
-        $$.on(djDebug, 'click', 'a.djToggleSwitch', function(event) {
+        $$.on(djDebug, "click", "a.djToggleSwitch", function (event) {
             event.preventDefault();
             const self = this;
             const id = this.dataset.toggleId;
             const open_me = this.textContent === this.dataset.toggleOpen;
             const name = this.dataset.toggleName;
-            const container = this.closest('.djDebugPanelContent').querySelector('#' + name + '_' + id);
-            container.querySelectorAll('.djDebugCollapsed').forEach(function(e) {
-                $$.toggle(e, open_me);
-            });
-            container.querySelectorAll('.djDebugUncollapsed').forEach(function(e) {
-                $$.toggle(e, !open_me);
-            });
-            this.closest('.djDebugPanelContent').querySelectorAll('.djToggleDetails_' + id).forEach(function(e) {
-                if (open_me) {
-                    e.classList.add('djSelected');
-                    e.classList.remove('djUnselected');
-                    self.textContent = self.dataset.toggleClose;
-                } else {
-                    e.classList.remove('djSelected');
-                    e.classList.add('djUnselected');
-                    self.textContent = self.dataset.toggleOpen;
-                }
-                const switch_ = e.querySelector('.djToggleSwitch');
-                if (switch_) {
-                    switch_.textContent = self.textContent;
-                }
-            });
+            const container = this.closest(
+                ".djDebugPanelContent"
+            ).querySelector("#" + name + "_" + id);
+            container
+                .querySelectorAll(".djDebugCollapsed")
+                .forEach(function (e) {
+                    $$.toggle(e, open_me);
+                });
+            container
+                .querySelectorAll(".djDebugUncollapsed")
+                .forEach(function (e) {
+                    $$.toggle(e, !open_me);
+                });
+            this.closest(".djDebugPanelContent")
+                .querySelectorAll(".djToggleDetails_" + id)
+                .forEach(function (e) {
+                    if (open_me) {
+                        e.classList.add("djSelected");
+                        e.classList.remove("djUnselected");
+                        self.textContent = self.dataset.toggleClose;
+                    } else {
+                        e.classList.remove("djSelected");
+                        e.classList.add("djUnselected");
+                        self.textContent = self.dataset.toggleOpen;
+                    }
+                    const switch_ = e.querySelector(".djToggleSwitch");
+                    if (switch_) {
+                        switch_.textContent = self.textContent;
+                    }
+                });
         });
 
-        djDebug.querySelector('#djHideToolBarButton').addEventListener('click', function(event) {
-            event.preventDefault();
-            djdt.hide_toolbar(true);
-        });
-        djDebug.querySelector('#djShowToolBarButton').addEventListener('click', function(event) {
-            event.preventDefault();
-            if (!djdt.handleDragged) {
-                djdt.show_toolbar();
-            }
-        });
+        djDebug
+            .querySelector("#djHideToolBarButton")
+            .addEventListener("click", function (event) {
+                event.preventDefault();
+                djdt.hide_toolbar(true);
+            });
+        djDebug
+            .querySelector("#djShowToolBarButton")
+            .addEventListener("click", function (event) {
+                event.preventDefault();
+                if (!djdt.handleDragged) {
+                    djdt.show_toolbar();
+                }
+            });
         let startPageY, baseY;
-        const handle = document.querySelector('#djDebugToolbarHandle');
-        const onHandleMove = function(event) {
+        const handle = document.querySelector("#djDebugToolbarHandle");
+        const onHandleMove = function (event) {
             // Chrome can send spurious mousemove events, so don't do anything unless the
             // cursor really moved.  Otherwise, it will be impossible to expand the toolbar
             // due to djdt.handleDragged being set to true.
@@ -237,113 +279,122 @@ const djdt = {
                     top = window.innerHeight - handle.offsetHeight;
                 }
 
-                handle.style.top = top + 'px';
+                handle.style.top = top + "px";
                 djdt.handleDragged = true;
             }
         };
-        djDebug.querySelector('#djShowToolBarButton').addEventListener('mousedown', function(event) {
-            event.preventDefault();
-            startPageY = event.pageY;
-            baseY = handle.offsetTop - startPageY;
-            document.addEventListener('mousemove', onHandleMove);
-        });
-        document.addEventListener('mouseup', function (event) {
-            document.removeEventListener('mousemove', onHandleMove);
+        djDebug
+            .querySelector("#djShowToolBarButton")
+            .addEventListener("mousedown", function (event) {
+                event.preventDefault();
+                startPageY = event.pageY;
+                baseY = handle.offsetTop - startPageY;
+                document.addEventListener("mousemove", onHandleMove);
+            });
+        document.addEventListener("mouseup", function (event) {
+            document.removeEventListener("mousemove", onHandleMove);
             if (djdt.handleDragged) {
                 event.preventDefault();
-                localStorage.setItem('djdt.top', handle.offsetTop);
+                localStorage.setItem("djdt.top", handle.offsetTop);
                 setTimeout(function () {
                     djdt.handleDragged = false;
                 }, 10);
             }
         });
-        const show = localStorage.getItem('djdt.show') || djDebug.dataset.defaultShow;
-        if (show === 'true') {
+        const show =
+            localStorage.getItem("djdt.show") || djDebug.dataset.defaultShow;
+        if (show === "true") {
             djdt.show_toolbar();
         } else {
             djdt.hide_toolbar();
         }
     },
-    hide_panels: function() {
-        const djDebug = document.getElementById('djDebug');
-        $$.hide(djDebug.querySelector('#djDebugWindow'));
-        djDebug.querySelectorAll('.djdt-panelContent').forEach(function(e) {
+    hide_panels: function () {
+        const djDebug = document.getElementById("djDebug");
+        $$.hide(djDebug.querySelector("#djDebugWindow"));
+        djDebug.querySelectorAll(".djdt-panelContent").forEach(function (e) {
             $$.hide(e);
         });
-        djDebug.querySelectorAll('#djDebugToolbar li').forEach(function(e) {
-            e.classList.remove('djdt-active');
+        djDebug.querySelectorAll("#djDebugToolbar li").forEach(function (e) {
+            e.classList.remove("djdt-active");
         });
     },
-    hide_toolbar: function() {
+    hide_toolbar: function () {
         djdt.hide_panels();
 
-        const djDebug = document.getElementById('djDebug');
-        $$.hide(djDebug.querySelector('#djDebugToolbar'));
+        const djDebug = document.getElementById("djDebug");
+        $$.hide(djDebug.querySelector("#djDebugToolbar"));
 
-        const handle = document.querySelector('#djDebugToolbarHandle');
+        const handle = document.querySelector("#djDebugToolbarHandle");
         $$.show(handle);
         // set handle position
-        let handleTop = localStorage.getItem('djdt.top');
+        let handleTop = localStorage.getItem("djdt.top");
         if (handleTop) {
-            handleTop = Math.min(handleTop, window.innerHeight - handle.offsetHeight);
-            handle.style.top = handleTop + 'px';
+            handleTop = Math.min(
+                handleTop,
+                window.innerHeight - handle.offsetHeight
+            );
+            handle.style.top = handleTop + "px";
         }
 
-        document.removeEventListener('keydown', onKeyDown);
+        document.removeEventListener("keydown", onKeyDown);
 
-        localStorage.setItem('djdt.show', 'false');
+        localStorage.setItem("djdt.show", "false");
     },
-    hide_one_level: function() {
-        const djDebug = document.getElementById('djDebug');
-        if ($$.visible(djDebug.querySelector('#djDebugWindow'))) {
-            $$.hide(djDebug.querySelector('#djDebugWindow'));
-        } else if (djDebug.querySelector('#djDebugToolbar li.djdt-active')) {
+    hide_one_level: function () {
+        const djDebug = document.getElementById("djDebug");
+        if ($$.visible(djDebug.querySelector("#djDebugWindow"))) {
+            $$.hide(djDebug.querySelector("#djDebugWindow"));
+        } else if (djDebug.querySelector("#djDebugToolbar li.djdt-active")) {
             djdt.hide_panels();
         } else {
             djdt.hide_toolbar(true);
         }
     },
-    show_toolbar: function() {
-        document.addEventListener('keydown', onKeyDown);
-        const djDebug = document.getElementById('djDebug');
-        $$.hide(djDebug.querySelector('#djDebugToolbarHandle'));
-        $$.show(djDebug.querySelector('#djDebugToolbar'));
-        localStorage.setItem('djdt.show', 'true');
+    show_toolbar: function () {
+        document.addEventListener("keydown", onKeyDown);
+        const djDebug = document.getElementById("djDebug");
+        $$.hide(djDebug.querySelector("#djDebugToolbarHandle"));
+        $$.show(djDebug.querySelector("#djDebugToolbar"));
+        localStorage.setItem("djdt.show", "true");
     },
     cookie: {
-        get: function(key){
+        get: function (key) {
             if (document.cookie.indexOf(key) === -1) {
                 return null;
             }
 
-            const cookieArray = document.cookie.split('; '),
-                  cookies = {};
+            const cookieArray = document.cookie.split("; "),
+                cookies = {};
 
-            cookieArray.forEach(function(e){
-                const parts = e.split('=');
-                cookies[ parts[0] ] = parts[1];
+            cookieArray.forEach(function (e) {
+                const parts = e.split("=");
+                cookies[parts[0]] = parts[1];
             });
 
-            return cookies[ key ];
+            return cookies[key];
         },
-        set: function(key, value, options){
+        set: function (key, value, options) {
             options = options || {};
 
-            if (typeof options.expires === 'number') {
-                const days = options.expires, t = options.expires = new Date();
+            if (typeof options.expires === "number") {
+                const days = options.expires,
+                    t = (options.expires = new Date());
                 t.setDate(t.getDate() + days);
             }
 
             document.cookie = [
-                encodeURIComponent(key) + '=' + String(value),
-                options.expires ? '; expires=' + options.expires.toUTCString() : '',
-                options.path    ? '; path=' + options.path : '',
-                options.domain  ? '; domain=' + options.domain : '',
-                options.secure  ? '; secure' : ''
-            ].join('');
+                encodeURIComponent(key) + "=" + String(value),
+                options.expires
+                    ? "; expires=" + options.expires.toUTCString()
+                    : "",
+                options.path ? "; path=" + options.path : "",
+                options.domain ? "; domain=" + options.domain : "",
+                options.secure ? "; secure" : "",
+            ].join("");
 
             return value;
-        }
+        },
     },
 };
 window.djdt = {
@@ -354,8 +405,8 @@ window.djdt = {
     cookie: djdt.cookie,
 };
 
-if (document.readyState !== 'loading') {
+if (document.readyState !== "loading") {
     djdt.init();
 } else {
-    document.addEventListener('DOMContentLoaded', djdt.init);
+    document.addEventListener("DOMContentLoaded", djdt.init);
 }

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.timer.js
@@ -1,41 +1,58 @@
 const timingOffset = performance.timing.navigationStart,
-      timingEnd = performance.timing.loadEventEnd,
-      totalTime = timingEnd - timingOffset;
+    timingEnd = performance.timing.loadEventEnd,
+    totalTime = timingEnd - timingOffset;
 function getLeft(stat) {
-    return ((performance.timing[stat] - timingOffset) / (totalTime)) * 100.0;
+    return ((performance.timing[stat] - timingOffset) / totalTime) * 100.0;
 }
 function getCSSWidth(stat, endStat) {
-    let width = ((performance.timing[endStat] - performance.timing[stat]) / (totalTime)) * 100.0;
+    let width =
+        ((performance.timing[endStat] - performance.timing[stat]) / totalTime) *
+        100.0;
     // Calculate relative percent (same as sql panel logic)
-    width = 100.0 * width / (100.0 - getLeft(stat));
-    return (width < 1) ? "2px" : width + "%";
+    width = (100.0 * width) / (100.0 - getLeft(stat));
+    return width < 1 ? "2px" : width + "%";
 }
 function addRow(stat, endStat) {
-    const row = document.createElement('tr');
+    const row = document.createElement("tr");
     if (endStat) {
         // Render a start through end bar
-        row.innerHTML = '<td>' + stat.replace('Start', '') + '</td>' +
+        row.innerHTML =
+            "<td>" +
+            stat.replace("Start", "") +
+            "</td>" +
             '<td class="djdt-timeline"><svg class="djDebugLineChart" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 5" preserveAspectRatio="none"><rect y="0" height="5" fill="#ccc" /></svg></td>' +
-            '<td>' + (performance.timing[stat] - timingOffset) + ' (+' + (performance.timing[endStat] - performance.timing[stat]) + ')</td>';
-        row.querySelector('rect').setAttribute('width', getCSSWidth(stat, endStat));
+            "<td>" +
+            (performance.timing[stat] - timingOffset) +
+            " (+" +
+            (performance.timing[endStat] - performance.timing[stat]) +
+            ")</td>";
+        row.querySelector("rect").setAttribute(
+            "width",
+            getCSSWidth(stat, endStat)
+        );
     } else {
         // Render a point in time
-        row.innerHTML = '<td>' + stat + '</td>' +
+        row.innerHTML =
+            "<td>" +
+            stat +
+            "</td>" +
             '<td class="djdt-timeline"><svg class="djDebugLineChart" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 5" preserveAspectRatio="none"><rect y="0" height="5" fill="#ccc" /></svg></td>' +
-            '<td>' + (performance.timing[stat] - timingOffset) + '</td>';
-        row.querySelector('rect').setAttribute('width', 2);
+            "<td>" +
+            (performance.timing[stat] - timingOffset) +
+            "</td>";
+        row.querySelector("rect").setAttribute("width", 2);
     }
-    row.querySelector('rect').setAttribute('x', getLeft(stat));
-    document.querySelector('#djDebugBrowserTimingTableBody').appendChild(row);
+    row.querySelector("rect").setAttribute("x", getLeft(stat));
+    document.querySelector("#djDebugBrowserTimingTableBody").appendChild(row);
 }
 
 // This is a reasonably complete and ordered set of timing periods (2 params) and events (1 param)
-addRow('domainLookupStart', 'domainLookupEnd');
-addRow('connectStart', 'connectEnd');
-addRow('requestStart', 'responseEnd'); // There is no requestEnd
-addRow('responseStart', 'responseEnd');
-addRow('domLoading', 'domComplete'); // Spans the events below
-addRow('domInteractive');
-addRow('domContentLoadedEventStart', 'domContentLoadedEventEnd');
-addRow('loadEventStart', 'loadEventEnd');
-document.querySelector('#djDebugBrowserTiming').classList.remove('djdt-hidden');
+addRow("domainLookupStart", "domainLookupEnd");
+addRow("connectStart", "connectEnd");
+addRow("requestStart", "responseEnd"); // There is no requestEnd
+addRow("responseStart", "responseEnd");
+addRow("domLoading", "domComplete"); // Spans the events below
+addRow("domInteractive");
+addRow("domContentLoadedEventStart", "domContentLoadedEventEnd");
+addRow("loadEventStart", "loadEventEnd");
+document.querySelector("#djDebugBrowserTiming").classList.remove("djdt-hidden");

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "devDependencies": {
-        "eslint": "^6.7.2"
+        "eslint": "^6.7.2",
+        "prettier": "^2.1.2"
     }
 }


### PR DESCRIPTION
Prettier is an opinionated formatting tool for JavaScript and CSS.
Similar to how Black is for Python, Prettier automates all formatting
decisions for JS and CSS files, thus eliminating differences in
preferences. Contributors can use "make style" just like before to
restyle files.