### PR TITLE
Improve "Setting up URLconf" section in installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,16 +43,16 @@ If you're upgrading from a previous version, you should review the
 Setting up URLconf
 ------------------
 
-Add the Debug Toolbar's URLs to your project's URLconf as follows::
+Add the Debug Toolbar's URLs to your project's URLconf::
 
+    import debug_toolbar
     from django.conf import settings
     from django.urls import include, path
 
-    if settings.DEBUG:
-        import debug_toolbar
-        urlpatterns = [
-            path('__debug__/', include(debug_toolbar.urls)),
-        ] + urlpatterns
+    urlpatterns = [
+        ...
+        path('__debug__/', include(debug_toolbar.urls)),
+    ]
 
 This example uses the ``__debug__`` prefix, but you can use any prefix that
 doesn't clash with your application's URLs. Note the lack of quotes around

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,7 +1,8 @@
-from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import TemplateView
+
+import debug_toolbar
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html")),
@@ -9,9 +10,5 @@ urlpatterns = [
     path("mootools/", TemplateView.as_view(template_name="mootools/index.html")),
     path("prototype/", TemplateView.as_view(template_name="prototype/index.html")),
     path("admin/", admin.site.urls),
+    path("__debug__/", include(debug_toolbar.urls)),
 ]
-
-if settings.DEBUG:
-    import debug_toolbar
-
-    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]


### PR DESCRIPTION
Remove the "if settings.DEBUG" guard. This guard is not necessary and
leads to several edge cases in local development setups.

This is not necessary as all views are guarded by the
require_show_toolbar decorator which uses the SHOW_TOOLBAR_CALLBACK
setting. This setting is already capable of enabling/disabling the
across the application when DEBUG is False. By default, when DEBUG is
False, these views return a 404 response.

By having the URLs always available, the MIDDLEWARE setting also doesn't
need special handling when DEBUG is False, simplifing the overall
configuration. An application should be able to reliably reverse URLs
regardless of the status of DEBUG.

Fixes #1035
Fixes #1043
Fixes #1332