### PR TITLE
Support for request-level urlconf overrides

### DIFF
--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -146,7 +146,9 @@ class DebugToolbar:
         # The primary caller of this function is in the middleware which may
         # not have resolver_match set.
         try:
-            resolver_match = request.resolver_match or resolve(request.path, getattr(request, 'urlconf', None))
+            resolver_match = request.resolver_match or resolve(
+                request.path, getattr(request, "urlconf", None)
+            )
         except Resolver404:
             return False
         return resolver_match.namespaces and resolver_match.namespaces[-1] == app_name

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -146,7 +146,7 @@ class DebugToolbar:
         # The primary caller of this function is in the middleware which may
         # not have resolver_match set.
         try:
-            resolver_match = request.resolver_match or resolve(request.path)
+            resolver_match = request.resolver_match or resolve(request.path, getattr(request, 'urlconf', None))
         except Resolver404:
             return False
         return resolver_match.namespaces and resolver_match.namespaces[-1] == app_name

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Next version
 * Fixed ``RENDER_PANELS`` functionality so that when ``True`` panels are
   rendered during the request and not loaded asynchronously.
 * HistoryPanel now shows status codes of responses.
+* Support ``request.urlconf`` override when checking for toolbar requests.
 
 
 3.2.1 (2021-04-14)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -121,6 +121,17 @@ class DebugToolbarTestCase(BaseTestCase):
         self.request.path = "/render_panel/"
         self.assertFalse(self.toolbar.is_toolbar_request(self.request))
 
+    @override_settings(ROOT_URLCONF="tests.urls_invalid")
+    def test_is_toolbar_request_override_request_urlconf(self):
+        """Test cases when the toolbar URL is configured on the request."""
+        self.request.path = "/__debug__/render_panel/"
+        self.assertFalse(self.toolbar.is_toolbar_request(self.request))
+
+        # Verify overriding the urlconf on the request is valid.
+        self.request.urlconf = "tests.urls"
+        self.request.path = "/__debug__/render_panel/"
+        self.assertTrue(self.toolbar.is_toolbar_request(self.request))
+
 
 @override_settings(DEBUG=True)
 class DebugToolbarIntegrationTestCase(IntegrationTestCase):


### PR DESCRIPTION
Middlewares can override the default urlconf per request by setting a "urlconf" attribute to the inbound HttpRequest instance
(doc: https://docs.djangoproject.com/en/3.2/ref/request-response/#django.http.HttpRequest.urlconf )
This change adds support for this kind of override