### PR TITLE
Implement CacheStatTracker.get_or_set

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -89,6 +89,10 @@ class CacheStatTracker(BaseCache):
         return self.cache.set(*args, **kwargs)
 
     @send_signal
+    def get_or_set(self, *args, **kwargs):
+        return self.cache.get_or_set(*args, **kwargs)
+
+    @send_signal
     def touch(self, *args, **kwargs):
         return self.cache.touch(*args, **kwargs)
 
@@ -169,6 +173,7 @@ class CachePanel(Panel):
                 ("add", 0),
                 ("get", 0),
                 ("set", 0),
+                ("get_or_set", 0),
                 ("touch", 0),
                 ("delete", 0),
                 ("clear", 0),
@@ -197,7 +202,7 @@ class CachePanel(Panel):
         backend=None,
         **kw,
     ):
-        if name == "get":
+        if name == "get" or name == "get_or_set":
             if return_value is None:
                 self.misses += 1
             else:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,7 @@ Change log
 Next version
 ------------
 
+* Track calls to :py:meth:`django.core.caches.cache.get_or_set`.
 * Removed support for Django < 3.2.
 * Updated check ``W006`` to look for
   ``django.template.loaders.app_directories.Loader``.

--- a/tests/panels/test_cache.py
+++ b/tests/panels/test_cache.py
@@ -26,6 +26,75 @@ class CachePanelTestCase(BaseTestCase):
         second_cache.get("foo")
         self.assertEqual(len(self.panel.calls), 2)
 
+    def test_get_or_set_value(self):
+        cache.cache.get_or_set("baz", "val")
+        self.assertEqual(cache.cache.get("baz"), "val")
+        calls = [
+            (call["name"], call["args"], call["kwargs"]) for call in self.panel.calls
+        ]
+        self.assertEqual(
+            calls,
+            [
+                ("get_or_set", ("baz", "val"), {}),
+                ("get", ("baz",), {}),
+            ],
+        )
+        self.assertEqual(
+            self.panel.counts,
+            {
+                "add": 0,
+                "get": 1,
+                "set": 0,
+                "get_or_set": 1,
+                "touch": 0,
+                "delete": 0,
+                "clear": 0,
+                "get_many": 0,
+                "set_many": 0,
+                "delete_many": 0,
+                "has_key": 0,
+                "incr": 0,
+                "decr": 0,
+                "incr_version": 0,
+                "decr_version": 0,
+            },
+        )
+
+    def test_get_or_set_does_not_override_existing_value(self):
+        cache.cache.set("foo", "bar")
+        cached_value = cache.cache.get_or_set("foo", "other")
+        self.assertEqual(cached_value, "bar")
+        calls = [
+            (call["name"], call["args"], call["kwargs"]) for call in self.panel.calls
+        ]
+        self.assertEqual(
+            calls,
+            [
+                ("set", ("foo", "bar"), {}),
+                ("get_or_set", ("foo", "other"), {}),
+            ],
+        )
+        self.assertEqual(
+            self.panel.counts,
+            {
+                "add": 0,
+                "get": 0,
+                "set": 1,
+                "get_or_set": 1,
+                "touch": 0,
+                "delete": 0,
+                "clear": 0,
+                "get_many": 0,
+                "set_many": 0,
+                "delete_many": 0,
+                "has_key": 0,
+                "incr": 0,
+                "decr": 0,
+                "incr_version": 0,
+                "decr_version": 0,
+            },
+        )
+
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and


### PR DESCRIPTION
Capture the get_or_set() calls to the cache, keeping the tracker
interface in line with django.core.cache.backends.BaseCache.