### PR TITLE
Add PRETTIFY_SQL setting to control token grouping in SQL panel

### DIFF
--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -4,6 +4,8 @@ import sqlparse
 from django.utils.html import escape
 from sqlparse import tokens as T
 
+from debug_toolbar import settings as dt_settings
+
 
 class BoldKeywordFilter:
     """sqlparse filter to bold SQL keywords"""
@@ -31,7 +33,8 @@ def reformat_sql(sql, with_toggle=False):
 
 def parse_sql(sql, aligned_indent=False):
     stack = sqlparse.engine.FilterStack()
-    stack.enable_grouping()
+    if dt_settings.get_config()["PRETTIFY_SQL"]:
+        stack.enable_grouping()
     if aligned_indent:
         stack.stmtprocess.append(
             sqlparse.filters.AlignedIndentFilter(char="&nbsp;", n="<br/>")

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -41,6 +41,7 @@ CONFIG_DEFAULTS = {
     "SHOW_TEMPLATE_CONTEXT": True,
     "SKIP_TEMPLATE_PREFIXES": ("django/forms/widgets/", "admin/widgets/"),
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
+    "PRETTIFY_SQL": True,
 }
 
 

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -37,11 +37,11 @@ CONFIG_DEFAULTS = {
         "django.utils.deprecation",
         "django.utils.functional",
     ),
+    "PRETTIFY_SQL": True,
     "PROFILER_MAX_DEPTH": 10,
     "SHOW_TEMPLATE_CONTEXT": True,
     "SKIP_TEMPLATE_PREFIXES": ("django/forms/widgets/", "admin/widgets/"),
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
-    "PRETTIFY_SQL": True,
 }
 
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -180,6 +180,39 @@ Panel options
   Useful for eliminating server-related entries which can result
   in enormous DOM structures and toolbar rendering delays.
 
+* ``PRETTIFY_SQL``
+
+  Default: ``True``
+
+  Panel: SQL
+
+  Controls SQL token grouping.
+
+  Token grouping allows pretty print of similar tokens,
+  like aligned indentation for every selected field.
+
+  When set to ``True``, it might cause render slowdowns
+  when a view make long SQL textual queries.
+
+  **Without grouping**::
+
+    SELECT "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name"
+    FROM "auth_user"
+    WHERE "auth_user"."username" = '''test_username'''
+    LIMIT 21
+
+  **With grouping**::
+
+    SELECT "auth_user"."id",
+       "auth_user"."password",
+       "auth_user"."last_login",
+       "auth_user"."is_superuser",
+       "auth_user"."username",
+       "auth_user"."first_name",
+       "auth_user"."last_name",
+      FROM "auth_user"
+    WHERE "auth_user"."username" = '''test_username'''
+    LIMIT 21
 
 * ``PROFILER_MAX_DEPTH``
 
@@ -220,40 +253,6 @@ Panel options
 
   The SQL panel highlights queries that took more that this amount of time,
   in milliseconds, to execute.
-
-* ``PRETTIFY_SQL``
-
-  Default: ``True``
-
-  Panel: SQL
-
-  Controls SQL token grouping.
-
-  Token grouping allows pretty print of similar tokens,
-  like aligned indentation for every selected field.
-
-  When set to ``True``, it might cause render slowdowns
-  when a view make long SQL textual queries.
-
-  **Without grouping**::
-
-    SELECT "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name"
-    FROM "auth_user"
-    WHERE "auth_user"."username" = '''test_username'''
-    LIMIT 21
-
-  **With grouping**::
-
-    SELECT "auth_user"."id",
-       "auth_user"."password",
-       "auth_user"."last_login",
-       "auth_user"."is_superuser",
-       "auth_user"."username",
-       "auth_user"."first_name",
-       "auth_user"."last_name",
-      FROM "auth_user"
-    WHERE "auth_user"."username" = '''test_username'''
-    LIMIT 21
 
 Here's what a slightly customized toolbar configuration might look like::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -221,6 +221,40 @@ Panel options
   The SQL panel highlights queries that took more that this amount of time,
   in milliseconds, to execute.
 
+* ``PRETTIFY_SQL``
+
+  Default: ``True``
+
+  Panel: SQL
+
+  Controls SQL token grouping.
+
+  Token grouping allows pretty print of similar tokens,
+  like aligned indentation for every selected field.
+
+  When set to ``True``, it might cause render slowdowns
+  when a view make long SQL textual queries.
+
+  **Without grouping**::
+
+    SELECT "auth_user"."id", "auth_user"."password", "auth_user"."last_login", "auth_user"."is_superuser", "auth_user"."username", "auth_user"."first_name", "auth_user"."last_name"
+    FROM "auth_user"
+    WHERE "auth_user"."username" = '''test_username'''
+    LIMIT 21
+
+  **With grouping**::
+
+    SELECT "auth_user"."id",
+       "auth_user"."password",
+       "auth_user"."last_login",
+       "auth_user"."is_superuser",
+       "auth_user"."username",
+       "auth_user"."first_name",
+       "auth_user"."last_name",
+      FROM "auth_user"
+    WHERE "auth_user"."username" = '''test_username'''
+    LIMIT 21
+
 Here's what a slightly customized toolbar configuration might look like::
 
     # This example is unlikely to be appropriate for your project.

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -9,6 +9,8 @@ from django.db.utils import DatabaseError
 from django.shortcuts import render
 from django.test.utils import override_settings
 
+from debug_toolbar import settings as dt_settings
+
 from ..base import BaseTestCase
 
 try:
@@ -357,3 +359,40 @@ class SQLPanelTestCase(BaseTestCase):
 
         # ensure the stacktrace is populated
         self.assertTrue(len(query[1]["stacktrace"]) > 0)
+
+    @override_settings(
+        DEBUG_TOOLBAR_CONFIG={"PRETTIFY_SQL": True},
+    )
+    def test_prettify_sql(self):
+        """
+        Test case to validate that the PRETTIFY_SQL setting changes the output
+        of the sql when it's toggled. It does not validate what it does
+        though.
+        """
+        list(User.objects.filter(username__istartswith="spam"))
+
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        pretty_sql = self.panel._queries[-1][1]["sql"]
+        self.assertEqual(len(self.panel._queries), 1)
+
+        # Reset the queries
+        self.panel._queries = []
+        # Run it again, but with prettyify off. Verify that it's different.
+        dt_settings.get_config()["PRETTIFY_SQL"] = False
+        list(User.objects.filter(username__istartswith="spam"))
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        self.assertEqual(len(self.panel._queries), 1)
+        self.assertNotEqual(pretty_sql, self.panel._queries[-1][1]["sql"])
+
+        self.panel._queries = []
+        # Run it again, but with prettyify back on.
+        # This is so we don't have to check what PRETTIFY_SQL does exactly,
+        # but we know it's doing something.
+        dt_settings.get_config()["PRETTIFY_SQL"] = True
+        list(User.objects.filter(username__istartswith="spam"))
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        self.assertEqual(len(self.panel._queries), 1)
+        self.assertEqual(pretty_sql, self.panel._queries[-1][1]["sql"])


### PR DESCRIPTION
As discussed in #1402, this PR expose a new setting, "PRETTIFY_SQL" which controls token grouping in SQL panel.
It is set as True by default in order to preserve current behaviour.

It should be disabled if a django application makes a very long textual SQL query, which will cause a huge slowdown during toolbar render.

This is a new PR (original #1404) to fix some commit issues as reported in [this](https://github.com/jazzband/django-debug-toolbar/pull/1404#issuecomment-738878417) comment.