### PR TITLE
Added missing signals to panel by default.

### DIFF
--- a/debug_toolbar/panels/signals.py
+++ b/debug_toolbar/panels/signals.py
@@ -1,15 +1,22 @@
 import weakref
 
-from django.core.signals import got_request_exception, request_finished, request_started
+from django.core.signals import (
+    got_request_exception,
+    request_finished,
+    request_started,
+    setting_changed,
+)
 from django.db.backends.signals import connection_created
 from django.db.models.signals import (
     class_prepared,
+    m2m_changed,
     post_delete,
     post_init,
     post_migrate,
     post_save,
     pre_delete,
     pre_init,
+    pre_migrate,
     pre_save,
 )
 from django.utils.module_loading import import_string
@@ -33,7 +40,10 @@ class SignalsPanel(Panel):
         "post_save": post_save,
         "pre_delete": pre_delete,
         "post_delete": post_delete,
+        "m2m_changed": m2m_changed,
+        "pre_migrate": pre_migrate,
         "post_migrate": post_migrate,
+        "setting_changed": setting_changed,
     }
 
     def nav_subtitle(self):


### PR DESCRIPTION
I looked through the [signals documentation](https://docs.djangoproject.com/en/stable/ref/signals/) and added some of the missing ones: [`m2m_changed`](https://docs.djangoproject.com/en/stable/ref/signals/#m2m-changed), [`pre_migrate`](https://docs.djangoproject.com/en/stable/ref/signals/#pre-migrate), and [`setting_changed`](https://docs.djangoproject.com/en/stable/ref/signals/#setting-changed).

Note that [`setting_changed`](https://docs.djangoproject.com/en/stable/ref/signals/#setting-changed) comes under the test signals, but says that it can be imported from `django.core.signals`. I left out [`template_rendered`](https://docs.djangoproject.com/en/stable/ref/signals/#template-rendered) as it is "only available during testing".

There are also [`django.contrib.auth.signals`](https://docs.djangoproject.com/en/stable/ref/contrib/auth/#module-django.contrib.auth.signals). I don't think adding them here would make a hard dependency on `django.contrib.auth` so they could be added?