### PR TITLE
Extract common base cursor wrapper class

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -58,7 +58,7 @@ def wrap_cursor(connection, panel):
             # prevent double wrapping
             # solves https://github.com/jazzband/django-debug-toolbar/issues/1239
             cursor = connection._djdt_chunked_cursor(*args, **kwargs)
-            if not isinstance(cursor, state.Wrapper):
+            if not isinstance(cursor, BaseCursorWrapper):
                 return state.Wrapper(cursor, connection, panel)
             return cursor
 
@@ -74,7 +74,11 @@ def unwrap_cursor(connection):
         del connection.chunked_cursor
 
 
-class ExceptionCursorWrapper:
+class BaseCursorWrapper:
+    pass
+
+
+class ExceptionCursorWrapper(BaseCursorWrapper):
     """
     Wraps a cursor and raises an exception on any operation.
     Used in Templates panel.
@@ -87,7 +91,7 @@ class ExceptionCursorWrapper:
         raise SQLQueryTriggered()
 
 
-class NormalCursorWrapper:
+class NormalCursorWrapper(BaseCursorWrapper):
     """
     Wraps a cursor and logs queries.
     """


### PR DESCRIPTION
This change follows on from #1475 and introduces a common base class for cursor wrappers.

This base class is substituted in to the conditional check that identifies whether a cursor is already wrapped by DDT's SQL cursor tracking.

This should be compatible with the test coverage offered in #1478.