### PR TITLE
Simplify fetch() calls in JavaScript

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -105,23 +105,19 @@ const djdt = {
         $$.on(djDebug, 'click', '.remoteCall', function(event) {
             event.preventDefault();
 
+            let url;
             const ajax_data = {};
 
             if (this.tagName === 'BUTTON') {
                 const form = this.closest('form');
-                ajax_data.url = this.formAction;
-
-                if (form) {
-                    ajax_data.body = new FormData(form);
-                    ajax_data.method = form.method.toUpperCase();
-                }
+                url = this.formAction;
+                ajax_data.method = form.method.toUpperCase();
+                ajax_data.body = new FormData(form);
+            } else if (this.tagName === 'A') {
+                url = this.href;
             }
 
-            if (this.tagName === 'A') {
-                ajax_data.url = this.href;
-            }
-
-            ajax(ajax_data.url, ajax_data).then(function(data) {
+            ajax(url, ajax_data).then(function(data) {
                 const win = djDebug.querySelector('#djDebugWindow');
                 win.innerHTML = data.content;
                 $$.show(win);
@@ -131,22 +127,19 @@ const djdt = {
         // Used by the history panel
         $$.on(djDebug, 'click', '.switchHistory', function(event) {
             event.preventDefault();
-            const ajax_data = {};
             const newStoreId = this.dataset.storeId;
             const form = this.closest('form');
             const tbody = this.closest('tbody');
 
-            ajax_data.url = this.getAttribute('formaction');
-
-            if (form) {
-                ajax_data.body = new FormData(form);
-                ajax_data.method = form.getAttribute('method') || 'POST';
-            }
+            const ajax_data = {
+                method: form.method.toUpperCase(),
+                body: new FormData(form),
+            };
 
             tbody.querySelector('.djdt-highlighted').classList.remove('djdt-highlighted');
             this.closest('tr').classList.add('djdt-highlighted');
 
-            ajax(ajax_data.url, ajax_data).then(function(data) {
+            ajax(form.action, ajax_data).then(function(data) {
                 djDebug.setAttribute('data-store-id', newStoreId);
                 Object.keys(data).map(function (panelId) {
                     if (djDebug.querySelector('#'+panelId)) {
@@ -160,18 +153,15 @@ const djdt = {
         // Used by the history panel
         $$.on(djDebug, 'click', '.refreshHistory', function(event) {
             event.preventDefault();
-            const ajax_data = {};
             const form = this.closest('form');
             const container = djDebug.querySelector('#djdtHistoryRequests');
 
-            ajax_data.url = this.getAttribute('formaction');
+            const ajax_data = {
+                method: form.method.toUpperCase(),
+                body: new FormData(form),
+            };
 
-            if (form) {
-                ajax_data.body = new FormData(form);
-                ajax_data.method = form.getAttribute('method') || 'POST';
-            }
-
-            ajax(ajax_data.url, ajax_data).then(function(data) {
+            ajax(form.action, ajax_data).then(function(data) {
                 if (data.requests.constructor === Array) {
                     data.requests.map(function(request) {
                         if (!container.querySelector('[data-store-id="'+request.id+'"]')) {

--- a/debug_toolbar/templates/debug_toolbar/panels/history.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history.html
@@ -1,7 +1,7 @@
 {% load i18n %}{% load static %}
-<form method="post">
+<form method="post" action="{% url 'djdt:history_refresh' %}">
     {{ refresh_form }}
-    <button formaction="{% url 'djdt:history_refresh' %}" class="refreshHistory">Refresh</button>
+    <button class="refreshHistory">Refresh</button>
 </form>
 <table style="max-height:100%;">
     <thead>

--- a/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
@@ -39,9 +39,9 @@
         </div>
     </td>
     <td class="djdt-actions">
-        <form method="post">
+        <form method="post" action="{% url 'djdt:history_sidebar' %}">
             {{ store_context.form }}
-            <button formaction="{% url 'djdt:history_sidebar' %}" data-store-id="{{ id }}" class="switchHistory">Switch</button>
+            <button data-store-id="{{ id }}" class="switchHistory">Switch</button>
         </form>
     </td>
 </tr>


### PR DESCRIPTION
The fetch() init object does not have a property "url", so remove it.

The element being either a button or a element is mutually exclusive, so
use an "else if".

When a button is pressed, an enclosing form element already exist, so
remove the guard.

Assign the object properties in the object literal instead of after.