### PR TITLE
Optimize render_stacktrace()

### DIFF
--- a/debug_toolbar/templates/debug_toolbar/panels/sql_stacktrace.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/sql_stacktrace.html
@@ -1,4 +1,0 @@
-{% for s in stacktrace %}<span class="djdt-path">{{s.0}}/</span><span class="djdt-file">{{s.1}}</span> in <span class="djdt-func">{{s.3}}</span>(<span class="djdt-lineno">{{s.2}}</span>)
-  <span class="djdt-code">{{s.4}}</span>
-  {% if show_locals %}<pre class="djdt-locals">{{s.5|pprint}}</pre>{% endif %}
-{% endfor %}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,7 @@ Next version
 * Reset settings when overridden in tests. Packages or projects using
   django-debug-toolbar can now use Django’s test settings tools, like
   ``@override_settings``, to reconfigure the toolbar during tests.
+* Optimize rendering of SQL panel, saving about 15% of its run time.
 
 3.2.4 (2021-12-15)
 ------------------


### PR DESCRIPTION
This function is called by the SQL panel to render each frame of each stack trace.

Previously it used a Django template, which is slow. By generating the HTML with pure Python code, we can avoid much of this overhead.

I tried this change on a demo app I built that has 96 total queries, due to N+1 queries. The queries execute in 13ms due to use of SQLite, so the whole view is a negligible concern. Nearly all the view runtime is the toolbar itself. Without this change, the runtime is ~1300ms; with the change it’s ~1100ms. That's a saving of **15%**.

I also checked the appearance of the generated HTML hasn’t changed.