### PR TITLE
Make doc warnings into errors to help ensure robust docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -n
+SPHINXOPTS    ?= -n -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,10 +16,10 @@ Change log
 * Started running Selenium tests on Travis CI.
 * Added a system check which prevents using django-debug-toolbar without
   any enabled panels.
-* Added  :func:`Panel.run_checks <debug_toolbar.panels.Panel.run_checks>`
-  for panels to verify the configuration before the application starts.
+* Added :meth:`Panel.run_checks() <debug_toolbar.panels.Panel.run_checks>` for
+  panels to verify the configuration before the application starts.
 * Validate the static file paths specified in ``STATICFILES_DIRS``
-  exist via :class:`StaticFilesPanel <debug_toolbar.panels.staticfiles.StaticFilesPanel>`
+  exist via :class:`~debug_toolbar.panels.staticfiles.StaticFilesPanel`
 * Introduced `prettier <https://prettier.io/>`__ to format the frontend
   code.
 * Started accessing history views using GET requests since they do not
@@ -62,7 +62,8 @@ Change log
   ``localStorage``.
 * Updated the code to avoid a few deprecation warnings and resource warnings.
 * Started loading JavaScript as ES6 modules.
-* Added support for ``cache.touch()`` when using django-debug-toolbar.
+* Added support for :meth:`cache.touch() <django.core.caches.cache.touch>` when
+  using django-debug-toolbar.
 * Eliminated more inline CSS.
 * Updated ``tox.ini`` and ``Makefile`` to use isort>=5.
 * Increased RESULTS_CACHE_SIZE to 25 to better support AJAX requests.
@@ -70,7 +71,8 @@ Change log
   ``box-sizing`` property.
 * Simplified the ``isort`` configuration by taking advantage of isort's
   ``black`` profile.
-* Added HistoryPanel including support for AJAX requests.
+* Added :class:`~debug_toolbar.panels.history.HistoryPanel` including support
+  for AJAX requests.
 
 **Backwards incompatible changes**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -105,10 +107,13 @@ Change log
 2.0 (2019-06-20)
 ----------------
 
-* Updated ``StaticFilesPanel`` to be compatible with Django 3.0.
-* The ``ProfilingPanel`` is now enabled but inactive by default.
+* Updated :class:`~debug_toolbar.panels.staticfiles.StaticFilesPanel` to be
+  compatible with Django 3.0.
+* The :class:`~debug_toolbar.panels.profiling.ProfilingPanel` is now enabled
+  but inactive by default.
 * Fixed toggling of table rows in the profiling panel UI.
-* The ``ProfilingPanel`` no longer skips remaining panels or middlewares.
+* The :class:`~debug_toolbar.panels.profiling.ProfilingPanel` no longer skips
+  remaining panels or middlewares.
 * Improved the installation documentation.
 * Fixed a possible crash in the template panel.
 * Added support for psycopg2 ``Composed`` objects.
@@ -120,17 +125,19 @@ Change log
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Removed support for Python 2.
 * Removed support for Django's deprecated ``MIDDLEWARE_CLASSES`` setting.
-* Restructured ``Panel`` to execute more like the new-style Django MIDDLEWARE.
-  The ``Panel.__init__()`` method is now passed ``get_response`` as the first
-  positional argument. The ``Panel.process_request()`` method must now always
+* Restructured :class:`debug_toolbar.panels.Panel` to execute more like the
+  new-style Django MIDDLEWARE. The ``Panel.__init__()`` method is now passed
+  ``get_response`` as the first positional argument. The
+  :meth:`debug_toolbar.panels.Panel.process_request` method must now always
   return a response. Usually this is the response returned by
   ``get_response()`` but the panel may also return a different response as is
-  the case in the ``RedirectsPanel``. Third party panels must adjust to this
-  new architecture. ``Panel.process_response()`` and ``Panel.process_view()``
-  have been removed as a result of this change.
+  the case in the :class:`~debug_toolbar.panels.redirects.RedirectsPanel`.
+  Third party panels must adjust to this new architecture.
+  ``Panel.process_response()`` and ``Panel.process_view()`` have been removed
+  as a result of this change.
 
 The deprecated API, ``debug_toolbar.panels.DebugPanel``, has been removed.
-Third party panels should use ``debug_toolbar.panels.Panel`` instead.
+Third party panels should use :class:`debug_toolbar.panels.Panel` instead.
 
 The following deprecated settings have been removed:
 

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -322,7 +322,7 @@ Panels can ship their own templates, static files and views. All views should
 be decorated with ``debug_toolbar.decorators.require_show_toolbar`` to prevent
 unauthorized access. There is no public CSS API at this time.
 
-.. autoclass:: debug_toolbar.panels.Panel(*args, **kwargs)
+.. autoclass:: debug_toolbar.panels.Panel
 
     .. autoattribute:: debug_toolbar.panels.Panel.nav_title
 
@@ -366,13 +366,13 @@ common methods available.
 
     Closes the topmost level (window/panel/toolbar)
 
-.. js:function:: djdt.cookie.get
+.. js:function:: djdt.cookie.get(key)
 
     This is a helper function to fetch values stored in the cookies.
 
     :param key: The key for the value to be fetched.
 
