### PR TITLE
Prefer document.getElementById() for simply ID lookups

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -15,10 +15,10 @@ $$.on(djDebug, "click", ".switchHistory", function (event) {
     ajaxForm(this).then(function (data) {
         djDebug.setAttribute("data-store-id", newStoreId);
         Object.keys(data).forEach(function (panelId) {
-            if (djDebug.querySelector("#" + panelId)) {
-                djDebug.querySelector("#" + panelId).outerHTML =
-                    data[panelId].content;
-                djDebug.querySelector("#djdt-" + panelId).outerHTML =
+            const panel = document.getElementById(panelId);
+            if (panel) {
+                panel.outerHTML = data[panelId].content;
+                document.getElementById("djdt-" + panelId).outerHTML =
                     data[panelId].button;
             }
         });
@@ -27,7 +27,7 @@ $$.on(djDebug, "click", ".switchHistory", function (event) {
 
 $$.on(djDebug, "click", ".refreshHistory", function (event) {
     event.preventDefault();
-    const container = djDebug.querySelector("#djdtHistoryRequests");
+    const container = document.getElementById("djdtHistoryRequests");
     ajaxForm(this).then(function (data) {
         data.requests.forEach(function (request) {
             if (

--- a/debug_toolbar/static/debug_toolbar/js/timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/timer.js
@@ -12,7 +12,7 @@ function getCSSWidth(stat, endStat) {
     width = (100.0 * width) / (100.0 - getLeft(stat));
     return width < 1 ? "2px" : width + "%";
 }
-function addRow(stat, endStat) {
+function addRow(tbody, stat, endStat) {
     const row = document.createElement("tr");
     if (endStat) {
         // Render a start through end bar
@@ -43,16 +43,17 @@ function addRow(stat, endStat) {
         row.querySelector("rect").setAttribute("width", 2);
     }
     row.querySelector("rect").setAttribute("x", getLeft(stat));
-    document.querySelector("#djDebugBrowserTimingTableBody").appendChild(row);
+    tbody.appendChild(row);
 }
 
+const tbody = document.getElementById("djDebugBrowserTimingTableBody");
 // This is a reasonably complete and ordered set of timing periods (2 params) and events (1 param)
-addRow("domainLookupStart", "domainLookupEnd");
-addRow("connectStart", "connectEnd");
-addRow("requestStart", "responseEnd"); // There is no requestEnd
-addRow("responseStart", "responseEnd");
-addRow("domLoading", "domComplete"); // Spans the events below
-addRow("domInteractive");
-addRow("domContentLoadedEventStart", "domContentLoadedEventEnd");
-addRow("loadEventStart", "loadEventEnd");
-document.querySelector("#djDebugBrowserTiming").classList.remove("djdt-hidden");
+addRow(tbody, "domainLookupStart", "domainLookupEnd");
+addRow(tbody, "connectStart", "connectEnd");
+addRow(tbody, "requestStart", "responseEnd"); // There is no requestEnd
+addRow(tbody, "responseStart", "responseEnd");
+addRow(tbody, "domLoading", "domComplete"); // Spans the events below
+addRow(tbody, "domInteractive");
+addRow(tbody, "domContentLoadedEventStart", "domContentLoadedEventEnd");
+addRow(tbody, "loadEventStart", "loadEventEnd");
+document.getElementById("djDebugBrowserTiming").classList.remove("djdt-hidden");

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -9,10 +9,10 @@ function onKeyDown(event) {
 const djdt = {
     handleDragged: false,
     init() {
-        const djDebug = document.querySelector("#djDebug");
+        const djDebug = document.getElementById("djDebug");
         $$.show(djDebug);
         $$.on(
-            djDebug.querySelector("#djDebugPanelList"),
+            document.getElementById("djDebugPanelList"),
             "click",
             "li a",
             function (event) {
@@ -20,7 +20,7 @@ const djdt = {
                 if (!this.className) {
                     return;
                 }
-                const current = djDebug.querySelector("#" + this.className);
+                const current = document.getElementById(this.className);
                 if ($$.visible(current)) {
                     djdt.hide_panels();
                 } else {
@@ -85,7 +85,7 @@ const djdt = {
             }
 
             ajax(url, ajax_data).then(function (data) {
-                const win = djDebug.querySelector("#djDebugWindow");
+                const win = document.getElementById("djDebugWindow");
                 win.innerHTML = data.content;
                 $$.show(win);
             });
@@ -98,9 +98,7 @@ const djdt = {
             const toggleClose = "-";
             const open_me = this.textContent === toggleOpen;
             const name = this.dataset.toggleName;
-            const container = this.closest(
-                ".djDebugPanelContent"
-            ).querySelector("#" + name + "_" + id);
+            const container = document.getElementById(name + "_" + id);
             container
                 .querySelectorAll(".djDebugCollapsed")
                 .forEach(function (e) {
@@ -131,21 +129,21 @@ const djdt = {
                 });
         });
 
-        djDebug
-            .querySelector("#djHideToolBarButton")
+        document
+            .getElementById("djHideToolBarButton")
             .addEventListener("click", function (event) {
                 event.preventDefault();
                 djdt.hide_toolbar(true);
             });
-        djDebug
-            .querySelector("#djShowToolBarButton")
+        document
+            .getElementById("djShowToolBarButton")
             .addEventListener("click", function () {
                 if (!djdt.handleDragged) {
                     djdt.show_toolbar();
                 }
             });
         let startPageY, baseY;
-        const handle = document.querySelector("#djDebugToolbarHandle");
+        const handle = document.getElementById("djDebugToolbarHandle");
         function onHandleMove(event) {
             // Chrome can send spurious mousemove events, so don't do anything unless the
             // cursor really moved.  Otherwise, it will be impossible to expand the toolbar
@@ -163,8 +161,8 @@ const djdt = {
                 djdt.handleDragged = true;
             }
         }
-        djDebug
-            .querySelector("#djShowToolBarButton")
+        document
+            .getElementById("djShowToolBarButton")
             .addEventListener("mousedown", function (event) {
                 event.preventDefault();
                 startPageY = event.pageY;
@@ -191,21 +189,20 @@ const djdt = {
     },
     hide_panels() {
         const djDebug = document.getElementById("djDebug");
-        $$.hide(djDebug.querySelector("#djDebugWindow"));
+        $$.hide(document.getElementById("djDebugWindow"));
         djDebug.querySelectorAll(".djdt-panelContent").forEach(function (e) {
             $$.hide(e);
         });
-        djDebug.querySelectorAll("#djDebugToolbar li").forEach(function (e) {
+        document.querySelectorAll("#djDebugToolbar li").forEach(function (e) {
             e.classList.remove("djdt-active");
         });
     },
     hide_toolbar() {
         djdt.hide_panels();
 
-        const djDebug = document.getElementById("djDebug");
-        $$.hide(djDebug.querySelector("#djDebugToolbar"));
+        $$.hide(document.getElementById("djDebugToolbar"));
 
-        const handle = document.querySelector("#djDebugToolbarHandle");
+        const handle = document.getElementById("djDebugToolbarHandle");
         $$.show(handle);
         // set handle position
         let handleTop = localStorage.getItem("djdt.top");
@@ -222,20 +219,22 @@ const djdt = {
         localStorage.setItem("djdt.show", "false");
     },
     hide_one_level() {
-        const djDebug = document.getElementById("djDebug");
-        if ($$.visible(djDebug.querySelector("#djDebugWindow"))) {
-            $$.hide(djDebug.querySelector("#djDebugWindow"));
-        } else if (djDebug.querySelector("#djDebugToolbar li.djdt-active")) {
-            djdt.hide_panels();
+        const win = document.getElementById("djDebugWindow");
+        if ($$.visible(win)) {
+            $$.hide(win);
         } else {
-            djdt.hide_toolbar(true);
+            const toolbar = document.getElementById("djDebugToolbar");
+            if (toolbar.querySelector("li.djdt-active")) {
+                djdt.hide_panels();
+            } else {
+                djdt.hide_toolbar(true);
+            }
         }
     },
     show_toolbar() {
         document.addEventListener("keydown", onKeyDown);
-        const djDebug = document.getElementById("djDebug");
-        $$.hide(djDebug.querySelector("#djDebugToolbarHandle"));
-        $$.show(djDebug.querySelector("#djDebugToolbar"));
+        $$.hide(document.getElementById("djDebugToolbarHandle"));
+        $$.show(document.getElementById("djDebugToolbar"));
         localStorage.setItem("djdt.show", "true");
     },
     cookie: {

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -46,7 +46,7 @@ function ajax(url, init) {
             );
         })
         .catch(function (error) {
-            const win = document.querySelector("#djDebugWindow");
+            const win = document.getElementById("djDebugWindow");
             win.innerHTML =
                 '<div class="djDebugPanelTitle"><button type="button" class="djDebugClose">»</button><h3>' +
                 error.message +


### PR DESCRIPTION
document.getElementById() is highly optimized by all browsers. There is
no need to introduce selector parsing when the ID is already known.

Further, DOM IDs must be unique. There is no advantage to querying an ID
as a descendant of another element. Using document.getElementId() will
always return a unique element if it exists. By removing the
intermediate ancestor, there are fewer lookups to do.