### PR TITLE
Drop '--loglevel debug' from prettier command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ style: package-lock.json
 style_check: package-lock.json
 	isort -c .
 	black --target-version=py35 --check .
-	npx prettier --loglevel debug --ignore-path .gitignore --check $(PRETTIER_TARGETS)
+	npx prettier --ignore-path .gitignore --check $(PRETTIER_TARGETS)
 
 flake8:
 	flake8


### PR DESCRIPTION
The output is too verbose. The extra logging was added during
development to diagnose a problem, but as an oversight it wasn't removed
after the issue was fixed.