### PR TITLE
Touch package-lock.json to avoid unnecessary rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ eslint: package-lock.json
 
 package-lock.json: package.json
 	npm install
+	touch $@
 
 test:
 	DJANGO_SETTINGS_MODULE=tests.settings \


### PR DESCRIPTION
When the command "npm install" takes no action, the file
package-lock.json is not modified. This means its timestamp remains the
same. Make uses timestamps to decide when something needs to be rebuilt
so if the timestamp isn't updated, Make may try to rebuild the file next
invocation.

For example:

    make style  # package-lock.json builds (good)
    make style  # package-lock.json doesn't rebuild (good)
    touch package.json
    make style  # package-lock.json rebuilds (good)
    make style  # package-lock.json rebuilds (bad)

The fourth call to "make style" should not run npm.