### PR TITLE
Avoid installing middleware if Content-Encoding is set at all

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -78,7 +78,7 @@ class DebugToolbarMiddleware:
         content_type = response.get("Content-Type", "").split(";")[0]
         if (
             getattr(response, "streaming", False)
-            or "gzip" in content_encoding
+            or content_encoding != ""
             or content_type not in _HTML_TYPES
         ):
             return response


### PR DESCRIPTION
The previous check for "gzip" ignored the possibility of other `Content-Encoding` values, such as Brotli’s ``br``, which the middleware could also not touch. Instead, do not attempt to alter the content for *any* `Content-Encoding`.

I tested by installing django-brotli in the example app below the toolbar middleware and hitting it with:

```
curl http://localhost:8000/ -H 'Accept-Encoding: br'
```

Without the change, it would crash with:

```
  File "/.../debug_toolbar/middleware.py", line 87, in __call__
    content = response.content.decode(response.charset)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc7 in position 1: invalid continuation byte
```

After, it is fixed.