### PR TITLE
Improve local testing for contributors.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,7 @@ jobs:
       mariadb:
         image: mariadb:10.3
         env:
-          MYSQL_ROOT_PASSWORD: mysql
-          MYSQL_DATABASE: mysql
+          MYSQL_ROOT_PASSWORD: debug_toolbar
         options: >-
           --health-cmd "mysqladmin ping"
           --health-interval 10s
@@ -61,11 +60,10 @@ jobs:
       run: tox
       env:
         DB_BACKEND: mysql
-        DB_NAME: mysql
         DB_USER: root
-        DB_PASSWORD: mysql
-        DB_HOST: "127.0.0.1"
-        DB_PORT: "3306"
+        DB_PASSWORD: debug_toolbar
+        DB_HOST: 127.0.0.1
+        DB_PORT: 3306
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1
@@ -84,7 +82,9 @@ jobs:
       postgres:
         image: 'postgres:9.5'
         env:
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: debug_toolbar
+          POSTGRES_USER: debug_toolbar
+          POSTGRES_PASSWORD: debug_toolbar
         ports:
         - 5432:5432
         options: >-
@@ -129,9 +129,6 @@ jobs:
       run: tox
       env:
         DB_BACKEND: postgresql
-        DB_NAME: postgres
-        DB_USER: postgres
-        DB_PASSWORD: postgres
         DB_HOST: localhost
         DB_PORT: 5432
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -53,7 +53,7 @@ Tests
 
 Once you've set up a development environment as explained above, you can run
 the test suite for the versions of Django and Python installed in that
-environment::
+environment using the SQLite database::
 
     $ make test
 
@@ -79,8 +79,23 @@ or by setting the ``DJANGO_SELENIUM_TESTS`` environment variable::
     $ DJANGO_SELENIUM_TESTS=true make coverage
     $ DJANGO_SELENIUM_TESTS=true tox
 
-At this time, there isn't an easy way to test against databases other than
-SQLite.
+To test via `tox` against other databases, you'll need to create the user,
+database and assign the proper permissions. For PostgreSQL in a `psql`
+shell (note this allows the debug_toolbar user the permission to create
+databases)::
+
+    psql> CREATE USER debug_toolbar WITH PASSWORD 'debug_toolbar';
+    psql> ALTER USER debug_toolbar CREATEDB;
+    psql> CREATE DATABASE debug_toolbar;
+    psql> GRANT ALL PRIVILEGES ON DATABASE debug_toolbar to debug_toolbar;
+
+For MySQL/MariaDB in a `mysql` shell::
+
+    mysql> CREATE DATABASE debug_toolbar;
+    mysql> CREATE USER 'debug_toolbar'@'localhost' IDENTIFIED BY 'debug_toolbar';
+    mysql> GRANT ALL PRIVILEGES ON debug_toolbar.* TO 'debug_toolbar'@'localhost';
+    mysql> GRANT ALL PRIVILEGES ON test_debug_toolbar.* TO 'debug_toolbar'@'localhost';
+
 
 Style
 -----

--- a/example/settings.py
+++ b/example/settings.py
@@ -73,26 +73,23 @@ DATABASES = {
 
 # To use another database, set the DB_BACKEND environment variable.
 if os.environ.get("DB_BACKEND", "").lower() == "postgresql":
-    # % su postgres
-    # % createuser debug_toolbar
-    # % createdb debug_toolbar -O debug_toolbar
+    # See docs/contributing for instructions on configuring PostgreSQL.
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.postgresql",
             "NAME": "debug_toolbar",
             "USER": "debug_toolbar",
+            "PASSWORD": "debug_toolbar",
         }
     }
 if os.environ.get("DB_BACKEND", "").lower() == "mysql":
-    # % mysql
-    # mysql> CREATE DATABASE debug_toolbar;
-    # mysql> CREATE USER 'debug_toolbar'@'localhost';
-    # mysql> GRANT ALL PRIVILEGES ON debug_toolbar.* TO 'debug_toolbar'@'localhost';
+    # See docs/contributing for instructions on configuring MySQL/MariaDB.
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.mysql",
             "NAME": "debug_toolbar",
             "USER": "debug_toolbar",
+            "PASSWORD": "debug_toolbar",
         }
     }
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -81,8 +81,8 @@ CACHES = {
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.%s" % os.getenv("DB_BACKEND"),
-        "NAME": os.getenv("DB_NAME"),
+        "ENGINE": "django.db.backends.%s" % os.getenv("DB_BACKEND", "sqlite3"),
+        "NAME": os.getenv("DB_NAME", ":memory:"),
         "USER": os.getenv("DB_USER"),
         "PASSWORD": os.getenv("DB_PASSWORD"),
         "HOST": os.getenv("DB_HOST", ""),

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,8 @@ envlist =
     docs
     style
     readme
-    py{36,37,38,39}-dj22-sqlite
-    py{36,37,38,39}-dj{30,31}-sqlite
-    py{36,37,38,39}-djmaster-sqlite
-    py{37,38,39}-dj{22,30,31}-{postgresql,mysql}
+    py{36,37,38,39}-dj{22,30,31,master}-sqlite
+    py{36,37,38,39}-dj{22,30,31}-{postgresql,mysql}
 
 [testenv]
 deps =
@@ -35,9 +33,31 @@ setenv =
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = d
     py38-dj31-postgresql: DJANGO_SELENIUM_TESTS = true
+    DB_NAME = {env:DB_NAME:debug_toolbar}
+    DB_USER = {env:DB_USER:debug_toolbar}
+    DB_HOST = {env:DB_HOST:localhost}
+    DB_PASSWORD =  {env:DB_PASSWORD:debug_toolbar}
 whitelist_externals = make
 pip_pre = True
 commands = make coverage TEST_ARGS='{posargs:tests}'
+
+[testenv:py{36,37,38,39}-dj{22,30,31}-postgresql]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = postgresql
+    DB_PORT = {env:DB_PORT:5432}
+
+[testenv:py{36,37,38,39}-dj{22,30,31}-mysql]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = mysql
+    DB_PORT = {env:DB_PORT:3306}
+
+[testenv:py{36,37,38,39}-dj{22,30,31,master}-sqlite]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = sqlite3
+    DB_NAME = ":memory:"
 
 [testenv:docs]
 commands = make -C {toxinidir}/docs spelling


### PR DESCRIPTION
Changes make test to default to SQLite via tests/settings.py's defaults.

Changes the GitHub actions configuration to use database connection
credentials specific to the toolbar. This makes the local setup and
the CI tests more similar.

Pulls the database environment configuration out of GitHub actions
and into tox. This allows a developer to run tox and test against
all locally installed and setup databases. The contributing docs
have been updated to contain database shell commands to setup the
local environment.

This is a follow-up to jazzband/django-debug-toolbar#1431