### PR TITLE
Remove redundant @override_settings(DEBUG=True) calls

### DIFF
--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -63,8 +63,8 @@ class HistoryPanelTestCase(BaseTestCase):
         )
 
 
+@override_settings(DEBUG=True)
 class HistoryViewsTestCase(IntegrationTestCase):
-    @override_settings(DEBUG=True)
     def test_history_panel_integration_content(self):
         """Verify the history panel's content renders properly.."""
         self.assertEqual(len(DebugToolbar._store), 0)
@@ -78,7 +78,6 @@ class HistoryViewsTestCase(IntegrationTestCase):
         content = toolbar.get_panel_by_id("HistoryPanel").content
         self.assertIn("bar", content)
 
-    @override_settings(DEBUG=True)
     def test_history_sidebar_invalid(self):
         response = self.client.get(reverse("djdt:history_sidebar"))
         self.assertEqual(response.status_code, 400)
@@ -90,7 +89,6 @@ class HistoryViewsTestCase(IntegrationTestCase):
         response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 400)
 
-    @override_settings(DEBUG=True)
     @patch("debug_toolbar.panels.history.views.DebugToolbar.fetch")
     def test_history_sidebar_hash(self, fetch):
         """Validate the hashing mechanism."""
@@ -103,7 +101,6 @@ class HistoryViewsTestCase(IntegrationTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {})
 
-    @override_settings(DEBUG=True)
     def test_history_sidebar(self):
         """Validate the history sidebar view."""
         self.client.get("/json_view/")
@@ -132,7 +129,6 @@ class HistoryViewsTestCase(IntegrationTestCase):
             },
         )
 
-    @override_settings(DEBUG=True)
     def test_history_refresh_invalid(self):
         response = self.client.get(reverse("djdt:history_refresh"))
         self.assertEqual(response.status_code, 400)
@@ -144,7 +140,6 @@ class HistoryViewsTestCase(IntegrationTestCase):
         response = self.client.get(reverse("djdt:history_refresh"), data=data)
         self.assertEqual(response.status_code, 400)
 
-    @override_settings(DEBUG=True)
     def test_history_refresh(self):
         """Verify refresh history response has request variables."""
         data = {"foo": "bar"}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -404,7 +404,6 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         self.assertIn("Data for this panel isn't available anymore.", error.text)
 
     @override_settings(
-        DEBUG=True,
         TEMPLATES=[
             {
                 "BACKEND": "django.template.backends.django.DjangoTemplates",


### PR DESCRIPTION
When the class is already decorated with @override_settings(DEBUG=True)
methods don't need to re-specify it.

When every method of a class is decorated with
@override_settings(DEBUG=True), can simplify by moving the decorator to
the class.