### PR TITLE
Really ugly work in progress hack to fix tests on Django@master

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -136,6 +136,14 @@ class CacheStatTracker(BaseCache):
 
 
 class CacheHandlerPatch(CacheHandler):
+    def __getitem__(self, alias):
+        actual_cache = super().__getitem__(alias)
+        return (
+            actual_cache
+            if isinstance(actual_cache, CacheStatTracker)
+            else CacheStatTracker(actual_cache)
+        )
+
     def create_connection(self, alias):
         return CacheStatTracker(super().create_connection(alias))
 


### PR DESCRIPTION
Django 3.2 has changed a few internals in the `django.core.cache` module. Our instrumentation doesn't pick up cache calls anymore. Here's a hack which has worked locally. Since django-debug-toolbar relies on monkey patching anyway, something like this may work.

(Test failures on released Django versions are to be expected.)