### PR TITLE
Remove unnecessary mock dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist =
 deps =
     dj32: django~=3.2.9
     dj40: django~=4.0.0
-    sqlite: mock
     postgresql: psycopg2-binary
     postgis: psycopg2-binary
     mysql: mysqlclient


### PR DESCRIPTION
Presumably left over from Python 2, since Python 3 added mock to the standard library.