### PR TITLE
Update translations and revert xgettext aliasing.

### DIFF
--- a/debug_toolbar/locale/en/LC_MESSAGES/django.po
+++ b/debug_toolbar/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Django Debug Toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-06 09:19+0200\n"
+"POT-Creation-Date: 2021-08-14 10:25-0500\n"
 "PO-Revision-Date: 2012-03-31 20:10+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,107 +20,111 @@ msgstr ""
 msgid "Debug Toolbar"
 msgstr ""
 
-#: panels/cache.py:188
+#: panels/cache.py:227
 msgid "Cache"
 msgstr ""
 
-#: panels/cache.py:193
+#: panels/cache.py:234
 #, python-format
 msgid "%(cache_calls)d call in %(time).2fms"
 msgid_plural "%(cache_calls)d calls in %(time).2fms"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/cache.py:201
+#: panels/cache.py:246
 #, python-format
 msgid "Cache calls from %(count)d backend"
 msgid_plural "Cache calls from %(count)d backends"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/headers.py:34
+#: panels/headers.py:33
 msgid "Headers"
 msgstr ""
 
-#: panels/logging.py:66
+#: panels/history/panel.py:20 panels/history/panel.py:21
+msgid "History"
+msgstr ""
+
+#: panels/logging.py:63
 msgid "Logging"
 msgstr ""
 
-#: panels/logging.py:72
+#: panels/logging.py:69
 #, python-format
 msgid "%(count)s message"
 msgid_plural "%(count)s messages"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/logging.py:75
+#: panels/logging.py:73
 msgid "Log messages"
 msgstr ""
 
-#: panels/profiling.py:148
+#: panels/profiling.py:150
 msgid "Profiling"
 msgstr ""
 
-#: panels/redirects.py:16
+#: panels/redirects.py:14
 msgid "Intercept redirects"
 msgstr ""
 
-#: panels/request.py:18
+#: panels/request.py:16
 msgid "Request"
 msgstr ""
 
-#: panels/request.py:35
+#: panels/request.py:36
 msgid "<no view>"
 msgstr ""
 
-#: panels/request.py:47
+#: panels/request.py:53
 msgid "<unavailable>"
 msgstr ""
 
-#: panels/settings.py:18
+#: panels/settings.py:24
 msgid "Settings"
 msgstr ""
 
-#: panels/settings.py:21
+#: panels/settings.py:27
 #, python-format
-msgid "Settings from <code>%s</code>"
+msgid "Settings from %s"
 msgstr ""
 
-#: panels/signals.py:44
+#: panels/signals.py:58
 #, python-format
 msgid "%(num_receivers)d receiver of 1 signal"
 msgid_plural "%(num_receivers)d receivers of 1 signal"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/signals.py:47
+#: panels/signals.py:66
 #, python-format
 msgid "%(num_receivers)d receiver of %(num_signals)d signals"
 msgid_plural "%(num_receivers)d receivers of %(num_signals)d signals"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/signals.py:52
+#: panels/signals.py:73
 msgid "Signals"
 msgstr ""
 
-#: panels/sql/panel.py:25
+#: panels/sql/panel.py:24
 msgid "Autocommit"
 msgstr ""
 
-#: panels/sql/panel.py:26
+#: panels/sql/panel.py:25
 msgid "Read uncommitted"
 msgstr ""
 
-#: panels/sql/panel.py:27
+#: panels/sql/panel.py:26
 msgid "Read committed"
 msgstr ""
 
-#: panels/sql/panel.py:28
+#: panels/sql/panel.py:27
 msgid "Repeatable read"
 msgstr ""
 
-#: panels/sql/panel.py:29
+#: panels/sql/panel.py:28
 msgid "Serializable"
 msgstr ""
 
@@ -144,11 +148,25 @@ msgstr ""
 msgid "Unknown"
 msgstr ""
 
-#: panels/sql/panel.py:108
+#: panels/sql/panel.py:109
 msgid "SQL"
 msgstr ""
 
