### PR TITLE
show namespaces alongside url_name in request panel

### DIFF
--- a/debug_toolbar/panels/request.py
+++ b/debug_toolbar/panels/request.py
@@ -44,7 +44,16 @@ class RequestPanel(Panel):
             view_info["view_func"] = get_name_from_obj(func)
             view_info["view_args"] = args
             view_info["view_kwargs"] = kwargs
-            view_info["view_urlname"] = getattr(match, "url_name", _("<unavailable>"))
+
+            if getattr(match, "url_name", False):
+                url_name = match.url_name
+                if match.namespaces:
+                    url_name = ":".join([*match.namespaces, url_name])
+            else:
+                url_name = _("<unavailable>")
+
+            view_info["view_urlname"] = url_name
+
         except Http404:
             pass
         self.record_stats(view_info)

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -84,3 +84,10 @@ class RequestPanelTestCase(BaseTestCase):
         content = self.panel.content
         self.assertIn("foo", content)
         self.assertIn("bar", content)
+
+    def test_namespaced_url(self):
+        self.request.path = "/admin/login/"
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        panel_stats = self.panel.get_stats()
+        self.assertEqual(panel_stats["view_urlname"], "admin:login")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,6 +63,10 @@ class DebugToolbarTestCase(BaseTestCase):
         panel.generate_stats(self.request, response)
         return panel.get_stats()
 
+    def test_namespaced_url(self):
+        stats = self._resolve_stats("/admin/login/")
+        self.assertEqual(stats["view_urlname"], "admin:login")
+
     def test_url_resolving_positional(self):
         stats = self._resolve_stats("/resolving1/a/b/")
         self.assertEqual(stats["view_urlname"], "positional-resolving")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,10 +63,6 @@ class DebugToolbarTestCase(BaseTestCase):
         panel.generate_stats(self.request, response)
         return panel.get_stats()
 
-    def test_namespaced_url(self):
-        stats = self._resolve_stats("/admin/login/")
-        self.assertEqual(stats["view_urlname"], "admin:login")
-
     def test_url_resolving_positional(self):
         stats = self._resolve_stats("/resolving1/a/b/")
         self.assertEqual(stats["view_urlname"], "positional-resolving")

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,3 +1,4 @@
+from django.contrib import admin
 from django.contrib.auth.views import LoginView
 from django.urls import include, path, re_path
 
@@ -22,5 +23,6 @@ urlpatterns = [
     path("json_view/", views.json_view),
     path("redirect/", views.redirect_view),
     path("login_without_redirect/", LoginView.as_view(redirect_field_name=None)),
+    path("admin/", admin.site.urls),
     path("__debug__/", include(debug_toolbar.urls)),
 ]


### PR DESCRIPTION
As far as I know, no one really asked for this, but I work on projects that make heavy use of namespaces with repetitive urls (e.g. create, edit, index) and having namespaces available in the request panel helps disambiguate and makes for a quicker grep. 

Before this PR:
![Screen Shot 2021-01-23 at 11 08 42 AM](https://user-images.githubusercontent.com/7769215/105607176-5db5a000-5d6b-11eb-8fe7-073dee595018.png)


After this PR:
![Screen Shot 2021-01-23 at 11 09 20 AM](https://user-images.githubusercontent.com/7769215/105607196-73c36080-5d6b-11eb-9302-e05e786842c2.png)

I used `:` as a separator because that's what you'd pass to e.g. `reverse("admin:login")`. We can alternatively add a separate 'namespace' title/content section, but this seemed cleaner to me

