### PR TITLE
Update the CI jobs list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,16 @@ envlist =
     docs
     style
     readme
-    py{36,37,38,39}-dj{22,30,31,master}-sqlite
-    py{36,37,38,39}-dj{22,30,31}-{postgresql,mysql}
+    py{36,37}-dj{22,30,31,32}-sqlite
+    py{38,39}-dj{22,30,31,32,master}-sqlite
+    py{36,37,38,39}-dj{22,30,31,32}-{postgresql,mysql}
 
 [testenv]
 deps =
     dj22: Django==2.2.*
     dj30: Django==3.0.*
     dj31: Django==3.1.*
+    dj32: Django>=3.2a1,<4.0
     sqlite: mock
     postgresql: psycopg2-binary
     mysql: mysqlclient
@@ -41,19 +43,19 @@ whitelist_externals = make
 pip_pre = True
 commands = make coverage TEST_ARGS='{posargs:tests}'
 
-[testenv:py{36,37,38,39}-dj{22,30,31}-postgresql]
+[testenv:py{36,37,38,39}-dj{22,30,31,32}-postgresql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
-[testenv:py{36,37,38,39}-dj{22,30,31}-mysql]
+[testenv:py{36,37,38,39}-dj{22,30,31,32}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
     DB_PORT = {env:DB_PORT:3306}
 
-[testenv:py{36,37,38,39}-dj{22,30,31,master}-sqlite]
+[testenv:py{36,37,38,39}-dj{22,30,31,32,master}-sqlite]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3


### PR DESCRIPTION
- Add the upcoming Django 3.2.
- Django 4.0 (the master branch at the time of writing) has dropped
  support for Python 3.6 and 3.7.