### PR TITLE
Simplify DebugToolbar.store()

### DIFF
--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -92,15 +92,9 @@ class DebugToolbar:
         if self.store_id:
             return
         self.store_id = uuid.uuid4().hex
-        cls = type(self)
-        cls._store[self.store_id] = self
-        for _ in range(len(cls._store) - self.config["RESULTS_CACHE_SIZE"]):
-            try:
-                # collections.OrderedDict
-                cls._store.popitem(last=False)
-            except TypeError:
-                # django.utils.datastructures.SortedDict
-                del cls._store[cls._store.keyOrder[0]]
+        self._store[self.store_id] = self
+        for _ in range(self.config["RESULTS_CACHE_SIZE"], len(self._store)):
+            self._store.popitem(last=False)
 
     @classmethod
     def fetch(cls, store_id):


### PR DESCRIPTION
django.utils.datastructures.SortedDict has been unused since
a0569d7b473a2292afbda35b4066bc0aa4429823.

Can access class variables using self so drop unnecessary type() call.

range() supports passing a first argument larger than the second, in
which case it doesn't yield any values.

    >>> list(range(2, 1))
    []