### PR TITLE
Remove settings import from install instructions.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,11 +51,10 @@ Setting up URLconf
 Add the Debug Toolbar's URLs to your project's URLconf::
 
     import debug_toolbar
-    from django.conf import settings
     from django.urls import include, path
 
     urlpatterns = [
-        ...
+        # ...
         path('__debug__/', include(debug_toolbar.urls)),
     ]
 


### PR DESCRIPTION
The import of settings is no longer required after #1349