### PR TITLE
Remove unnecessary guard in refresh history callback

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -29,16 +29,12 @@ $$.on(djDebug, "click", ".refreshHistory", function (event) {
     event.preventDefault();
     const container = djDebug.querySelector("#djdtHistoryRequests");
     ajaxForm(this).then(function (data) {
-        if (data.requests.constructor === Array) {
-            data.requests.forEach(function (request) {
-                if (
-                    !container.querySelector(
-                        '[data-store-id="' + request.id + '"]'
-                    )
-                ) {
-                    container.innerHTML = request.content + container.innerHTML;
-                }
-            });
-        }
+        data.requests.forEach(function (request) {
+            if (
+                !container.querySelector('[data-store-id="' + request.id + '"]')
+            ) {
+                container.innerHTML = request.content + container.innerHTML;
+            }
+        });
     });
 });


### PR DESCRIPTION
The function ajaxForm() rejects the fetch promise when the response is
not a 200, so we can assume that if the code is being executed a 200 was
returned.

In the event a 200 is returned, the requests attribute is always a
JavaScript Array.