### PR TITLE
Make history views accept GET requests

### DIFF
--- a/debug_toolbar/panels/history/views.py
+++ b/debug_toolbar/panels/history/views.py
@@ -1,17 +1,15 @@
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.template.loader import render_to_string
-from django.views.decorators.csrf import csrf_exempt
 
 from debug_toolbar.decorators import require_show_toolbar
 from debug_toolbar.panels.history.forms import HistoryStoreForm
 from debug_toolbar.toolbar import DebugToolbar
 
 
-@csrf_exempt
 @require_show_toolbar
 def history_sidebar(request):
     """Returns the selected debug toolbar history snapshot."""
-    form = HistoryStoreForm(request.POST or None)
+    form = HistoryStoreForm(request.GET)
 
     if form.is_valid():
         store_id = form.cleaned_data["store_id"]
@@ -33,11 +31,10 @@ def history_sidebar(request):
     return HttpResponseBadRequest("Form errors")
 
 
-@csrf_exempt
 @require_show_toolbar
 def history_refresh(request):
     """Returns the refreshed list of table rows for the History Panel."""
-    form = HistoryStoreForm(request.POST or None)
+    form = HistoryStoreForm(request.GET)
 
     if form.is_valid():
         requests = []

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -59,6 +59,19 @@ const ajax = function (url, init) {
     });
 };
 
+function ajaxForm(element) {
+    const form = element.closest("form");
+    const url = new URL(form.action);
+    const formData = new FormData(form);
+    for (const [name, value] of formData.entries()) {
+        url.searchParams.append(name, value);
+    }
+    const ajaxData = {
+        method: form.method.toUpperCase(),
+    };
+    return ajax(url, ajaxData);
+}
+
 const djdt = {
     handleDragged: false,
     init: function () {
@@ -148,20 +161,14 @@ const djdt = {
         $$.on(djDebug, "click", ".switchHistory", function (event) {
             event.preventDefault();
             const newStoreId = this.dataset.storeId;
-            const form = this.closest("form");
             const tbody = this.closest("tbody");
-
-            const ajax_data = {
-                method: form.method.toUpperCase(),
-                body: new FormData(form),
-            };
 
             tbody
                 .querySelector(".djdt-highlighted")
                 .classList.remove("djdt-highlighted");
             this.closest("tr").classList.add("djdt-highlighted");
 
-            ajax(form.action, ajax_data).then(function (data) {
+            ajaxForm(this).then(function (data) {
                 djDebug.setAttribute("data-store-id", newStoreId);
                 Object.keys(data).forEach(function (panelId) {
                     if (djDebug.querySelector("#" + panelId)) {
@@ -177,15 +184,8 @@ const djdt = {
         // Used by the history panel
         $$.on(djDebug, "click", ".refreshHistory", function (event) {
             event.preventDefault();
-            const form = this.closest("form");
             const container = djDebug.querySelector("#djdtHistoryRequests");
-
-            const ajax_data = {
-                method: form.method.toUpperCase(),
-                body: new FormData(form),
-            };
-
-            ajax(form.action, ajax_data).then(function (data) {
+            ajaxForm(this).then(function (data) {
                 if (data.requests.constructor === Array) {
                     data.requests.forEach(function (request) {
                         if (

--- a/debug_toolbar/templates/debug_toolbar/panels/history.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history.html
@@ -1,5 +1,5 @@
 {% load i18n %}{% load static %}
-<form method="post" action="{% url 'djdt:history_refresh' %}">
+<form method="get" action="{% url 'djdt:history_refresh' %}">
     {{ refresh_form }}
     <button class="refreshHistory">Refresh</button>
 </form>

--- a/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
@@ -39,7 +39,7 @@
         </div>
     </td>
     <td class="djdt-actions">
-        <form method="post" action="{% url 'djdt:history_sidebar' %}">
+        <form method="get" action="{% url 'djdt:history_sidebar' %}">
             {{ store_context.form }}
             <button data-store-id="{{ id }}" class="switchHistory">Switch</button>
         </form>

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -80,14 +80,14 @@ class HistoryViewsTestCase(IntegrationTestCase):
 
     @override_settings(DEBUG=True)
     def test_history_sidebar_invalid(self):
-        response = self.client.post(reverse("djdt:history_sidebar"))
+        response = self.client.get(reverse("djdt:history_sidebar"))
         self.assertEqual(response.status_code, 400)
 
         data = {
             "store_id": "foo",
             "hash": "invalid",
         }
-        response = self.client.post(reverse("djdt:history_sidebar"), data=data)
+        response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 400)
 
     @override_settings(DEBUG=True)
@@ -99,7 +99,7 @@ class HistoryViewsTestCase(IntegrationTestCase):
             "store_id": "foo",
             "hash": "3280d66a3cca10098a44907c5a1fd255265eed31",
         }
-        response = self.client.post(reverse("djdt:history_sidebar"), data=data)
+        response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {})
 
@@ -112,7 +112,7 @@ class HistoryViewsTestCase(IntegrationTestCase):
             "store_id": store_id,
             "hash": HistoryStoreForm.make_hash({"store_id": store_id}),
         }
-        response = self.client.post(reverse("djdt:history_sidebar"), data=data)
+        response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             set(response.json().keys()),
@@ -134,14 +134,14 @@ class HistoryViewsTestCase(IntegrationTestCase):
 
     @override_settings(DEBUG=True)
     def test_history_refresh_invalid(self):
-        response = self.client.post(reverse("djdt:history_refresh"))
+        response = self.client.get(reverse("djdt:history_refresh"))
         self.assertEqual(response.status_code, 400)
 
         data = {
             "store_id": "foo",
             "hash": "invalid",
         }
-        response = self.client.post(reverse("djdt:history_refresh"), data=data)
+        response = self.client.get(reverse("djdt:history_refresh"), data=data)
         self.assertEqual(response.status_code, 400)
 
     @override_settings(DEBUG=True)
@@ -153,7 +153,7 @@ class HistoryViewsTestCase(IntegrationTestCase):
             "store_id": "foo",
             "hash": "3280d66a3cca10098a44907c5a1fd255265eed31",
         }
-        response = self.client.post(reverse("djdt:history_refresh"), data=data)
+        response = self.client.get(reverse("djdt:history_refresh"), data=data)
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data["requests"]), 1)


### PR DESCRIPTION
The history views are safe(they do not have server-side side-effects).
Therefore, these should be GET requests. This removes the need for the
csrf_exempt decorator.

The new JavaScript function ajaxForm() is a helper that uses an HTML
form element to collect data to make a fetch() call.