-#: panels/staticfiles.py:88
+#: panels/sql/panel.py:114
+#, python-format
+msgid "%(query_count)d query in %(sql_time).2fms"
+msgid_plural "%(query_count)d queries in %(sql_time).2fms"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/sql/panel.py:127
+#, python-format
+msgid "SQL queries from %(count)d connection"
+msgid_plural "SQL queries from %(count)d connections"
+msgstr[0] ""
+msgstr[1] ""
+
+#: panels/staticfiles.py:85
 #, python-format
 msgid "Static files (%(num_found)s found, %(num_used)s used)"
 msgstr ""
@@ -157,75 +175,76 @@ msgstr ""
 msgid "Static files"
 msgstr ""
 
-#: panels/staticfiles.py:111
+#: panels/staticfiles.py:112
 #, python-format
 msgid "%(num_used)s file used"
 msgid_plural "%(num_used)s files used"
 msgstr[0] ""
 msgstr[1] ""
 
-#: panels/templates/panel.py:161
+#: panels/templates/panel.py:144
 msgid "Templates"
 msgstr ""
 
-#: panels/templates/panel.py:166
+#: panels/templates/panel.py:149
 #, python-format
 msgid "Templates (%(num_templates)s rendered)"
 msgstr ""
 
-#: panels/templates/panel.py:198
+#: panels/templates/panel.py:181
 msgid "No origin"
 msgstr ""
 
-#: panels/timer.py:26
+#: panels/timer.py:25
 #, python-format
 msgid "CPU: %(cum)0.2fms (%(total)0.2fms)"
 msgstr ""
 
-#: panels/timer.py:31
+#: panels/timer.py:30
 #, python-format
 msgid "Total: %0.2fms"
 msgstr ""
 
-#: panels/timer.py:37 templates/debug_toolbar/panels/logging.html:7
+#: panels/timer.py:36 templates/debug_toolbar/panels/history.html:9
+#: templates/debug_toolbar/panels/logging.html:7
 #: templates/debug_toolbar/panels/sql_explain.html:11
 #: templates/debug_toolbar/panels/sql_profile.html:12
 #: templates/debug_toolbar/panels/sql_select.html:11
 msgid "Time"
 msgstr ""
 
-#: panels/timer.py:45
+#: panels/timer.py:44
 msgid "User CPU time"
 msgstr ""
 
-#: panels/timer.py:45
+#: panels/timer.py:44
 #, python-format
 msgid "%(utime)0.3f msec"
 msgstr ""
 
-#: panels/timer.py:46
+#: panels/timer.py:45
 msgid "System CPU time"
 msgstr ""
 
-#: panels/timer.py:46
+#: panels/timer.py:45
 #, python-format
 msgid "%(stime)0.3f msec"
 msgstr ""
 
-#: panels/timer.py:47
+#: panels/timer.py:46
 msgid "Total CPU time"
 msgstr ""
 
-#: panels/timer.py:47
+#: panels/timer.py:46
 #, python-format
 msgid "%(total)0.3f msec"
 msgstr ""
 
-#: panels/timer.py:48
+#: panels/timer.py:47
 msgid "Elapsed time"
 msgstr ""
 
-#: panels/timer.py:48
+#: panels/timer.py:47
 #, python-format
 msgid "%(total_time)0.3f msec"
 msgstr ""
@@ -234,33 +253,33 @@ msgstr ""
 msgid "Context switches"
 msgstr ""
 
-#: panels/timer.py:49
+#: panels/timer.py:50
 #, python-format
 msgid "%(vcsw)d voluntary, %(ivcsw)d involuntary"
 msgstr ""
 
-#: panels/versions.py:20
+#: panels/versions.py:19
 msgid "Versions"
 msgstr ""
 
-#: templates/debug_toolbar/base.html:14
+#: templates/debug_toolbar/base.html:18
 msgid "Hide toolbar"
 msgstr ""
 
-#: templates/debug_toolbar/base.html:14
+#: templates/debug_toolbar/base.html:18
 msgid "Hide"
 msgstr ""
 
