### PR TITLE
Add Python 3.10 test pipeline for Django 3.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     packaging
     py{36,37}-dj{22,31,32}-{sqlite,postgresql,postgis,mysql}
     py{38,39}-dj{22,31,32,40,main}-{sqlite,postgresql,postgis,mysql}
-    py{310}-dj{40,main}-{sqlite,postgresql,postgis,mysql}
+    py{310}-dj{32,40,main}-{sqlite,postgresql,postgis,mysql}
 
 [testenv]
 deps =


### PR DESCRIPTION
[Django 3.2.9](https://docs.djangoproject.com/en/3.2/releases/3.2.9/) added compatibility with Python 3.10