### PR TITLE
Support JS events when loading a panel.

### DIFF
--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -107,6 +107,10 @@ class Panel:
     def scripts(self):
         """
         Scripts used by the HTML content of the panel when it's displayed.
+
+        When a panel is loaded on the frontend, a JavaScript event will be
+        dispatched of the format ``djdt.panel.[panel_id]``. The scripts used can
+        listen for this event to execute functionality on panel load.
         """
         return []
 

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -108,9 +108,9 @@ class Panel:
         """
         Scripts used by the HTML content of the panel when it's displayed.
 
-        When a panel is loaded on the frontend, a JavaScript event will be
-        dispatched of the format ``djdt.panel.[panel_id]``. The scripts used can
-        listen for this event to execute functionality on panel load.
+        When a panel is rendered on the frontend, the ``djdt.panel.render``
+        JavaScript event will be dispatched. The scripts can listen for
+        this event to support dynamic functionality.
         """
         return []
 

--- a/debug_toolbar/static/debug_toolbar/js/timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/timer.js
@@ -1,4 +1,7 @@
+import { $$ } from "./utils.js";
+
 function insertBrowserTiming() {
+    console.log(["inserted"]);
     const timingOffset = performance.timing.navigationStart,
         timingEnd = performance.timing.loadEventEnd,
         totalTime = timingEnd - timingOffset;
@@ -48,20 +51,25 @@ function insertBrowserTiming() {
         tbody.appendChild(row);
     }
 
-    const tbody = document.getElementById("djDebugBrowserTimingTableBody");
-    // This is a reasonably complete and ordered set of timing periods (2 params) and events (1 param)
-    addRow(tbody, "domainLookupStart", "domainLookupEnd");
-    addRow(tbody, "connectStart", "connectEnd");
-    addRow(tbody, "requestStart", "responseEnd"); // There is no requestEnd
-    addRow(tbody, "responseStart", "responseEnd");
-    addRow(tbody, "domLoading", "domComplete"); // Spans the events below
-    addRow(tbody, "domInteractive");
-    addRow(tbody, "domContentLoadedEventStart", "domContentLoadedEventEnd");
-    addRow(tbody, "loadEventStart", "loadEventEnd");
-    document
-        .getElementById("djDebugBrowserTiming")
-        .classList.remove("djdt-hidden");
+    const browserTiming = document.getElementById("djDebugBrowserTiming");
+    // Determine if the browser timing section has already been rendered.
+    if (browserTiming.classList.contains("djdt-hidden")) {
+        const tbody = document.getElementById("djDebugBrowserTimingTableBody");
+        // This is a reasonably complete and ordered set of timing periods (2 params) and events (1 param)
+        addRow(tbody, "domainLookupStart", "domainLookupEnd");
+        addRow(tbody, "connectStart", "connectEnd");
+        addRow(tbody, "requestStart", "responseEnd"); // There is no requestEnd
+        addRow(tbody, "responseStart", "responseEnd");
+        addRow(tbody, "domLoading", "domComplete"); // Spans the events below
+        addRow(tbody, "domInteractive");
+        addRow(tbody, "domContentLoadedEventStart", "domContentLoadedEventEnd");
+        addRow(tbody, "loadEventStart", "loadEventEnd");
+        browserTiming.classList.remove("djdt-hidden");
+    }
 }
 
 const djDebug = document.getElementById("djDebug");
-djDebug.addEventListener("djdt.panel.TimerPanel", insertBrowserTiming, false);
+// Insert the browser timing now since it's possible for this
+// script to miss the initial panel load event.
+insertBrowserTiming();
+$$.onPanelRender(djDebug, "TimerPanel", insertBrowserTiming);