-#: templates/debug_toolbar/base.html:20
+#: templates/debug_toolbar/base.html:25
+msgid "Show toolbar"
+msgstr ""
+
+#: templates/debug_toolbar/includes/panel_button.html:4
 msgid "Disable for next and successive requests"
 msgstr ""
 
-#: templates/debug_toolbar/base.html:20
+#: templates/debug_toolbar/includes/panel_button.html:4
 msgid "Enable for next and successive requests"
-msgstr ""
-
-#: templates/debug_toolbar/base.html:42
-msgid "Show toolbar"
 msgstr ""
 
 #: templates/debug_toolbar/panels/cache.html:2
@@ -292,7 +311,7 @@ msgid "Calls"
 msgstr ""
 
 #: templates/debug_toolbar/panels/cache.html:43
-#: templates/debug_toolbar/panels/sql.html:30
+#: templates/debug_toolbar/panels/sql.html:36
 msgid "Time (ms)"
 msgstr ""
 
@@ -327,10 +346,8 @@ msgstr ""
 #: templates/debug_toolbar/panels/headers.html:9
 #: templates/debug_toolbar/panels/headers.html:28
 #: templates/debug_toolbar/panels/headers.html:49
-#: templates/debug_toolbar/panels/request.html:33
-#: templates/debug_toolbar/panels/request.html:59
-#: templates/debug_toolbar/panels/request.html:85
-#: templates/debug_toolbar/panels/request.html:110
+#: templates/debug_toolbar/panels/history_tr.html:23
+#: templates/debug_toolbar/panels/request_variables.html:11
 #: templates/debug_toolbar/panels/settings.html:6
 #: templates/debug_toolbar/panels/timer.html:11
 msgid "Value"
@@ -348,6 +365,33 @@ msgstr ""
 msgid ""
 "Since the WSGI environ inherits the environment of the server, only a "
 "significant subset is shown below."
+msgstr ""
+
+#: templates/debug_toolbar/panels/history.html:10
+msgid "Method"
+msgstr ""
+
+#: templates/debug_toolbar/panels/history.html:11
+#: templates/debug_toolbar/panels/staticfiles.html:43
+msgid "Path"
+msgstr ""
+
+#: templates/debug_toolbar/panels/history.html:12
+msgid "Request Variables"
+msgstr ""
+
+#: templates/debug_toolbar/panels/history.html:13
+msgid "Status"
+msgstr ""
+
+#: templates/debug_toolbar/panels/history.html:14
+#: templates/debug_toolbar/panels/sql.html:37
+msgid "Action"
+msgstr ""
+
+#: templates/debug_toolbar/panels/history_tr.html:22
+#: templates/debug_toolbar/panels/request_variables.html:10
+msgid "Variable"
 msgstr ""
 
 #: templates/debug_toolbar/panels/logging.html:6
@@ -408,38 +452,31 @@ msgstr ""
 msgid "Cookies"
 msgstr ""
 
-#: templates/debug_toolbar/panels/request.html:32
-#: templates/debug_toolbar/panels/request.html:58
-#: templates/debug_toolbar/panels/request.html:84
-#: templates/debug_toolbar/panels/request.html:109
-msgid "Variable"
-msgstr ""
-
-#: templates/debug_toolbar/panels/request.html:46
+#: templates/debug_toolbar/panels/request.html:27
 msgid "No cookies"
 msgstr ""
 
-#: templates/debug_toolbar/panels/request.html:50
+#: templates/debug_toolbar/panels/request.html:31
 msgid "Session data"
 msgstr ""
 
-#: templates/debug_toolbar/panels/request.html:72
+#: templates/debug_toolbar/panels/request.html:34
 msgid "No session data"
 msgstr ""
 
-#: templates/debug_toolbar/panels/request.html:76
+#: templates/debug_toolbar/panels/request.html:38
 msgid "GET data"
 msgstr ""
 
-#: templates/debug_toolbar/panels/request.html:98
+#: templates/debug_toolbar/panels/request.html:41
 msgid "No GET data"
 msgstr ""
 
-#: templates/debug_toolbar/panels/request.html:102
+#: templates/debug_toolbar/panels/request.html:45
 msgid "POST data"
 msgstr ""
 
