### PR TITLE
Remove "Requirements Status" badge from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,6 @@ Django Debug Toolbar
    :target: https://codecov.io/gh/jazzband/django-debug-toolbar
    :alt: Test coverage status
 
-.. image:: https://requires.io/github/jazzband/django-debug-toolbar/requirements.svg?branch=master
-     :target: https://requires.io/github/jazzband/django-debug-toolbar/requirements/?branch=master
-     :alt: Requirements Status
-
 The Django Debug Toolbar is a configurable set of panels that display various
 debug information about the current request/response and when clicked, display
 more details about the panel's content.


### PR DESCRIPTION
The badge always displays as "outdated". The casual observer may
conclude that Django Debug Toolbar is not maintained. As the library
dependencies aren't pinned to an upper bound, there really isn't
anything that can go out of date.

Better to avoid the mixed message.