### PR TITLE
Revert "fix AttributeError: 'dict' object has no attribute 'getlist' #1406"

### DIFF
--- a/debug_toolbar/panels/request.py
+++ b/debug_toolbar/panels/request.py
@@ -26,8 +26,8 @@ class RequestPanel(Panel):
     def generate_stats(self, request, response):
         self.record_stats(
             {
-                "get": [(k, request.GET.get(k)) for k in sorted(request.GET)],
-                "post": [(k, request.POST.get(k)) for k in sorted(request.POST)],
+                "get": [(k, request.GET.getlist(k)) for k in sorted(request.GET)],
+                "post": [(k, request.POST.getlist(k)) for k in sorted(request.POST)],
                 "cookies": [
                     (k, request.COOKIES.get(k)) for k in sorted(request.COOKIES)
                 ],


### PR DESCRIPTION
Reverts jazzband/django-debug-toolbar#1407

`get` and `getlist` aren't the same. Also, the change didn't contain any tests which are necessary to avoid regressions in this area.