### PR TITLE
Remove unused DOM classes from table elements

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -444,10 +444,6 @@
     text-align: left;
 }
 
-#djDebug .djSqlExplain td {
-    white-space: pre;
-}
-
 #djDebug span.djDebugLineChart {
     background-color: #777;
     height: 3px;

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_explain.html
@@ -13,7 +13,7 @@
       <dt>{% trans "Database" %}</dt>
       <dd>{{ alias }}</dd>
     </dl>
-    <table class="djSqlExplain">
+    <table>
       <thead>
         <tr>
           {% for h in headers %}
@@ -25,7 +25,7 @@
         {% for row in result %}
           <tr>
             {% for column in row %}
-              <td>{{ column|escape }}</td>
+              <td>{% if forloop.last %}<code>{% endif %}{{ column|escape }}{% if forloop.last %}</code>{% endif %}</td>
             {% endfor %}
           </tr>
         {% endfor %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_profile.html
@@ -14,7 +14,7 @@
         <dt>{% trans "Database" %}</dt>
         <dd>{{ alias }}</dd>
       </dl>
-      <table class="djSqlProfile">
+      <table>
         <thead>
           <tr>
             {% for h in headers %}

--- a/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_select.html
@@ -14,7 +14,7 @@
       <dd>{{ alias }}</dd>
     </dl>
     {% if result %}
-      <table class="djSqlSelect">
+      <table>
         <thead>
           <tr>
             {% for h in headers %}


### PR DESCRIPTION
The class djSqlExplain was used for a small amount of CSS, this has been
replaced by using a "code" element, which better fits the data being
displayed and doesn't require a one-off DOM classes.