### PR TITLE
Prefer literal over HTML entity

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -9,7 +9,7 @@
   <div class="djdt-hidden" id="djDebugToolbar">
     <ul id="djDebugPanelList">
       {% if toolbar.panels %}
-        <li><a id="djHideToolBarButton" href="#" title="{% trans "Hide toolbar" %}">{% trans "Hide" %} &#187;</a></li>
+        <li><a id="djHideToolBarButton" href="#" title="{% trans "Hide toolbar" %}">{% trans "Hide" %} »</a></li>
       {% else %}
         <li id="djDebugButton">DEBUG</li>
       {% endif %}


### PR DESCRIPTION
Literals are easier to read when viewing the source (don't need to
memorize code points). The files are encoded in UTF-8 and all modern
browser support UTF-8, so it is compatible.