### PR TITLE
Move repetitive HTML in request.html to include-able template

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/request.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request.html
@@ -22,104 +22,28 @@
 
 {% if cookies %}
   <h4>{% trans "Cookies" %}</h4>
-  <table>
-    <colgroup>
-      <col class="djdt-width-20">
-      <col>
-    </colgroup>
-    <thead>
-      <tr>
-        <th>{% trans "Variable" %}</th>
-        <th>{% trans "Value" %}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for key, value in cookies %}
-        <tr>
-          <td><code>{{ key|pprint }}</code></td>
-          <td><code>{{ value|pprint }}</code></td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  {% include 'debug_toolbar/panels/request_variables.html' with variables=cookies %}
 {% else %}
   <h4>{% trans "No cookies" %}</h4>
 {% endif %}
 
 {% if session %}
   <h4>{% trans "Session data" %}</h4>
-  <table>
-    <colgroup>
-      <col class="djdt-width-20">
-      <col>
-    </colgroup>
-    <thead>
-      <tr>
-        <th>{% trans "Variable" %}</th>
-        <th>{% trans "Value" %}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for key, value in session %}
-        <tr>
-          <td><code>{{ key|pprint }}</code></td>
-          <td><code>{{ value|pprint }}</code></td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  {% include 'debug_toolbar/panels/request_variables.html' with variables=session %}
 {% else %}
   <h4>{% trans "No session data" %}</h4>
 {% endif %}
 
 {% if get %}
   <h4>{% trans "GET data" %}</h4>
-  <table>
-    <colgroup>
-      <col class="djdt-width-20">
-      <col>
-    </colgroup>
-    <thead>
-      <tr>
-        <th>{% trans "Variable" %}</th>
-        <th>{% trans "Value" %}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for key, value in get %}
-        <tr>
-          <td><code>{{ key|pprint }}</code></td>
-          <td><code>{{ value|pprint }}</code></td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  {% include 'debug_toolbar/panels/request_variables.html' with variables=get %}
 {% else %}
   <h4>{% trans "No GET data" %}</h4>
 {% endif %}
 
 {% if post %}
   <h4>{% trans "POST data" %}</h4>
-  <table>
-    <colgroup>
-      <col class="djdt-width-20">
-      <col>
-    </colgroup>
-    <thead>
-      <tr>
-        <th>{% trans "Variable" %}</th>
-        <th>{% trans "Value" %}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for key, value in post %}
-        <tr class="{% cycle 'row1' 'row2' %}">
-          <td><code>{{ key|pprint }}</code></td>
-          <td><code>{{ value|pprint }}</code></td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  {% include 'debug_toolbar/panels/request_variables.html' with variables=post %}
 {% else %}
   <h4>{% trans "No POST data" %}</h4>
 {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/request_variables.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/request_variables.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+
+<table>
+  <colgroup>
+    <col class="djdt-width-20">
+    <col>
+  </colgroup>
+  <thead>
+    <tr>
+      <th>{% trans "Variable" %}</th>
+      <th>{% trans "Value" %}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for key, value in variables %}
+      <tr>
+        <td><code>{{ key|pprint }}</code></td>
+        <td><code>{{ value|pprint }}</code></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>


### PR DESCRIPTION
The two column table used to display key/value data structures was
repeated several times. To ensure these tables always remain in sync,
move to a common reusable template.

The POST table was missed when these were altered in
d45808fedcfd9d760050f87347e78dc9cb5108cb, which helps show how factoring
out the common HTML helps future maintenance.