### PR TITLE
Avoid stripping additional characters from GIS SQL params.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,73 @@ jobs:
       with:
         name: Python ${{ matrix.python-version }}
 
+  postgis:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    services:
+      postgres:
+        image: postgis/postgis:14-3.1
+        env:
+          POSTGRES_DB: debug_toolbar
+          POSTGRES_USER: debug_toolbar
+          POSTGRES_PASSWORD: debug_toolbar
+        ports:
+        - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key:
+          ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.cfg') }}-${{ hashFiles('**/tox.ini') }}
+        restore-keys: |
+          ${{ matrix.python-version }}-v1-
+
+    - name: Install enchant (only for docs)
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get -y install enchant
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+
+    - name: Test with tox
+      run: tox
+      env:
+        DB_BACKEND: postgis
+        DB_HOST: localhost
+        DB_PORT: 5432
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        name: Python ${{ matrix.python-version }}
+
   sqlite:
     runs-on: ubuntu-latest
     strategy:

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -141,7 +141,9 @@ class NormalCursorWrapper(BaseCursorWrapper):
 
                 def strip_GeomFromEWKB(param):
                     if isinstance(param, str):
-                        return param.lstrip("ST_GeomFromEWKB('\\x").rstrip("'::bytea)")
+                        return param.split("ST_GeomFromEWKB('\\x", maxsplit=1)[
+                            0
+                        ].rsplit("'::bytea)", maxsplit=1)[0]
                     return param
 
                 params = [strip_GeomFromEWKB(param) for param in params]

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -89,6 +89,11 @@ databases)::
     psql> CREATE DATABASE debug_toolbar;
     psql> GRANT ALL PRIVILEGES ON DATABASE debug_toolbar to debug_toolbar;
 
+If you're going to test the PostGIS integration locally the PostgreSQL user
+will need to be a super user in order to create the extensions.
+
+    psql> ALTER USER debug_toolbar WITH SUPERUSER;
+
 For MySQL/MariaDB in a ``mysql`` shell::
 
     mysql> CREATE DATABASE debug_toolbar;

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,12 @@ setenv =
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
+[testenv:py{36,37,38,39,310}-dj{22,31,32,40,main}-postgis]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = postgis
+    DB_PORT = {env:DB_PORT:5432}
+
 [testenv:py{36,37,38,39,310}-dj{22,31,32,40,main}}-mysql]
 setenv =
     {[testenv]setenv}


### PR DESCRIPTION
If the param lead or ended with characters identified in the strip
calls, those characters would also be removed. Using split will
retain all of the characters in between the given strings.

When we drop support for < 3.9, we can switch to
the removeprefix and removesuffix functions.

Fixes #1543

This should add a test case that confirms the fix for 1543, but I'm unsure of what that would look like. If we think we absolutely need a test case for it, then perhaps we move it to `panels/sql/utils.py` so it can be in a unit test rather than an integration test.