### PR TITLE
Fix SQL selected / SQL explain for gis queries

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -130,6 +130,14 @@ class NormalCursorWrapper:
     def _record(self, method, sql, params):
         start_time = time()
         try:
+            if isinstance(params, list):
+
+                def strip_GeomFromEWKB(param):
+                    if isinstance(param, str):
+                        return param.lstrip("ST_GeomFromEWKB('\\x").rstrip("'::bytea)")
+                    return param
+
+                params = [strip_GeomFromEWKB(param) for param in params]
             return method(sql, params)
         finally:
             stop_time = time()


### PR DESCRIPTION
Without this fix, pushing the 'sel' or 'explain' button for a query containing some EWKB-encoded geometry 
as parameter results in this crash:
```
Internal Server Error: /__debug__/sql_explain/
Traceback (most recent call last):
  File "/Users/jieter/.pyenv/versions/obs/lib/python3.8/site-packages/django/db/backends/utils.py", line 86, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.InternalError_: parse error - invalid geometry
LINE 1: ...ure" IN (0, 1, 5)) AND "waarneming"."geo_point" @ 'ST_GeomFr...
                                                             ^
HINT:  "ST" <-- parse error at position 2 within geometry
```

I'm not sure if this is the appropriate location in the code, but with this fix, both `sql_select` and `sql_explain` 
work without flaws.

Previous PR adding a similar fix: #1130
Fixes: #423