-#: templates/debug_toolbar/panels/request.html:123
+#: templates/debug_toolbar/panels/request.html:48
 msgid "No POST data"
 msgstr ""
 
@@ -452,74 +489,66 @@ msgid "Signal"
 msgstr ""
 
 #: templates/debug_toolbar/panels/signals.html:6
-msgid "Providing"
-msgstr ""
-
-#: templates/debug_toolbar/panels/signals.html:7
 msgid "Receivers"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:7
+#: templates/debug_toolbar/panels/sql.html:6
 #, python-format
 msgid "%(num)s query"
 msgid_plural "%(num)s queries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/debug_toolbar/panels/sql.html:9
+#: templates/debug_toolbar/panels/sql.html:8
 #, python-format
 msgid ""
 "including <abbr title=\"Similar queries are queries with the same SQL, but "
 "potentially different parameters.\">%(count)s similar</abbr>"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:13
+#: templates/debug_toolbar/panels/sql.html:12
 #, python-format
 msgid ""
 "and <abbr title=\"Duplicate queries are identical to each other: they "
 "execute exactly the same SQL and parameters.\">%(dupes)s duplicates</abbr>"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:28
+#: templates/debug_toolbar/panels/sql.html:34
 msgid "Query"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:29
+#: templates/debug_toolbar/panels/sql.html:35
 #: templates/debug_toolbar/panels/timer.html:36
 msgid "Timeline"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:31
-msgid "Action"
-msgstr ""
-
-#: templates/debug_toolbar/panels/sql.html:48
+#: templates/debug_toolbar/panels/sql.html:52
 #, python-format
 msgid "%(count)s similar queries."
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:54
+#: templates/debug_toolbar/panels/sql.html:58
 #, python-format
 msgid "Duplicated %(dupes)s times."
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:86
+#: templates/debug_toolbar/panels/sql.html:95
 msgid "Connection:"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:88
+#: templates/debug_toolbar/panels/sql.html:97
 msgid "Isolation level:"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:91
+#: templates/debug_toolbar/panels/sql.html:100
 msgid "Transaction status:"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:105
+#: templates/debug_toolbar/panels/sql.html:114
 msgid "(unknown)"
 msgstr ""
 
-#: templates/debug_toolbar/panels/sql.html:114
+#: templates/debug_toolbar/panels/sql.html:123
 msgid "No SQL queries were recorded during this request."
 msgstr ""
 
@@ -594,10 +623,6 @@ msgid_plural "%(payload_count)s files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: templates/debug_toolbar/panels/staticfiles.html:43
-msgid "Path"
-msgstr ""
-
 #: templates/debug_toolbar/panels/template_source.html:4
 msgid "Template source:"
 msgstr ""
@@ -657,18 +682,18 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: templates/debug_toolbar/redirect.html:8
+#: templates/debug_toolbar/redirect.html:10
 msgid "Location:"
 msgstr ""
 
-#: templates/debug_toolbar/redirect.html:10
+#: templates/debug_toolbar/redirect.html:12
 msgid ""
 "The Django Debug Toolbar has intercepted a redirect to the above URL for "
 "debug viewing purposes. You can click the above link to continue with the "
 "redirect as normal."
 msgstr ""
 
