### PR TITLE
Move eslint/flake8 to style/style_check make targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache: pip
 matrix:
   fast_finish: true
   include:
-    - env: TOXENV=eslint
-    - env: TOXENV=flake8
     - env: TOXENV=style
     - env: TOXENV=readme
     - python: 3.5

--- a/Makefile
+++ b/Makefile
@@ -6,24 +6,21 @@ style: package-lock.json
 	isort .
 	black --target-version=py35 .
 	flake8
+	npx eslint --ignore-path .gitignore --fix .
 	npx prettier --ignore-path .gitignore --write $(PRETTIER_TARGETS)
 
 style_check: package-lock.json
 	isort -c .
 	black --target-version=py35 --check .
-	npx prettier --ignore-path .gitignore --check $(PRETTIER_TARGETS)
-
-flake8:
 	flake8
+	npx eslint --ignore-path .gitignore .
+	npx prettier --ignore-path .gitignore --check $(PRETTIER_TARGETS)
 
 example:
 	python example/manage.py migrate --noinput
 	-DJANGO_SUPERUSER_PASSWORD=p python example/manage.py createsuperuser \
 		--noinput --username="$(USER)" --email="$(USER)@mailinator.com"
 	python example/manage.py runserver
-
-eslint: package-lock.json
-	npx eslint --ignore-path .gitignore .
 
 package-lock.json: package.json
 	npm install

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
 envlist =
-    eslint
-    flake8
     style
     readme
     py{35,36,37,38}-dj22-sqlite
@@ -35,23 +33,13 @@ whitelist_externals = make
 pip_pre = True
 commands = make coverage TEST_ARGS='{posargs:tests}'
 
-[testenv:flake8]
-basepython = python3
-commands = make flake8
-deps = flake8
-skip_install = true
-
 [testenv:style]
 basepython = python3
 commands = make style_check
 deps =
     black>=19.10b0
+    flake8
     isort>=5.0.2
-skip_install = true
-
-[testenv:eslint]
-commands = make eslint
-deps =
 skip_install = true
 
 [testenv:readme]


### PR DESCRIPTION
This makes it more likely to for contributors to catch errors alongside
style errors before hitting CI servers. Developers need only run one
make target rather than several.