### PR TITLE
Use only pre-commit for style linters and fixers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,4 +221,4 @@ jobs:
         python -m pip install --upgrade tox
 
     - name: Test with tox
-      run: tox -e docs,style,packaging
+      run: tox -e docs,packaging

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,5 @@ docs/_build
 example/db.sqlite3
 htmlcov
 .tox
-node_modules
-package-lock.json
 geckodriver.log
 coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,8 @@ repos:
     -   id: eslint
         files: \.js?$
         types: [file]
+        args:
+        - --fix
 -   repo: https://github.com/psf/black
     rev: 21.11b1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,10 @@
-.PHONY: flake8 example test coverage translatable_strings update_translations
-
-PRETTIER_TARGETS = '**/*.(css|js)'
-
-style: package-lock.json
-	isort .
-	black --target-version=py36 .
-	flake8
-	npx eslint --ignore-path .gitignore --fix .
-	npx prettier --ignore-path .gitignore --write $(PRETTIER_TARGETS)
-	! grep -r '\(style=\|onclick=\|<script>\|<style\)' debug_toolbar/templates/
-
-style_check: package-lock.json
-	isort -c .
-	black --target-version=py36 --check .
-	flake8
-	npx eslint --ignore-path .gitignore .
-	npx prettier --ignore-path .gitignore --check $(PRETTIER_TARGETS)
-	! grep -r '\(style=\|onclick=\|<script>\|<style\)' debug_toolbar/templates/
+.PHONY: example test coverage translatable_strings update_translations
 
 example:
 	python example/manage.py migrate --noinput
 	-DJANGO_SUPERUSER_PASSWORD=p python example/manage.py createsuperuser \
 		--noinput --username="$(USER)" --email="$(USER)@mailinator.com"
 	python example/manage.py runserver
-
-package-lock.json: package.json
-	npm install
-	touch $@
 
 test:
 	DJANGO_SETTINGS_MODULE=tests.settings \

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -103,14 +103,19 @@ Style
 The Django Debug Toolbar uses `black <https://github.com/psf/black>`__ to
 format code and additionally uses flake8 and isort. The toolbar uses
 `pre-commit <https://pre-commit>`__ to automatically apply our style guidelines
-when a commit is made. If necessary this  can be bypassed using::
+when a commit is made. Set up pre-commit before committing with:
+
+    $ pre-commit install
+
+If necessary you can bypass pre-commit locally with::
 
     $ git commit --no-verify
 
+Note that it runs on CI.
 
 To reformat the code manually use::
 
-    $ make style
+    $ pre-commit run --all-files
 
 Patches
 -------

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -21,6 +21,7 @@ middleware
 middlewares
 multi
 neo
+pre
 profiler
 psycopg
 py

--- a/package.json
+++ b/package.json
@@ -1,6 +1,0 @@
-{
-    "devDependencies": {
-        "eslint": "^7.10.0",
-        "prettier": "^2.1.2"
-    }
-}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     docs
-    style
     packaging
     py{36,37}-dj{22,31,32}-{sqlite,postgresql,postgis,mysql}
     py{38,39}-dj{22,31,32,40,main}-{sqlite,postgresql,postgis,mysql}
@@ -67,14 +66,6 @@ commands = make -C {toxinidir}/docs spelling
 deps =
     Sphinx
     sphinxcontrib-spelling
-
-[testenv:style]
-commands = make style_check
-deps =
-    black>=19.10b0
-    flake8
-    isort>=5.0.2
-skip_install = true
 
 [testenv:packaging]
 commands =


### PR DESCRIPTION
The method of using the `Makefile`, running under `tox`, duplicated the work of pre-commit and pre-commit.ci. Additionally tox did not use the same pinned versions and arguments as in `.pre-commit-config.yaml`, so there is the potential for a version clash to cause the two paths to conflict, e.g. when a new version of Black is released.

Sticking to only `pre-commit` seems sensible, saves some CI time, and allows some files to be removed.