### PR TITLE
Correct docstring for Panel.enable_instrumentation()

### DIFF
--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -131,8 +131,7 @@ class Panel:
         time.
 
         Unless the toolbar or this panel is disabled, this method will be
-        called early in :class:`DebugToolbarMiddleware.process_request`. It
-        should be idempotent.
+        called early in ``DebugToolbarMiddleware``. It should be idempotent.
         """
 
     def disable_instrumentation(self):


### PR DESCRIPTION
Since 5299cf826284b6e082c5f18050e4f706faa81c39 the method
DebugToolbarMiddleware.process_request() does not exist.

Also drop the Sphinx :class: directive as DebugToolbarMiddleware doesn't
have a definition in docs.