### PR TITLE
Allow overriding CSS and JavaScript

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -1,7 +1,11 @@
-{% load i18n %}{% load static %}
+{% load i18n static %}
+{% block css %}
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" media="print">
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}">
+{% endblock %}
+{% block js %}
 <script type="module" src="{% static 'debug_toolbar/js/toolbar.js' %}" async></script>
+{% endblock %}
 <div id="djDebug" class="djdt-hidden" dir="ltr"
      {% if toolbar.store_id %}data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}"{% endif %}
      data-default-show="{% if toolbar.config.SHOW_COLLAPSED %}false{% else %}true{% endif %}"

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -12,14 +12,14 @@
      {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>
   <div class="djdt-hidden" id="djDebugToolbar">
     <ul id="djDebugPanelList">
-      <li><a id="djHideToolBarButton" href="#" title="{% trans "Hide toolbar" %}">{% trans "Hide" %} »</a></li>
+      <li><a id="djHideToolBarButton" href="#" title="{% trans 'Hide toolbar' %}">{% trans "Hide" %} »</a></li>
       {% for panel in toolbar.panels %}
         {% include "debug_toolbar/includes/panel_button.html" %}
       {% endfor %}
     </ul>
   </div>
   <div class="djdt-hidden" id="djDebugToolbarHandle">
-    <div title="{% trans "Show toolbar" %}" id="djShowToolBarButton">
+    <div title="{% trans 'Show toolbar' %}" id="djShowToolBarButton">
       <span id="djShowToolBarD">D</span><span id="djShowToolBarJ">J</span>DT
     </div>
   </div>


### PR DESCRIPTION
If I want to override the CSS and JavaScript shipped with debug toolbar there is no easy way to do this cleanly.

This change adds two template blocks to the base template, which allows extending the template cleanly, patching just CSS and/or JavaScript, as follows:

```django
{# FILE: templates/debug_toolbar/base.html #}

{% extends "debug_toolbar/base.html" %}
{% load static %}

{% block css %}
{{ block.super }}
<link rel="stylesheet" href="{% static 'css/debug-toolbar-custom.css' %}">
{% endblock %}

{% block js %}
{{ block.super }}
<script src="{% static 'js/debug-toolbar-custom.js' %}" async></script>
{% endblock %}
```

I also fixed a minor syntax highlighting issue, but I included that with a separate commit. I hope that's fine.
