### PR TITLE
Fix "go back" button in djDebugWindow

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -21,7 +21,7 @@ const $$ = {
         }
     },
     visible: function (element) {
-        element.classList.contains("djdt-hidden");
+        return !element.classList.contains("djdt-hidden");
     },
     executeScripts: function (scripts) {
         scripts.forEach(function (script) {


### PR DESCRIPTION
Regression introduced in 344baae7bce6570b93807c078c15652aa24699bc where
the return statement in visible() mistakenly went missing.

A new Selenium test was added to help ensure the regression doesn't
return.