### PR TITLE
Prefer requestAnimationFrame() over setTimeout()

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -177,9 +177,9 @@ const djdt = {
             if (djdt.handleDragged) {
                 event.preventDefault();
                 localStorage.setItem("djdt.top", handle.offsetTop);
-                setTimeout(function () {
+                requestAnimationFrame(function () {
                     djdt.handleDragged = false;
-                }, 10);
+                });
             }
         });
         const show =


### PR DESCRIPTION
For UI changes that need to delay until the next browser repaint, using
requestAnimationFrame() is preferred over using an arbitrary short time
with setTimeout().

https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame