### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-rc.1']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     services:
       mariadb:
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-rc.1']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     services:
       postgres:
@@ -143,7 +143,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-rc.1']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]


### PR DESCRIPTION
- switches workflow job matrix from rc1 to 3.10 proper, with [passing tests](https://github.com/joshuadavidthomas/django-debug-toolbar/actions)
- updates trove classifiers