### PR TITLE
Update Signal panel description in the docs

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -90,7 +90,7 @@ Signal
 
 Path: ``debug_toolbar.panels.signals.SignalsPanel``
 
-List of signals, their args and receivers.
+List of signals and receivers.
 
 Logging
 ~~~~~~~


### PR DESCRIPTION
Since fb7c000ef4d8785084817f95754b93fca7bdc07c the panel no longer
displays args (as they were deprecated upstream).