### PR TITLE
unsigning history forms

### DIFF
--- a/debug_toolbar/panels/history/panel.py
+++ b/debug_toolbar/panels/history/panel.py
@@ -8,7 +8,6 @@ from django.urls import path
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from debug_toolbar.forms import SignedDataForm
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.history import views
 from debug_toolbar.panels.history.forms import HistoryStoreForm
@@ -84,9 +83,7 @@ class HistoryPanel(Panel):
         for id, toolbar in reversed(self.toolbar._store.items()):
             stores[id] = {
                 "toolbar": toolbar,
-                "form": SignedDataForm(
-                    initial=HistoryStoreForm(initial={"store_id": id}).initial
-                ),
+                "form": HistoryStoreForm(initial={"store_id": id}),
             }
 
         return render_to_string(
@@ -94,10 +91,8 @@ class HistoryPanel(Panel):
             {
                 "current_store_id": self.toolbar.store_id,
                 "stores": stores,
-                "refresh_form": SignedDataForm(
-                    initial=HistoryStoreForm(
-                        initial={"store_id": self.toolbar.store_id}
-                    ).initial
+                "refresh_form": HistoryStoreForm(
+                    initial={"store_id": self.toolbar.store_id}
                 ),
             },
         )

--- a/debug_toolbar/panels/history/views.py
+++ b/debug_toolbar/panels/history/views.py
@@ -1,17 +1,15 @@
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.template.loader import render_to_string
 
-from debug_toolbar.decorators import require_show_toolbar, signed_data_view
-from debug_toolbar.forms import SignedDataForm
+from debug_toolbar.decorators import require_show_toolbar
 from debug_toolbar.panels.history.forms import HistoryStoreForm
 from debug_toolbar.toolbar import DebugToolbar
 
 
 @require_show_toolbar
-@signed_data_view
-def history_sidebar(request, verified_data):
+def history_sidebar(request):
     """Returns the selected debug toolbar history snapshot."""
-    form = HistoryStoreForm(verified_data)
+    form = HistoryStoreForm(request.GET)
 
     if form.is_valid():
         store_id = form.cleaned_data["store_id"]
@@ -38,10 +36,9 @@ def history_sidebar(request, verified_data):
 
 
 @require_show_toolbar
-@signed_data_view
-def history_refresh(request, verified_data):
+def history_refresh(request):
     """Returns the refreshed list of table rows for the History Panel."""
-    form = HistoryStoreForm(verified_data)
+    form = HistoryStoreForm(request.GET)
 
     if form.is_valid():
         requests = []
@@ -56,11 +53,7 @@ def history_refresh(request, verified_data):
                             "id": id,
                             "store_context": {
                                 "toolbar": toolbar,
-                                "form": SignedDataForm(
-                                    initial=HistoryStoreForm(
-                                        initial={"store_id": id}
-                                    ).initial
-                                ),
+                                "form": HistoryStoreForm(initial={"store_id": id}),
                             },
                         },
                     ),

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -3,7 +3,6 @@ import html
 from django.test import RequestFactory, override_settings
 from django.urls import resolve, reverse
 
-from debug_toolbar.forms import SignedDataForm
 from debug_toolbar.toolbar import DebugToolbar
 
 from ..base import BaseTestCase, IntegrationTestCase
@@ -98,15 +97,11 @@ class HistoryViewsTestCase(IntegrationTestCase):
         response = self.client.get(reverse("djdt:history_sidebar"))
         self.assertEqual(response.status_code, 400)
 
-        data = {"signed": SignedDataForm.sign({"store_id": "foo"}) + "invalid"}
-        response = self.client.get(reverse("djdt:history_sidebar"), data=data)
-        self.assertEqual(response.status_code, 400)
-
     def test_history_sidebar(self):
         """Validate the history sidebar view."""
         self.client.get("/json_view/")
         store_id = list(DebugToolbar._store)[0]
-        data = {"signed": SignedDataForm.sign({"store_id": store_id})}
+        data = {"store_id": store_id}
         response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -121,7 +116,7 @@ class HistoryViewsTestCase(IntegrationTestCase):
         """Validate the history sidebar view."""
         self.client.get("/json_view/")
         store_id = list(DebugToolbar._store)[0]
-        data = {"signed": SignedDataForm.sign({"store_id": store_id})}
+        data = {"store_id": store_id}
         response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -131,14 +126,14 @@ class HistoryViewsTestCase(IntegrationTestCase):
         self.client.get("/json_view/")
 
         # Querying old store_id should return in empty response
-        data = {"signed": SignedDataForm.sign({"store_id": store_id})}
+        data = {"store_id": store_id}
         response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {})
 
         # Querying with latest store_id
         latest_store_id = list(DebugToolbar._store)[0]
-        data = {"signed": SignedDataForm.sign({"store_id": latest_store_id})}
+        data = {"store_id": latest_store_id}
         response = self.client.get(reverse("djdt:history_sidebar"), data=data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -146,28 +141,18 @@ class HistoryViewsTestCase(IntegrationTestCase):
             self.PANEL_KEYS,
         )
 
-    def test_history_refresh_invalid_signature(self):
-        response = self.client.get(reverse("djdt:history_refresh"))
-        self.assertEqual(response.status_code, 400)
-
-        data = {"signed": "eyJzdG9yZV9pZCI6ImZvbyIsImhhc2giOiI4YWFiMzIzZGZhODIyMW"}
-        response = self.client.get(reverse("djdt:history_refresh"), data=data)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(b"Invalid signature", response.content)
-
     def test_history_refresh(self):
         """Verify refresh history response has request variables."""
         data = {"foo": "bar"}
         self.client.get("/json_view/", data, content_type="application/json")
-        data = {"signed": SignedDataForm.sign({"store_id": "foo"})}
+        data = {"store_id": "foo"}
         response = self.client.get(reverse("djdt:history_refresh"), data=data)
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data["requests"]), 1)
 
         store_id = list(DebugToolbar._store)[0]
-        signature = SignedDataForm.sign({"store_id": store_id})
-        self.assertIn(html.escape(signature), data["requests"][0]["content"])
+        self.assertIn(html.escape(store_id), data["requests"][0]["content"])
 
         for val in ["foo", "bar"]:
             self.assertIn(val, data["requests"][0]["content"])


### PR DESCRIPTION
As discussed in #1577  Removing the signing feature of the history forms.

Arguments for the change: It doesn't really provide any security and makes working with them harder.

I can't personally think of a situation where an attacker has access to the debug toolbar + store_id + real database, but as is so often true with security it could be a not obvious exploit - please weigh in if this code is providing value!
