### PR TITLE
only update if context exists

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -45,7 +45,8 @@ def _request_context_bind_template(self, template):
         name = "{}.{}".format(processor.__module__, processor.__name__)
         context = processor(self.request)
         self.context_processors[name] = context
-        updates.update(context)
+        if context:
+            updates.update(context)
     self.dicts[self._processors_index] = updates
 
     try:


### PR DESCRIPTION
fix for #542

fixes this error that comes if a user is not authenticated yet.
![image](https://user-images.githubusercontent.com/17788706/133594871-16b9cb39-ec91-4a50-9c26-6033f28fbfd5.png)
