### PR TITLE
Remove unused positional argument to hide_toolbar()

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -133,7 +133,7 @@ const djdt = {
             .getElementById("djHideToolBarButton")
             .addEventListener("click", function (event) {
                 event.preventDefault();
-                djdt.hide_toolbar(true);
+                djdt.hide_toolbar();
             });
         document
             .getElementById("djShowToolBarButton")
@@ -227,7 +227,7 @@ const djdt = {
             if (toolbar.querySelector("li.djdt-active")) {
                 djdt.hide_panels();
             } else {
-                djdt.hide_toolbar(true);
+                djdt.hide_toolbar();
             }
         }
     },


### PR DESCRIPTION
hide_toolbar() does not take any arguments since
6d16e0886833dfe4b0e39b3c70e948befaa071a5.