### PR TITLE
Simplify SQL HTML and CSS

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -413,10 +413,6 @@
     border-radius: 3px;
 }
 
-#djDebug .djDebugSqlWrap {
-    position: relative;
-}
-
 #djDebug .djDebugCollapsed {
     color: #333;
 }
@@ -434,8 +430,7 @@
 }
 
 #djDebug .djDebugSql {
-    word-break: break-word;
-    z-index: 100000002;
+    overflow-wrap: anywhere;
 }
 
 #djDebug .djSQLDetailsDiv tbody th {

--- a/debug_toolbar/templates/debug_toolbar/panels/sql.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql.html
@@ -37,9 +37,7 @@
             <button type="button" class="djToggleSwitch" data-toggle-name="sqlMain" data-toggle-id="{{ forloop.counter }}">+</button>
           </td>
           <td class="djdt-query">
-            <div class="djDebugSqlWrap">
-              <div class="djDebugSql">{{ query.sql|safe }}</div>
-            </div>
+            <div class="djDebugSql">{{ query.sql|safe }}</div>
             {% if query.similar_count %}
               <strong>
                 <span class="djdt-color" style="background-color:{{ query.similar_color }}"></span>


### PR DESCRIPTION
Remove ineffective z-index. Using the Firefox developer tools reports:

    z-index has no effect on this element as it's not a positional element.

Per MDN (https://developer.mozilla.org/en-US/docs/Web/CSS/word-break)
using "word-break: break-word" is deprecated. Replace usage with
"overflow-wrap: anywhere".

This allows removing some CSS and one div element.