### PR TITLE
Default the make test command to use sqlite database.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,13 @@ package-lock.json: package.json
 	touch $@
 
 test:
-	DJANGO_SETTINGS_MODULE=tests.settings \
+	DB_BACKEND=sqlite3 DB_NAME=":memory:" \
+        DJANGO_SETTINGS_MODULE=tests.settings \
 		python -m django test $${TEST_ARGS:-tests}
 
 test_selenium:
-	DJANGO_SELENIUM_TESTS=true DJANGO_SETTINGS_MODULE=tests.settings \
+	DB_BACKEND=sqlite3 DB_NAME=":memory:" \
+        DJANGO_SELENIUM_TESTS=true DJANGO_SETTINGS_MODULE=tests.settings \
 		python -m django test $${TEST_ARGS:-tests}
 
 coverage:


### PR DESCRIPTION
With the change to use github actions, we need to supply env variables to
tox and our tests. It takes a bit to find that information as a new dev,
so let's default to sqlite to make running the tests easier.