### PR TITLE
Prefer String.includes() over String.indexOf()

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -240,7 +240,7 @@ const djdt = {
     },
     cookie: {
         get: function (key) {
-            if (document.cookie.indexOf(key) === -1) {
+            if (!document.cookie.includes(key)) {
                 return null;
             }
 


### PR DESCRIPTION
For simple inclusion checks, String.includes() is more explicit and
reads a little bit nicer.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes