### PR TITLE
Handle non-string template variables in TemplatesPanel

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -88,10 +88,9 @@ class TemplatesPanel(Panel):
         for context_layer in context.dicts:
             if hasattr(context_layer, "items") and context_layer:
                 # Check if the layer is in the cache.
-                key_values = sorted(context_layer.items())
                 pformatted = None
-                for _key_values, _pformatted in self.pformat_layers:
-                    if _key_values == key_values:
+                for key_values, _pformatted in self.pformat_layers:
+                    if key_values == context_layer:
                         pformatted = _pformatted
                         break
 
@@ -133,7 +132,7 @@ class TemplatesPanel(Panel):
                             finally:
                                 recording(True)
                     pformatted = pformat(temp_layer)
-                    self.pformat_layers.append((key_values, pformatted))
+                    self.pformat_layers.append((context_layer, pformatted))
                 context_list.append(pformatted)
 
         kwargs["context"] = context_list

--- a/tests/templates/registration/login.html
+++ b/tests/templates/registration/login.html
@@ -1,0 +1,1 @@
+{% extends 'base.html' %}

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.views import LoginView
 from django.urls import include, path, re_path
 
 import debug_toolbar
@@ -20,5 +21,6 @@ urlpatterns = [
     path("cached_view/", views.cached_view),
     path("json_view/", views.json_view),
     path("redirect/", views.redirect_view),
+    path("login_without_redirect/", LoginView.as_view(redirect_field_name=None)),
     path("__debug__/", include(debug_toolbar.urls)),
 ]


### PR DESCRIPTION
Don't need to sort the context layers are dict objects are comparable.

Fixes #1317