### PR TITLE
Add test coverage to ensure that SQL tracker wrappers are applied only once to database cursors

### DIFF
--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import unittest
+from unittest.mock import patch
 
 import django
 from django.contrib.auth.models import User
@@ -11,6 +12,7 @@ from django.shortcuts import render
 from django.test.utils import override_settings
 
 from debug_toolbar import settings as dt_settings
+import debug_toolbar.panels.sql.tracking as sql_tracking
 
 from ..base import BaseTestCase
 
@@ -60,6 +62,20 @@ class SQLPanelTestCase(BaseTestCase):
 
         # ensure query was logged
         self.assertEqual(len(self.panel._queries), 1)
+
+    @patch('debug_toolbar.panels.sql.tracking.state', wraps=sql_tracking.state)
+    def test_cursor_wrapper_singleton(self, mock_state):
+        list(User.objects.all())
+
+        # ensure that cursor wrapping is applied only once
+        self.assertEqual(mock_state.Wrapper.call_count, 1)
+
+    @patch('debug_toolbar.panels.sql.tracking.state', wraps=sql_tracking.state)
+    def test_chunked_cursor_wrapper_singleton(self, mock_state):
+        list(User.objects.all().iterator())
+
+        # ensure that cursor wrapping is applied only once
+        self.assertEqual(mock_state.Wrapper.call_count, 1)
 
     def test_generate_server_timing(self):
         self.assertEqual(len(self.panel._queries), 0)

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -63,14 +63,14 @@ class SQLPanelTestCase(BaseTestCase):
         # ensure query was logged
         self.assertEqual(len(self.panel._queries), 1)
 
-    @patch('debug_toolbar.panels.sql.tracking.state', wraps=sql_tracking.state)
+    @patch("debug_toolbar.panels.sql.tracking.state", wraps=sql_tracking.state)
     def test_cursor_wrapper_singleton(self, mock_state):
         list(User.objects.all())
 
         # ensure that cursor wrapping is applied only once
         self.assertEqual(mock_state.Wrapper.call_count, 1)
 
-    @patch('debug_toolbar.panels.sql.tracking.state', wraps=sql_tracking.state)
+    @patch("debug_toolbar.panels.sql.tracking.state", wraps=sql_tracking.state)
     def test_chunked_cursor_wrapper_singleton(self, mock_state):
         list(User.objects.all().iterator())
 

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -11,8 +11,8 @@ from django.db.utils import DatabaseError
 from django.shortcuts import render
 from django.test.utils import override_settings
 
-from debug_toolbar import settings as dt_settings
 import debug_toolbar.panels.sql.tracking as sql_tracking
+from debug_toolbar import settings as dt_settings
 
 from ..base import BaseTestCase
 


### PR DESCRIPTION
This is an attempt to add test coverage for the behaviour discovered in #1239 and addressed in #1475.

The idea is to [`patch`](https://docs.python.org/3.6/library/unittest.mock.html#unittest.mock.patch) the [`state.Wrapper` method](https://github.com/jazzband/django-debug-toolbar/blob/6ec6bfe0ba5912d7fd0a2b98176a215847157696/debug_toolbar/panels/sql/tracking.py#L23-L37) that is called to add each wrapping layer, and count the number of calls for both chunked and non-chunked types of cursor (across all database provider implementations).

cc @saemideluxe