### PR TITLE
Use default app config discovery

### DIFF
--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -1,3 +1,5 @@
+import django
+
 __all__ = ["VERSION"]
 
 
@@ -9,4 +11,5 @@ VERSION = "3.2.1"
 
 urls = "debug_toolbar.toolbar", "djdt"
 
-default_app_config = "debug_toolbar.apps.DebugToolbarConfig"
+if django.VERSION < (3, 2):
+    default_app_config = "debug_toolbar.apps.DebugToolbarConfig"


### PR DESCRIPTION
Django 3.2 deprecated default_app_config.
https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery