### PR TITLE
Use current_thread instead of currentThread method that was deprecated in Python 3.10

### DIFF
--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -78,6 +78,6 @@ class LoggingPanel(Panel):
 
     def generate_stats(self, request, response):
         records = collector.get_collection()
-        self._records[threading.currentThread()] = records
+        self._records[threading.current_thread()] = records
         collector.clear_collection()
         self.record_stats({"records": records})

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -118,7 +118,7 @@ class StaticFilesPanel(panels.Panel):
 
     def generate_stats(self, request, response):
         used_paths = collector.get_collection()
-        self._paths[threading.currentThread()] = used_paths
+        self._paths[threading.current_thread()] = used_paths
 
         self.record_stats(
             {

--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -252,14 +252,14 @@ class ThreadCollector:
         is provided, returns a list for the current thread.
         """
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         if thread not in self.collections:
             self.collections[thread] = []
         return self.collections[thread]
 
     def clear_collection(self, thread=None):
         if thread is None:
-            thread = threading.currentThread()
+            thread = threading.current_thread()
         if thread in self.collections:
             del self.collections[thread]
 


### PR DESCRIPTION
Fixes #1464 