--- a/debug_toolbar/static/debug_toolbar/js/timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/timer.js
@@ -1,59 +1,67 @@
-const timingOffset = performance.timing.navigationStart,
-    timingEnd = performance.timing.loadEventEnd,
-    totalTime = timingEnd - timingOffset;
-function getLeft(stat) {
-    return ((performance.timing[stat] - timingOffset) / totalTime) * 100.0;
-}
-function getCSSWidth(stat, endStat) {
-    let width =
-        ((performance.timing[endStat] - performance.timing[stat]) / totalTime) *
-        100.0;
-    // Calculate relative percent (same as sql panel logic)
-    width = (100.0 * width) / (100.0 - getLeft(stat));
-    return width < 1 ? "2px" : width + "%";
-}
-function addRow(tbody, stat, endStat) {
-    const row = document.createElement("tr");
-    if (endStat) {
-        // Render a start through end bar
-        row.innerHTML =
-            "<td>" +
-            stat.replace("Start", "") +
-            "</td>" +
-            '<td><svg class="djDebugLineChart" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 5" preserveAspectRatio="none"><rect y="0" height="5" fill="#ccc" /></svg></td>' +
-            "<td>" +
-            (performance.timing[stat] - timingOffset) +
-            " (+" +
-            (performance.timing[endStat] - performance.timing[stat]) +
-            ")</td>";
-        row.querySelector("rect").setAttribute(
-            "width",
-            getCSSWidth(stat, endStat)
-        );
-    } else {
-        // Render a point in time
-        row.innerHTML =
-            "<td>" +
-            stat +
-            "</td>" +
-            '<td><svg class="djDebugLineChart" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 5" preserveAspectRatio="none"><rect y="0" height="5" fill="#ccc" /></svg></td>' +
-            "<td>" +
-            (performance.timing[stat] - timingOffset) +
-            "</td>";
-        row.querySelector("rect").setAttribute("width", 2);
+function insertBrowserTiming() {
+    const timingOffset = performance.timing.navigationStart,
+        timingEnd = performance.timing.loadEventEnd,
+        totalTime = timingEnd - timingOffset;
+    function getLeft(stat) {
+        return ((performance.timing[stat] - timingOffset) / totalTime) * 100.0;
     }
-    row.querySelector("rect").setAttribute("x", getLeft(stat));
-    tbody.appendChild(row);
+    function getCSSWidth(stat, endStat) {
+        let width =
+            ((performance.timing[endStat] - performance.timing[stat]) /
+                totalTime) *
+            100.0;
+        // Calculate relative percent (same as sql panel logic)
+        width = (100.0 * width) / (100.0 - getLeft(stat));
+        return width < 1 ? "2px" : width + "%";
+    }
+    function addRow(tbody, stat, endStat) {
+        const row = document.createElement("tr");
+        if (endStat) {
+            // Render a start through end bar
+            row.innerHTML =
+                "<td>" +
+                stat.replace("Start", "") +
+                "</td>" +
+                '<td><svg class="djDebugLineChart" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 5" preserveAspectRatio="none"><rect y="0" height="5" fill="#ccc" /></svg></td>' +
+                "<td>" +
+                (performance.timing[stat] - timingOffset) +
+                " (+" +
+                (performance.timing[endStat] - performance.timing[stat]) +
+                ")</td>";
+            row.querySelector("rect").setAttribute(
+                "width",
+                getCSSWidth(stat, endStat)
+            );
+        } else {
+            // Render a point in time
+            row.innerHTML =
+                "<td>" +
+                stat +
+                "</td>" +
+                '<td><svg class="djDebugLineChart" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 5" preserveAspectRatio="none"><rect y="0" height="5" fill="#ccc" /></svg></td>' +
+                "<td>" +
+                (performance.timing[stat] - timingOffset) +
+                "</td>";
+            row.querySelector("rect").setAttribute("width", 2);
+        }
+        row.querySelector("rect").setAttribute("x", getLeft(stat));
+        tbody.appendChild(row);
+    }
+
+    const tbody = document.getElementById("djDebugBrowserTimingTableBody");
+    // This is a reasonably complete and ordered set of timing periods (2 params) and events (1 param)
+    addRow(tbody, "domainLookupStart", "domainLookupEnd");
+    addRow(tbody, "connectStart", "connectEnd");
+    addRow(tbody, "requestStart", "responseEnd"); // There is no requestEnd
+    addRow(tbody, "responseStart", "responseEnd");
+    addRow(tbody, "domLoading", "domComplete"); // Spans the events below
+    addRow(tbody, "domInteractive");
+    addRow(tbody, "domContentLoadedEventStart", "domContentLoadedEventEnd");
+    addRow(tbody, "loadEventStart", "loadEventEnd");
+    document
+        .getElementById("djDebugBrowserTiming")
+        .classList.remove("djdt-hidden");
 }
 
-const tbody = document.getElementById("djDebugBrowserTimingTableBody");
-// This is a reasonably complete and ordered set of timing periods (2 params) and events (1 param)
-addRow(tbody, "domainLookupStart", "domainLookupEnd");
-addRow(tbody, "connectStart", "connectEnd");
-addRow(tbody, "requestStart", "responseEnd"); // There is no requestEnd
-addRow(tbody, "responseStart", "responseEnd");
-addRow(tbody, "domLoading", "domComplete"); // Spans the events below
-addRow(tbody, "domInteractive");
-addRow(tbody, "domContentLoadedEventStart", "domContentLoadedEventEnd");
-addRow(tbody, "loadEventStart", "loadEventEnd");
-document.getElementById("djDebugBrowserTiming").classList.remove("djdt-hidden");
+const djDebug = document.getElementById("djDebug");
+djDebug.addEventListener("djdt.panel.TimerPanel", insertBrowserTiming, false);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -20,7 +20,8 @@ const djdt = {
                 if (!this.className) {
                     return;
                 }
-                const current = document.getElementById(this.className);
+                const panelId = this.className;
+                const current = document.getElementById(panelId);
                 if ($$.visible(current)) {
                     djdt.hide_panels();
                 } else {
@@ -38,27 +39,24 @@ const djdt = {
                             djDebug.dataset.renderPanelUrl,
                             window.location
                         );
-                        const onLoadEvent = current.dataset.onLoadEvent;
                         url.searchParams.append("store_id", store_id);
-                        url.searchParams.append("panel_id", this.className);
+                        url.searchParams.append("panel_id", panelId);
                         ajax(url).then(function (data) {
                             inner.previousElementSibling.remove(); // Remove AJAX loader
                             inner.innerHTML = data.content;
-                            if (data.scripts.length > 0) {
-                                let raisedEvent = false;
-                                $$.executeScripts(data.scripts, function () {
-                                    // Attempt to raise the event only once.
-                                    if (!raisedEvent) {
-                                        raisedEvent = true;
-                                        djDebug.dispatchEvent(
-                                            new Event(onLoadEvent)
-                                        );
-                                    }
-                                });
-                            } else {
-                                djDebug.dispatchEvent(new Event(onLoadEvent));
-                            }
+                            $$.executeScripts(data.scripts);
+                            djDebug.dispatchEvent(
+                                new CustomEvent("djdt.panel.render", {
+                                    detail: { panelId: panelId },
+                                })
+                            );
                         });
+                    } else {
+                        djDebug.dispatchEvent(
+                            new CustomEvent("djdt.panel.render", {
+                                detail: { panelId: panelId },
+                            })
+                        );
                     }
                 }
             }

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -38,12 +38,26 @@ const djdt = {
                             djDebug.dataset.renderPanelUrl,
                             window.location
                         );
+                        const onLoadEvent = current.dataset.onLoadEvent;
                         url.searchParams.append("store_id", store_id);
                         url.searchParams.append("panel_id", this.className);
                         ajax(url).then(function (data) {
                             inner.previousElementSibling.remove(); // Remove AJAX loader
                             inner.innerHTML = data.content;
-                            $$.executeScripts(data.scripts);
+                            if (data.scripts.length > 0) {
+                                let raisedEvent = false;
+                                $$.executeScripts(data.scripts, function () {
+                                    // Attempt to raise the event only once.
+                                    if (!raisedEvent) {
+                                        raisedEvent = true;
+                                        djDebug.dispatchEvent(
+                                            new Event(onLoadEvent)
+                                        );
+                                    }
+                                });
+                            } else {
+                                djDebug.dispatchEvent(new Event(onLoadEvent));
+                            }
                         });
                     }
                 }

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -7,6 +7,21 @@ const $$ = {
             }
         });
     },
