### PR TITLE
Capitalize "Unicode" in code, comments, and docs

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -99,7 +99,7 @@ class TemplatesPanel(Panel):
                     temp_layer = {}
                     for key, value in context_layer.items():
                         # Replace any request elements - they have a large
-                        # unicode representation and the request data is
+                        # Unicode representation and the request data is
                         # already made available from the Request panel.
                         if isinstance(value, http.HttpRequest):
                             temp_layer[key] = "<<request>>"
@@ -125,7 +125,7 @@ class TemplatesPanel(Panel):
                             except SQLQueryTriggered:
                                 temp_layer[key] = "<<triggers database query>>"
                             except UnicodeEncodeError:
-                                temp_layer[key] = "<<unicode encode error>>"
+                                temp_layer[key] = "<<Unicode encode error>>"
                             except Exception:
                                 temp_layer[key] = "<<unhandled exception>>"
                             else:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -153,7 +153,7 @@ The following deprecated settings have been removed:
 * Convert system check errors to warnings to accommodate exotic
   configurations.
 * Fixed a crash when explaining raw querysets.
-* Fixed an obscure unicode error with binary data fields.
+* Fixed an obscure Unicode error with binary data fields.
 * Added MariaDB and Python 3.7 builds to the CI.
 
 1.10.1 (2018-09-11)


### PR DESCRIPTION
It is a proper noun.