### PR TITLE
Simplify djToggleSwitch HTML

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -97,7 +97,9 @@ const djdt = {
             event.preventDefault();
             const self = this;
             const id = this.dataset.toggleId;
-            const open_me = this.textContent === this.dataset.toggleOpen;
+            const toggleOpen = "+";
+            const toggleClose = "-";
+            const open_me = this.textContent === toggleOpen;
             const name = this.dataset.toggleName;
             const container = this.closest(
                 ".djDebugPanelContent"
@@ -118,11 +120,11 @@ const djdt = {
                     if (open_me) {
                         e.classList.add("djSelected");
                         e.classList.remove("djUnselected");
-                        self.textContent = self.dataset.toggleClose;
+                        self.textContent = toggleClose;
                     } else {
                         e.classList.remove("djSelected");
                         e.classList.add("djUnselected");
-                        self.textContent = self.dataset.toggleOpen;
+                        self.textContent = toggleOpen;
                     }
                     const switch_ = e.querySelector(".djToggleSwitch");
                     if (switch_) {

--- a/debug_toolbar/templates/debug_toolbar/panels/cache.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/cache.html
@@ -51,7 +51,7 @@
       {% for call in calls %}
         <tr id="cacheMain_{{ forloop.counter }}">
           <td class="djdt-toggle">
-            <a class="djToggleSwitch" data-toggle-name="cacheMain" data-toggle-id="{{ forloop.counter }}" data-toggle-open="+" data-toggle-close="-" href>+</a>
+            <a class="djToggleSwitch" data-toggle-name="cacheMain" data-toggle-id="{{ forloop.counter }}" href>+</a>
           </td>
           <td>{{ call.time|floatformat:"4" }}</td>
           <td>{{ call.name|escape }}</td>

--- a/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/history_tr.html
@@ -10,7 +10,7 @@
         <p>{{ store_context.toolbar.stats.HistoryPanel.request_url|truncatechars:100|escape }}</p>
     </td>
     <td>
-        <a class="djToggleSwitch" data-toggle-name="historyMain" data-toggle-id="{{ id }}" data-toggle-open="+" data-toggle-close="-" href>+</a>
+        <a class="djToggleSwitch" data-toggle-name="historyMain" data-toggle-id="{{ id }}" href>+</a>
         <div class="djUnselected djToggleDetails_{{ id }}">
           <table>
             <colgroup>

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -16,7 +16,7 @@
         <td>
           <div style="padding-left:{{ call.indent }}px">
             {% if call.has_subfuncs %}
-              <a class="djProfileToggleDetails djToggleSwitch" data-toggle-name="profilingMain" data-toggle-id="{{ call.id }}" data-toggle-open="+" data-toggle-close="-" href>-</a>
+              <a class="djProfileToggleDetails djToggleSwitch" data-toggle-name="profilingMain" data-toggle-id="{{ call.id }}" href>-</a>
             {% else %}
               <span class="djNoToggleSwitch"></span>
             {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -34,7 +34,7 @@
         <tr class="{% if query.is_slow %} djDebugRowWarning{% endif %}" id="sqlMain_{{ forloop.counter }}">
           <td><span class="djdt-color" style="background-color:rgb({{ query.rgb_color|join:', '}})"></span></td>
           <td class="djdt-toggle">
-            <a class="djToggleSwitch" data-toggle-name="sqlMain" data-toggle-id="{{ forloop.counter }}" data-toggle-open="+" data-toggle-close="-" href="">+</a>
+            <a class="djToggleSwitch" data-toggle-name="sqlMain" data-toggle-id="{{ forloop.counter }}" href="">+</a>
           </td>
           <td class="djdt-query">
             <div class="djDebugSqlWrap">


### PR DESCRIPTION
Every instance of djToggleSwitch uses the same text to represent open &
close. Therefore, parameterizing it adds unnecessary HTML to each use. Now,
simply assume "-" and "+" will be used.

Should new uses of djToggleSwitch be added, this reduces the amount of
copy & paste necessary.