### PR TITLE
Remove pkg_resources usage

### DIFF
--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -1,13 +1,9 @@
 __all__ = ["VERSION"]
 
 
-try:
-    import pkg_resources
-
-    VERSION = pkg_resources.get_distribution("django-debug-toolbar").version
-except Exception:
-    VERSION = "unknown"
-
+# Do not use pkg_resources to find the version but set it here directly!
+# see issue #1446
+VERSION = "3.2"
 
 # Code that discovers files or modules in INSTALLED_APPS imports this module.
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -141,8 +141,8 @@ The release itself requires the following steps:
    Commit.
 
 #. Bump version numbers in ``docs/changes.rst``, ``docs/conf.py``,
-   ``README.rst`` and ``setup.py``. Add the release date to
-   ``docs/changes.rst``. Commit.
+   ``README.rst``, ``debug_toolbar/__init__.py`` and ``setup.py``.
+   Add the release date to ``docs/changes.rst``. Commit.
 
 #. Tag the new version.
 


### PR DESCRIPTION
Fixes #1446 

I replaced the usage of `pkg_resources` by a hard-coded version number to save ~30% on the import time (and thus start-up time of any django app, script, test run etc that uses debug_toolbar).

Before:
```
$ time python -c "import debug_toolbar; import debug_toolbar.apps" 2>&1
python -c "import debug_toolbar; import debug_toolbar.apps" 2>&1  0,28s user 0,03s system 99% cpu 0,316 total
```

After:
```
$ time python -c "import debug_toolbar; import debug_toolbar.apps" 2>&1
python -c "import debug_toolbar; import debug_toolbar.apps" 2>&1  0,18s user 0,03s system 100% cpu 0,207 total
```

Do you think this is worth the additional hassle for the maintainer/release person to update the version number in one more place? :-)