### PR TITLE
Ignore all coverage files from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *~
 .idea
 build
-.coverage
+.coverage*
 dist
 django_debug_toolbar.egg-info
 docs/_build


### PR DESCRIPTION
Since #1542, coverage creates parallel files, with names like `.coverage.<hostname>.<pid>.<someothernumber>`, which need ignoring too.