### PR TITLE
Remove codecov, solely use coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,0 @@
-[run]
-source = debug_toolbar
-branch = 1
-
-[report]
-omit = *tests*,*migrations*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
         with:
           name: coverage-data
 
-      - name: Combine coverage & fail if it's <100%.
+      - name: Combine coverage & check percentage
         run: |
           python -m coverage combine
           python -m coverage html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,7 +213,7 @@ jobs:
         run: |
           python -m coverage combine
           python -m coverage html --skip-covered --skip-empty
-          python -m coverage report --fail-under=100
+          python -m coverage report
 
       - name: Upload HTML report if check failed.
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Combine coverage & fail if it's <100%.
         run: |
           python -m coverage combine
-          python -m coverage html --skip-covered --skip-empty
+          python -m coverage html
           python -m coverage report
 
       - name: Upload HTML report if check failed.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,10 +70,11 @@ jobs:
         DB_HOST: 127.0.0.1
         DB_PORT: 3306
 
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v2
       with:
-        name: Python ${{ matrix.python-version }}
+        name: coverage-data
+        path: ".coverage.*"
 
   postgres:
     runs-on: ubuntu-latest
@@ -137,10 +138,11 @@ jobs:
         DB_HOST: localhost
         DB_PORT: 5432
 
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v2
       with:
-        name: Python ${{ matrix.python-version }}
+        name: coverage-data
+        path: ".coverage.*"
 
   sqlite:
     runs-on: ubuntu-latest
@@ -183,10 +185,42 @@ jobs:
         DB_BACKEND: sqlite3
         DB_NAME: ":memory:"
 
-    - name: Upload coverage
-      uses: codecov/codecov-action@v1
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v2
       with:
-        name: Python ${{ matrix.python-version }}
+        name: coverage-data
+        path: ".coverage.*"
+
+  coverage:
+    name: Check coverage.
+    runs-on: "ubuntu-latest"
+    needs: [sqlite, mysql, postgres]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          # Use latest, so it understands all syntax.
+          python-version: "3.10"
+
+      - run: python -m pip install --upgrade coverage
+
+      - name: Download coverage data.
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage-data
+
+      - name: Combine coverage & fail if it's <100%.
+        run: |
+          python -m coverage combine
+          python -m coverage html --skip-covered --skip-empty
+          python -m coverage report --fail-under=100
+
+      - name: Upload HTML report if check failed.
+        uses: actions/upload-artifact@v2
+        with:
+          name: html-report
+          path: htmlcov
+        if: ${{ failure() }}
 
   lint:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ source =
    .tox/*/site-packages
 
 [coverage:report]
+fail_under = 100
 show_missing = True
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,19 @@ exclude =
     tests
     tests.*
 
+[coverage:run]
+branch = True
+parallel = True
+source = debug_toolbar
+
+[coverage:paths]
+source =
+   src
+   .tox/*/site-packages
+
+[coverage:report]
+show_missing = True
+
 [flake8]
 extend-ignore = E203, E501
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ source =
    .tox/*/site-packages
 
 [coverage:report]
-fail_under = 100
+fail_under = 89
 show_missing = True
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,11 @@ exclude =
     tests
     tests.*
 
+
+[coverage.html]
+skip_covered = True
+skip_empty = True
+
 [coverage:run]
 branch = True
 parallel = True

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     sqlparse
 passenv=
     CI
+    COVERAGE_ARGS
     DB_BACKEND
     DB_NAME
     DB_USER
@@ -39,9 +40,10 @@ setenv =
     DB_USER = {env:DB_USER:debug_toolbar}
     DB_HOST = {env:DB_HOST:localhost}
     DB_PASSWORD =  {env:DB_PASSWORD:debug_toolbar}
+    DJANGO_SETTINGS_MODULE = tests.settings
 whitelist_externals = make
 pip_pre = True
-commands = make coverage TEST_ARGS='{posargs:tests}'
+commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
 [testenv:py{36,37,38,39,310}-dj{22,31,32}-postgresql]
 setenv =


### PR DESCRIPTION
CodeCov has become a bit flaky in their evaluation of code coverage.
Using GitHub actions, we can utilize coverage to combine multiple reports.

Thanks to Hynek Schlawack for the approach.
https://hynek.me/articles/ditch-codecov-python/