-.. js:function:: djdt.cookie.set
+.. js:function:: djdt.cookie.set(key, value, options)
 
     This is a helper function to set a value stored in the cookies.
 

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -12,7 +12,7 @@ The following panels are enabled by default.
 History
 ~~~~~~~
 
-Path: ``debug_toolbar.panels.history.HistoryPanel``
+.. class:: debug_toolbar.panels.history.HistoryPanel
 
 This panel shows the history of requests made and allows switching to a past
 snapshot of the toolbar to view that request's stats.
@@ -20,28 +20,28 @@ snapshot of the toolbar to view that request's stats.
 Version
 ~~~~~~~
 
-Path: ``debug_toolbar.panels.versions.VersionsPanel``
+.. class:: debug_toolbar.panels.versions.VersionsPanel
 
 Shows versions of Python, Django, and installed apps if possible.
 
 Timer
 ~~~~~
 
-Path: ``debug_toolbar.panels.timer.TimerPanel``
+.. class:: debug_toolbar.panels.timer.TimerPanel
 
 Request timer.
 
 Settings
 ~~~~~~~~
 
-Path: ``debug_toolbar.panels.settings.SettingsPanel``
+.. class:: debug_toolbar.panels.settings.SettingsPanel
 
 A list of settings in settings.py.
 
 Headers
 ~~~~~~~
 
-Path: ``debug_toolbar.panels.headers.HeadersPanel``
+.. class:: debug_toolbar.panels.headers.HeadersPanel
 
 This panels shows the HTTP request and response headers, as well as a
 selection of values from the WSGI environment.
@@ -53,56 +53,56 @@ also add response headers such as ``Date`` and ``Server``.
 Request
 ~~~~~~~
 
-Path: ``debug_toolbar.panels.request.RequestPanel``
+.. class:: debug_toolbar.panels.request.RequestPanel
 
 GET/POST/cookie/session variable display.
 
 SQL
 ~~~
 
-Path: ``debug_toolbar.panels.sql.SQLPanel``
+.. class:: debug_toolbar.panels.sql.SQLPanel
 
 SQL queries including time to execute and links to EXPLAIN each query.
 
 Template
 ~~~~~~~~
 
-Path: ``debug_toolbar.panels.templates.TemplatesPanel``
+.. class:: debug_toolbar.panels.templates.TemplatesPanel
 
 Templates and context used, and their template paths.
 
 Static files
 ~~~~~~~~~~~~
 
-Path: ``debug_toolbar.panels.staticfiles.StaticFilesPanel``
+.. class:: debug_toolbar.panels.staticfiles.StaticFilesPanel
 
 Used static files and their locations (via the ``staticfiles`` finders).
 
 Cache
 ~~~~~
 
-Path: ``debug_toolbar.panels.cache.CachePanel``
+.. class:: debug_toolbar.panels.cache.CachePanel
 
 Cache queries. Is incompatible with Django's per-site caching.
 
 Signal
 ~~~~~~
 
-Path: ``debug_toolbar.panels.signals.SignalsPanel``
+.. class:: debug_toolbar.panels.signals.SignalsPanel
 
 List of signals and receivers.
 
 Logging
 ~~~~~~~
 
-Path: ``debug_toolbar.panels.logging.LoggingPanel``
+.. class:: debug_toolbar.panels.logging.LoggingPanel
 
 Logging output via Python's built-in :mod:`logging` module.
 
 Redirects
 ~~~~~~~~~
 
-Path: ``debug_toolbar.panels.redirects.RedirectsPanel``
+.. class:: debug_toolbar.panels.redirects.RedirectsPanel
 
 When this panel is enabled, the debug toolbar will show an intermediate page
 upon redirect so you can view any debug information prior to redirecting. This
@@ -118,7 +118,7 @@ the ``DISABLE_PANELS`` configuration option.
 Profiling
 ~~~~~~~~~
 
-Path: ``debug_toolbar.panels.profiling.ProfilingPanel``
+.. class:: debug_toolbar.panels.profiling.ProfilingPanel
 
 Profiling information for the processing of the request.
 
@@ -370,18 +370,18 @@ common methods available.
 
     This is a helper function to fetch values stored in the cookies.
 
-    :param string key: The key for the value to be fetched.
+    :param key: The key for the value to be fetched.
 
 .. js:function:: djdt.cookie.set
 
     This is a helper function to set a value stored in the cookies.
 
-    :param string key: The key to be used.
+    :param key: The key to be used.
 
-    :param string value: The value to be set.
+    :param value: The value to be set.
 
-    :param Object options: The options for the value to be set. It should contain
-        the properties ``expires`` and ``path``.
+    :param options: The options for the value to be set. It should contain the
+        properties ``expires`` and ``path``.
 
 .. js:function:: djdt.hide_toolbar
 


### PR DESCRIPTION
Pass the Sphinx command line option -W to make warnings into errors. All
existing warnings/errors have been fixed.

Panels now use the Sphinx :class: directive to allow interlinking to
them (e.g. from changes.rst).

Removed unknown references to JavaScript types. Fixes the warning:

    WARNING: js:func reference target not found: String

The types are somewhat intuitive anyway given the available context
clues.

In addition, improve docs through additional linking and descriptions

Now that Panels can be easily linked, do so throughout changes.rst.

Improve JavaScript argument documentation by listing them inline.
