### PR TITLE
Optimize SQL reformatting

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,7 +11,7 @@ Next version
 * Reset settings when overridden in tests. Packages or projects using
   django-debug-toolbar can now use Django’s test settings tools, like
   ``@override_settings``, to reconfigure the toolbar during tests.
-* Optimize rendering of SQL panel, saving about 15% of its run time.
+* Optimize rendering of SQL panel, saving about 30% of its run time.
 
 3.2.4 (2021-12-15)
 ------------------


### PR DESCRIPTION
Add a few bits of caching:

1. Add sub-function to `parse_sql` with `lru_cache`, so that repeat calls with the same query are fast.
   This saves a lot of processing in N+1 situations.
2. Cache constructed filter stacks in `get_filter_stack()`.
   This avoids recreating all the various sqlparse objects for each query.
3. Pre-compile the simplification regex.
   The `re` module already uses an internal LRU cache of regexes, but this avoids recompiling if the regex ever drops out of that cache.

Building on top of #1571, this takes run time for the same tested view from ~1100ms to ~950ms, another ~15% saving.