### PR TITLE
Remove support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
         - sudo apt-get -y install libenchant1c2a
     - env: TOXENV=style
     - env: TOXENV=readme
-    - python: 3.5
-      env: TOXENV=py35-dj22-sqlite
     - python: 3.6
       env: TOXENV=py36-dj22-sqlite
     - python: 3.7

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ PRETTIER_TARGETS = '**/*.(css|js)'
 
 style: package-lock.json
 	isort .
-	black --target-version=py35 .
+	black --target-version=py36 .
 	flake8
 	npx eslint --ignore-path .gitignore --fix .
 	npx prettier --ignore-path .gitignore --write $(PRETTIER_TARGETS)
 
 style_check: package-lock.json
 	isort -c .
-	black --target-version=py35 --check .
+	black --target-version=py36 --check .
 	flake8
 	npx eslint --ignore-path .gitignore .
 	npx prettier --ignore-path .gitignore --check $(PRETTIER_TARGETS)

--- a/debug_toolbar/panels/history/panel.py
+++ b/debug_toolbar/panels/history/panel.py
@@ -51,14 +51,7 @@ class HistoryPanel(Panel):
                 and request.body
                 and request.META.get("CONTENT_TYPE") == "application/json"
             ):
-                # Python <= 3.5's json.loads expects a string.
-                data = json.loads(
-                    request.body
-                    if sys.version_info[:2] > (3, 5)
-                    else request.body.decode(
-                        request.encoding or settings.DEFAULT_CHARSET
-                    )
-                )
+                data = json.loads(request.body)
         except RawPostDataException:
             # It is not guaranteed that we may read the request data (again).
             data = None

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,7 @@ Change log
 * Started spellchecking the documentation.
 * Removed calls to the deprecated ``request.is_ajax()`` method. These calls
   were unnecessary now that most endpoints return JSON anyway.
+* Removed support for Python 3.5.
 
 
 3.1 (2020-09-21)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,14 +22,13 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     Django >= 2.2
     sqlparse >= 0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     docs
     style
     readme
-    py{35,36,37,38}-dj22-sqlite
+    py{36,37,38}-dj22-sqlite
     py{36,37,38}-dj{30,31}-sqlite
     py{36,37,38}-djmaster-sqlite
     py{37,38}-dj{22,30,31}-{postgresql,mariadb}


### PR DESCRIPTION
The Travis CI build started failing because of a Selenium upgrade. Instead of pinning Selenium to a lower version let's just drop support for Python 3.5 and remove a workaround or two.