+    onPanelRender(root, panelId, fn) {
+        /*
+        This is a helper function to attach a handler for a `djdt.panel.render`
+        event of a specific panel.
+
+        root: The container element that the listener should be attached to.
+        panelId: The Id of the panel.
+        fn: A function to execute when the event is triggered.
+         */
+        root.addEventListener("djdt.panel.render", function (event) {
+            if (event.detail.panelId === panelId) {
+                fn.call(event);
+            }
+        });
+    },
     show(element) {
         element.classList.remove("djdt-hidden");
     },
@@ -23,13 +38,12 @@ const $$ = {
     visible(element) {
         return !element.classList.contains("djdt-hidden");
     },
-    executeScripts(scripts, onLoad) {
+    executeScripts(scripts) {
         scripts.forEach(function (script) {
             const el = document.createElement("script");
             el.type = "module";
             el.src = script;
             el.async = true;
-            el.onload = onLoad;
             document.head.appendChild(el);
         });
     },

--- a/debug_toolbar/static/debug_toolbar/js/utils.js
+++ b/debug_toolbar/static/debug_toolbar/js/utils.js
@@ -23,12 +23,13 @@ const $$ = {
     visible(element) {
         return !element.classList.contains("djdt-hidden");
     },
-    executeScripts(scripts) {
+    executeScripts(scripts, onLoad) {
         scripts.forEach(function (script) {
             const el = document.createElement("script");
             el.type = "module";
             el.src = script;
             el.async = true;
+            el.onload = onLoad;
             document.head.appendChild(el);
         });
     },

--- a/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
+++ b/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 {% if panel.has_content and panel.enabled %}
-  <div id="{{ panel.panel_id }}" class="djdt-panelContent djdt-hidden" data-on-load-event="djdt.panel.{{ panel.panel_id }}">
+  <div id="{{ panel.panel_id }}" class="djdt-panelContent djdt-hidden">
     <div class="djDebugPanelTitle">
       <button type="button" class="djDebugClose">×</button>
       <h3>{{ panel.title }}</h3>

--- a/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
+++ b/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 {% if panel.has_content and panel.enabled %}
-  <div id="{{ panel.panel_id }}" class="djdt-panelContent djdt-hidden">
+  <div id="{{ panel.panel_id }}" class="djdt-panelContent djdt-hidden" data-on-load-event="djdt.panel.{{ panel.panel_id }}">
     <div class="djDebugPanelTitle">
       <button type="button" class="djDebugClose">×</button>
       <h3>{{ panel.title }}</h3>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,11 @@ Next version
 * Added ``PRETTIFY_SQL`` configuration option to support controlling
   SQL token grouping. By default it's set to True. When set to False,
   a performance improvement can be seen by the SQL panel.
+* Support JavaScript event when a panel loads of the format
+  ``djdt.panel.[PanelId]`` where PanelId is the panel's python class'
+  ``panel_id`` property. Listening for this event corrects the bug
+  in the Timer Panel in which it doesn't insert the browser timings
+  after being switching requests in the History Panel.
 
 
 3.2 (2020-12-03)

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -184,9 +184,9 @@ URL: https://github.com/danyi1212/django-windowsauth
 
 Path: ``windows_auth.panels.LDAPPanel``
 
-LDAP Operations performed during the request, including timing, request and response messages, 
+LDAP Operations performed during the request, including timing, request and response messages,
 the entries received, write changes list, stack-tracing and error debugging.
-This panel also shows connection usage metrics when it is collected. 
+This panel also shows connection usage metrics when it is collected.
 `Check out the docs <https://django-windowsauth.readthedocs.io/en/latest/howto/debug_toolbar.html>`_.
 
 Line Profiler
@@ -406,23 +406,28 @@ common methods available.
 Events
 ^^^^^^
 
-.. js:attribute:: djdt.panel.[panel_id]
+.. js:attribute:: djdt.panel.render
 
-    ``[panel_id]`` is the ``panel_id`` property of the panel's Python class.
-
-    This is an event raised when a panel is loaded for the first time. This
-    will not be raised on every render of the panel as the panel's content
-    is cached after the first load. This event can be useful when creating
-    custom scripts to process the HTML further.
+    This is an event raised when a panel is rendered. It has the property
+    ``detail.panelId`` which identifies which panel has been loaded. This
+    event can be useful when creating custom scripts to process the HTML
+    further.
 
     An example of this for the ``CustomPanel`` would be:
 
 .. code-block:: javascript
 
+    import { $$ } from "./utils.js";
     function addCustomMetrics() {
         // Logic to process/add custom metrics here.
+
+        // Be sure to cover the case of this function being called twice
+        // due to file being loaded asynchronously.
     }
-    // The panel events are dispatched on the #djDebug element.
     const djDebug = document.getElementById("djDebug");
-    // When the event djdt.panel.CustomPanel is raised, call AddCustomMetrics
-    djDebug.addEventListener("djdt.panel.CustomPanel", addCustomMetrics, false);
+    $$.onPanelRender(djDebug, "CustomPanel", addCustomMetrics);
+    // Since a panel's scripts are loaded asynchronously, it's possible that
+    // the above statement would occur after the djdt.panel.render event has
+    // been raised. To account for that, the rendering function should be
+    // called here as well.
+    addCustomMetrics();

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -402,3 +402,27 @@ common methods available.
 .. js:function:: djdt.show_toolbar
 
     Shows the toolbar.
+
+Events
+^^^^^^
+
+.. js:attribute:: djdt.panel.[panel_id]
+
+    ``[panel_id]`` is the ``panel_id`` property of the panel's Python class.
+
+    This is an event raised when a panel is loaded for the first time. This
+    will not be raised on every render of the panel as the panel's content
+    is cached after the first load. This event can be useful when creating
+    custom scripts to process the HTML further.
+
+    An example of this for the ``CustomPanel`` would be:
+
+.. code-block:: javascript
+
+    function addCustomMetrics() {
+        // Logic to process/add custom metrics here.
+    }
+    // The panel events are dispatched on the #djDebug element.
+    const djDebug = document.getElementById("djDebug");
+    // When the event djdt.panel.CustomPanel is raised, call AddCustomMetrics
+    djDebug.addEventListener("djdt.panel.CustomPanel", addCustomMetrics, false);


### PR DESCRIPTION
This fixes the problem of the Timer Panel not inserting the browser
timings section after being loaded via the HistoryPanel.

These events could be wired into to better render panels or support
a more dynamic toolbar and/or panel.


Fixes #1439 