### PR TITLE
Add warning for having django.contrib.postgres after debug_toolbar.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,7 +12,9 @@ Next version
   rendered during the request and not loaded asynchronously.
 * HistoryPanel now shows status codes of responses.
 * Support ``request.urlconf`` override when checking for toolbar requests.
-
+* Add warning W006 to indicate that ``django.contrib.postgres`` is
+  specified after ``debug_toolbar`` in ``INSTALLED_APPS`` which leads to
+  ``can't adapt type 'dict'`` messages.
 
 3.2.1 (2021-04-14)
 ------------------

--- a/docs/checks.rst
+++ b/docs/checks.rst
@@ -14,3 +14,5 @@ Debug Toolbar setup and configuration:
 * **debug_toolbar.W004**: ``debug_toolbar`` is incompatible with
   ``MIDDLEWARE_CLASSES`` setting.
 * **debug_toolbar.W005**: Setting ``DEBUG_TOOLBAR_PANELS`` is empty.
+* **debug_toolbar.W006**: ``django.contrib.postgres`` occurs after
+  ``debug_toolbar`` in ``INSTALLED_APPS``.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -91,6 +91,25 @@ class ChecksTestCase(SimpleTestCase):
             messages,
         )
 
+    @override_settings(
+        INSTALLED_APPS=[
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "debug_toolbar",
+            "django.contrib.postgres",
+        ]
+    )
+    def test_check_installed_apps_error(self):
+        messages = run_checks()
+        self.assertIn(
+            Warning(
+                "django.contrib.postgres occurs after django_toolbar in INSTALLED_APPS. This can lead to `can't adapt type 'dict'` messages.",
+                hint="Move django.contrib.postgres to before django_toolbar in INSTALLED_APPS.",
+                id="debug_toolbar.W006",
+            ),
+            messages,
+        )
+
     @unittest.skipIf(django.VERSION >= (4,), "Django>=4 handles missing dirs itself.")
     @override_settings(
         STATICFILES_DIRS=[PATH_DOES_NOT_EXIST],


### PR DESCRIPTION
Having the INSTALLED_APPS misconfigured in this was can lead to HStoreFields
throwing can't adapt type 'dict' messages.

This closes PR #804

Given the issues we've had with folks installing the toolbar, I think adding more documentation to the installation section is no longer the right approach. Instead logging a warning to the user when the apps are misconfigured should catch the developer's attention and be corrected.