### PR TITLE
Display all fetch() errors in ajax()

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -36,21 +36,24 @@ const $$ = {
 
 function ajax(url, init) {
     init = Object.assign({ credentials: "same-origin" }, init);
-    return fetch(url, init).then(function (response) {
-        if (response.ok) {
-            return response.json();
-        } else {
+    return fetch(url, init)
+        .then(function (response) {
+            if (response.ok) {
+                return response.json();
+            }
+            return Promise.reject(
+                new Error(response.status + ": " + response.statusText)
+            );
+        })
+        .catch(function (error) {
             const win = document.querySelector("#djDebugWindow");
             win.innerHTML =
                 '<div class="djDebugPanelTitle"><a class="djDebugClose" href="">»</a><h3>' +
-                response.status +
-                ": " +
-                response.statusText +
+                error.message +
                 "</h3></div>";
             $$.show(win);
-            return Promise.reject();
-        }
-    });
+            throw error;
+        });
 }
 
 function ajaxForm(element) {


### PR DESCRIPTION
Previously, only successful requests with non-200 responses would
display as an error. But fetch() can fail for other reasons too. For
example, if the network connection is lost, fetch() fails with:

    TypeError: NetworkError when attempting to fetch resource.

This is now displayed rather than showing the spinner indefinitely.

The error is re-thrown in JavaScript so it displays in the JavaScript
console and can interact with the browser's developer tools.