### PR TITLE
Added MrBenn Panel to Third Party Panels

### DIFF
--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -141,6 +141,15 @@ Third-party panels
 
 If you'd like to add a panel to this list, please submit a pull request!
 
+MrBenn Toolbar Plugin
+~~~~~~~~~~
+
+URL: https://github.com/andytwoods/mrbenn
+
+Path: ``mrbenn_panel.panel.MrBennPanel``
+
+Allows you to quickly open template files and views directly in your IDE! In addition to the path above, you need to add ``mrbenn_panel`` in ``INSTALLED_APPS``
+
 Flamegraph
 ~~~~~~~~~~
 

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -141,15 +141,6 @@ Third-party panels
 
 If you'd like to add a panel to this list, please submit a pull request!
 
-MrBenn Toolbar Plugin
-~~~~~~~~~~
-
-URL: https://github.com/andytwoods/mrbenn
-
-Path: ``mrbenn_panel.panel.MrBennPanel``
-
-Allows you to quickly open template files and views directly in your IDE! In addition to the path above, you need to add ``mrbenn_panel`` in ``INSTALLED_APPS``
-
 Flamegraph
 ~~~~~~~~~~
 
@@ -243,6 +234,17 @@ URL: https://github.com/hmarr/django-debug-toolbar-mongo
 Path: ``debug_toolbar_mongo.panel.MongoDebugPanel``
 
 Adds MongoDB debugging information.
+
+MrBenn Toolbar Plugin
+~~~~~~~~~~~~~~~~~~~~~
+
+URL: https://github.com/andytwoods/mrbenn
+
+Path: ``mrbenn_panel.panel.MrBennPanel``
+
+Allows you to quickly open template files and views directly in your IDE!
+In addition to the path above, you need to add ``mrbenn_panel`` in
+``INSTALLED_APPS``
 
 Neo4j
 ~~~~~


### PR DESCRIPTION
The MrBenn Toolbar Plugin is an addon for the Django Debug Toolbar which allows you to quickly open template files and views in your IDE! It would be great if this could be added to the docs so that as many people as possible find out about it, since it can probably be one of the most used panels for DJT!