### PR TITLE
Fixed issue with toolbar expecting urls to start with __debug__.

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -44,7 +44,7 @@ class DebugToolbarMiddleware:
     def __call__(self, request):
         # Decide whether the toolbar is active for this request.
         show_toolbar = get_show_toolbar()
-        if not show_toolbar(request) or request.path.startswith("/__debug__/"):
+        if not show_toolbar(request) or DebugToolbar.is_toolbar_request(request):
             return self.get_response(request)
 
         toolbar = DebugToolbar(request, self.get_response)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,7 +9,7 @@ Next version
 * Added ``PRETTIFY_SQL`` configuration option to support controlling
   SQL token grouping. By default it's set to True. When set to False,
   a performance improvement can be seen by the SQL panel.
-* Fixed issue with toolbar expecting urls to start with `/__debug__/`
+* Fixed issue with toolbar expecting URL paths to start with `/__debug__/`
   while the documentation indicates it's not required.
 
 3.2 (2020-12-03)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,7 +9,8 @@ Next version
 * Added ``PRETTIFY_SQL`` configuration option to support controlling
   SQL token grouping. By default it's set to True. When set to False,
   a performance improvement can be seen by the SQL panel.
-
+* Fixed issue with toolbar expecting urls to start with `/__debug__/`
+  while the documentation indicates it's not required.
 
 3.2 (2020-12-03)
 ----------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -101,6 +101,25 @@ class DebugToolbarTestCase(BaseTestCase):
         self.client.get("/cached_view/")
         self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 5)
 
+    def test_is_toolbar_request(self):
+        self.request.path = "/__debug__/render_panel/"
+        self.assertTrue(self.toolbar.is_toolbar_request(self.request))
+
+        self.request.path = "/invalid/__debug__/render_panel/"
+        self.assertFalse(self.toolbar.is_toolbar_request(self.request))
+
+        self.request.path = "/render_panel/"
+        self.assertFalse(self.toolbar.is_toolbar_request(self.request))
+
+    @override_settings(ROOT_URLCONF="tests.urls_invalid")
+    def test_is_toolbar_request_without_djdt_urls(self):
+        """Test cases when the toolbar urls aren't configured."""
+        self.request.path = "/__debug__/render_panel/"
+        self.assertFalse(self.toolbar.is_toolbar_request(self.request))
+
+        self.request.path = "/render_panel/"
+        self.assertFalse(self.toolbar.is_toolbar_request(self.request))
+
 
 @override_settings(DEBUG=True)
 class DebugToolbarIntegrationTestCase(IntegrationTestCase):

--- a/tests/urls_invalid.py
+++ b/tests/urls_invalid.py
@@ -1,0 +1,2 @@
+"""Invalid urls.py file for testing"""
+urlpatterns = []


### PR DESCRIPTION
When the history panel was added and we expanded the number of
urls we were instrumenting, there was a check added to exclude
the requests to the toolbar's views. This was done by checking
the path of the request to see if it started with `__debug__`.
However, the documentation states that is not a requirement.
This change checks the urls to see if the namespace of the
resolved url matches the toolbar's namespace.

This still isn't perfect as another url path could contain the
last namespace of djdt, but this is much less likely than a user
defining the toolbar's urls at a different path than `/__debug__/`