-#: views.py:16
+#: views.py:15
 msgid ""
 "Data for this panel isn't available anymore. Please reload the page and "
 "retry."

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -19,7 +19,7 @@ from django.core.cache import (
 from django.core.cache.backends.base import BaseCache
 from django.dispatch import Signal
 from django.middleware import cache as middleware_cache
-from django.utils.translation import gettext_lazy as _, ngettext as __
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from debug_toolbar import settings as dt_settings
 from debug_toolbar.panels import Panel
@@ -230,7 +230,7 @@ class CachePanel(Panel):
     def nav_subtitle(self):
         cache_calls = len(self.calls)
         return (
-            __(
+            ngettext(
                 "%(cache_calls)d call in %(time).2fms",
                 "%(cache_calls)d calls in %(time).2fms",
                 cache_calls,
@@ -242,7 +242,7 @@ class CachePanel(Panel):
     def title(self):
         count = len(getattr(settings, "CACHES", ["default"]))
         return (
-            __(
+            ngettext(
                 "Cache calls from %(count)d backend",
                 "Cache calls from %(count)d backends",
                 count,

--- a/debug_toolbar/panels/logging.py
+++ b/debug_toolbar/panels/logging.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 
-from django.utils.translation import gettext_lazy as _, ngettext as __
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from debug_toolbar.panels import Panel
 from debug_toolbar.utils import ThreadCollector
@@ -66,7 +66,7 @@ class LoggingPanel(Panel):
     def nav_subtitle(self):
         stats = self.get_stats()
         record_count = len(stats["records"]) if stats else None
-        return __("%(count)s message", "%(count)s messages", record_count) % {
+        return ngettext("%(count)s message", "%(count)s messages", record_count) % {
             "count": record_count
         }
 

--- a/debug_toolbar/panels/signals.py
+++ b/debug_toolbar/panels/signals.py
@@ -20,7 +20,7 @@ from django.db.models.signals import (
     pre_save,
 )
 from django.utils.module_loading import import_string
-from django.utils.translation import gettext_lazy as _, ngettext as __
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from debug_toolbar.panels import Panel
 
@@ -54,7 +54,7 @@ class SignalsPanel(Panel):
         # hard coding of one signal
         if num_signals == 1:
             return (
-                __(
+                ngettext(
                     "%(num_receivers)d receiver of 1 signal",
                     "%(num_receivers)d receivers of 1 signal",
                     num_receivers,
@@ -62,7 +62,7 @@ class SignalsPanel(Panel):
                 % {"num_receivers": num_receivers}
             )
         return (
-            __(
+            ngettext(
                 "%(num_receivers)d receiver of %(num_signals)d signals",
                 "%(num_receivers)d receivers of %(num_signals)d signals",
                 num_receivers,

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -5,7 +5,7 @@ from pprint import saferepr
 
 from django.db import connections
 from django.urls import path
-from django.utils.translation import gettext_lazy as _, ngettext_lazy as __
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from debug_toolbar.forms import SignedDataForm
 from debug_toolbar.panels import Panel
@@ -110,16 +110,20 @@ class SQLPanel(Panel):
 
     @property
     def nav_subtitle(self):
-        return __("%d query in %.2fms", "%d queries in %.2fms", self._num_queries) % (
+        return ngettext(
+            "%(query_count)d query in %(sql_time).2fms",
+            "%(query_count)d queries in %(sql_time).2fms",
             self._num_queries,
-            self._sql_time,
-        )
+        ) % {
+            "query_count": self._num_queries,
+            "sql_time": self._sql_time,
+        }
 
     @property
     def title(self):
         count = len(self._databases)
         return (
-            __(
+            ngettext(
                 "SQL queries from %(count)d connection",
                 "SQL queries from %(count)d connections",
                 count,

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -6,7 +6,7 @@ from django.contrib.staticfiles import finders, storage
 from django.core.checks import Warning
 from django.core.files.storage import get_storage_class
 from django.utils.functional import LazyObject
-from django.utils.translation import gettext_lazy as _, ngettext as __
+from django.utils.translation import gettext_lazy as _, ngettext
 
 from debug_toolbar import panels
 from debug_toolbar.utils import ThreadCollector
@@ -108,9 +108,9 @@ class StaticFilesPanel(panels.Panel):
     @property
     def nav_subtitle(self):
         num_used = self.num_used
-        return __("%(num_used)s file used", "%(num_used)s files used", num_used) % {
-            "num_used": num_used
-        }
+        return ngettext(
+            "%(num_used)s file used", "%(num_used)s files used", num_used
+        ) % {"num_used": num_used}
 
     def process_request(self, request):
         collector.clear_collection()


### PR DESCRIPTION
Aliasing xgettext causes the usage not to be picked up by makemessages.
Only gettext and gettext_lazy work with aliasing.