### PR TITLE
Use twine to check generated package and readme

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,4 +216,4 @@ jobs:
         python -m pip install --upgrade tox
 
     - name: Test with tox
-      run: tox -e docs,style,readme
+      run: tox -e docs,style,packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ name = django-debug-toolbar
 version = 3.2.1
 description = A configurable set of panels that display various debug information about the current request/response.
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 author = Rob Hudson
 author_email = rob@cogit8.org
 url = https://github.com/jazzband/django-debug-toolbar

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     docs
     style
-    readme
+    packaging
     py{36,37}-dj{22,31,32}-sqlite
     py{38,39}-dj{22,31,32,main}-sqlite
     py{36,37,38,39}-dj{22,31,32}-{postgresql,mysql}
@@ -74,9 +74,14 @@ deps =
     isort>=5.0.2
 skip_install = true
 
-[testenv:readme]
-commands = python setup.py check -r -s
-deps = readme_renderer
+[testenv:packaging]
+commands =
+    python setup.py sdist bdist_wheel
+    twine check --strict dist/*
+deps =
+ readme_renderer
+ twine
+ wheel
 skip_install = true
 
 [gh-actions]


### PR DESCRIPTION
The setup.py check command is deprecated. Use twine check instead.
Rename the tox environment to packaging, it now checks the package.