### PR TITLE
Fixes and improvements to history views

### DIFF
--- a/debug_toolbar/panels/history/views.py
+++ b/debug_toolbar/panels/history/views.py
@@ -56,7 +56,11 @@ def history_refresh(request, verified_data):
                             "id": id,
                             "store_context": {
                                 "toolbar": toolbar,
-                                "form": SignedDataForm(initial={"store_id": id}),
+                                "form": SignedDataForm(
+                                    initial=HistoryStoreForm(
+                                        initial={"store_id": id}
+                                    ).initial
+                                ),
                             },
                         },
                     ),

--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -15,7 +15,6 @@ $$.on(djDebug, "click", ".switchHistory", function (event) {
 
     ajaxForm(this).then(function (data) {
         djDebug.setAttribute("data-store-id", newStoreId);
-        console.log("New id is" + newStoreId);
         // Check if response is empty, it could be due to an expired store_id.
         if (Object.keys(data).length === 0) {
             const container = document.getElementById("djdtHistoryRequests");

--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -7,21 +7,31 @@ $$.on(djDebug, "click", ".switchHistory", function (event) {
     const newStoreId = this.dataset.storeId;
     const tbody = this.closest("tbody");
 
-    tbody
-        .querySelector(".djdt-highlighted")
-        .classList.remove("djdt-highlighted");
-    this.closest("tr").classList.add("djdt-highlighted");
+    const highlighted = tbody.querySelector(".djdt-highlighted");
+    if (highlighted) {
+        highlighted.classList.remove("djdt-highlighted");
+        this.closest("tr").classList.add("djdt-highlighted");
+    }
 
     ajaxForm(this).then(function (data) {
         djDebug.setAttribute("data-store-id", newStoreId);
-        Object.keys(data).forEach(function (panelId) {
-            const panel = document.getElementById(panelId);
-            if (panel) {
-                panel.outerHTML = data[panelId].content;
-                document.getElementById("djdt-" + panelId).outerHTML =
-                    data[panelId].button;
-            }
-        });
+        console.log("New id is" + newStoreId);
+        // Check if response is empty, it could be due to an expired store_id.
+        if (Object.keys(data).length === 0) {
+            const container = document.getElementById("djdtHistoryRequests");
+            container.querySelector(
+                'button[data-store-id="' + newStoreId + '"]'
+            ).innerHTML = "Switch [EXPIRED]";
+        } else {
+            Object.keys(data).forEach(function (panelId) {
+                const panel = document.getElementById(panelId);
+                if (panel) {
+                    panel.outerHTML = data[panelId].content;
+                    document.getElementById("djdt-" + panelId).outerHTML =
+                        data[panelId].button;
+                }
+            });
+        }
     });
 });
 
@@ -29,12 +39,14 @@ $$.on(djDebug, "click", ".refreshHistory", function (event) {
     event.preventDefault();
     const container = document.getElementById("djdtHistoryRequests");
     ajaxForm(this).then(function (data) {
+        // Remove existing rows first then re-populate with new data
+        container
+            .querySelectorAll("tr[data-store-id]")
+            .forEach(function (node) {
+                node.remove();
+            });
         data.requests.forEach(function (request) {
-            if (
-                !container.querySelector('[data-store-id="' + request.id + '"]')
-            ) {
-                container.innerHTML = request.content + container.innerHTML;
-            }
+            container.innerHTML = request.content + container.innerHTML;
         });
     });
 });

--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -10,8 +10,8 @@ $$.on(djDebug, "click", ".switchHistory", function (event) {
     const highlighted = tbody.querySelector(".djdt-highlighted");
     if (highlighted) {
         highlighted.classList.remove("djdt-highlighted");
-        this.closest("tr").classList.add("djdt-highlighted");
     }
+    this.closest("tr").classList.add("djdt-highlighted");
 
     ajaxForm(this).then(function (data) {
         djDebug.setAttribute("data-store-id", newStoreId);

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -1,3 +1,5 @@
+import html
+
 from django.test import RequestFactory, override_settings
 from django.urls import resolve, reverse
 
@@ -64,6 +66,21 @@ class HistoryPanelTestCase(BaseTestCase):
 
 @override_settings(DEBUG=True)
 class HistoryViewsTestCase(IntegrationTestCase):
+    PANEL_KEYS = {
+        "VersionsPanel",
+        "TimerPanel",
+        "SettingsPanel",
+        "HeadersPanel",
+        "RequestPanel",
+        "SQLPanel",
+        "StaticFilesPanel",
+        "TemplatesPanel",
+        "CachePanel",
+        "SignalsPanel",
+        "LoggingPanel",
+        "ProfilingPanel",
+    }
+
     def test_history_panel_integration_content(self):
         """Verify the history panel's content renders properly.."""
         self.assertEqual(len(DebugToolbar._store), 0)
@@ -88,26 +105,45 @@ class HistoryViewsTestCase(IntegrationTestCase):
     def test_history_sidebar(self):
         """Validate the history sidebar view."""
         self.client.get("/json_view/")
-        store_id = list(DebugToolbar._store.keys())[0]
+        store_id = list(DebugToolbar._store)[0]
         data = {"signed": SignedDataForm.sign({"store_id": store_id})}
         response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            set(response.json().keys()),
-            {
-                "VersionsPanel",
-                "TimerPanel",
-                "SettingsPanel",
-                "HeadersPanel",
-                "RequestPanel",
-                "SQLPanel",
-                "StaticFilesPanel",
-                "TemplatesPanel",
-                "CachePanel",
-                "SignalsPanel",
-                "LoggingPanel",
-                "ProfilingPanel",
-            },
+            set(response.json()),
+            self.PANEL_KEYS,
+        )
+
+    @override_settings(
+        DEBUG_TOOLBAR_CONFIG={"RESULTS_CACHE_SIZE": 1, "RENDER_PANELS": False}
+    )
+    def test_history_sidebar_expired_store_id(self):
+        """Validate the history sidebar view."""
+        self.client.get("/json_view/")
+        store_id = list(DebugToolbar._store)[0]
+        data = {"signed": SignedDataForm.sign({"store_id": store_id})}
+        response = self.client.get(reverse("djdt:history_sidebar"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            set(response.json()),
+            self.PANEL_KEYS,
+        )
+        self.client.get("/json_view/")
+
+        # Querying old store_id should return in empty response
+        data = {"signed": SignedDataForm.sign({"store_id": store_id})}
+        response = self.client.get(reverse("djdt:history_sidebar"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {})
+
+        # Querying with latest store_id
+        latest_store_id = list(DebugToolbar._store)[0]
+        data = {"signed": SignedDataForm.sign({"store_id": latest_store_id})}
+        response = self.client.get(reverse("djdt:history_sidebar"), data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            set(response.json()),
+            self.PANEL_KEYS,
         )
 
     def test_history_refresh_invalid_signature(self):
@@ -128,5 +164,10 @@ class HistoryViewsTestCase(IntegrationTestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data["requests"]), 1)
+
+        store_id = list(DebugToolbar._store)[0]
+        signature = SignedDataForm.sign({"store_id": store_id})
+        self.assertIn(html.escape(signature), data["requests"][0]["content"])
+
         for val in ["foo", "bar"]:
             self.assertIn(val, data["requests"][0]["content"])


### PR DESCRIPTION
- Allow refreshing while requests are still happening by
  using a list of dict.items()
- Fixed issue with `history_refresh`, it now returns SignedDataForm
  to allow Switch requests to work after refresh.
- Clean up old rows in FE from that have now expired when refresh
  happens.
- Fixed `history_sidebar` view to not raise 500 error when no toolbar
  is found for an expired `store_id`.
- Old rows that have now expired, display [EXPIRED] next to the
  Switch text.

Fixes https://github.com/jazzband/django-debug-toolbar/issues/1483