### PR TITLE
Order History panels requests descending chronologically.

### DIFF
--- a/debug_toolbar/panels/history/views.py
+++ b/debug_toolbar/panels/history/views.py
@@ -42,8 +42,8 @@ def history_refresh(request):
 
     if form.is_valid():
         requests = []
-        # Convert to list to handle mutations happenening in parallel
-        for id, toolbar in list(DebugToolbar._store.items())[::-1]:
+        # Convert to list to handle mutations happening in parallel
+        for id, toolbar in list(DebugToolbar._store.items()):
             requests.append(
                 {
                     "id": id,

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -143,16 +143,24 @@ class HistoryViewsTestCase(IntegrationTestCase):
 
     def test_history_refresh(self):
         """Verify refresh history response has request variables."""
-        data = {"foo": "bar"}
-        self.client.get("/json_view/", data, content_type="application/json")
-        data = {"store_id": "foo"}
-        response = self.client.get(reverse("djdt:history_refresh"), data=data)
+        self.client.get("/json_view/", {"foo": "bar"}, content_type="application/json")
+        self.client.get(
+            "/json_view/", {"spam": "eggs"}, content_type="application/json"
+        )
+
+        response = self.client.get(
+            reverse("djdt:history_refresh"), data={"store_id": "foo"}
+        )
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertEqual(len(data["requests"]), 1)
+        self.assertEqual(len(data["requests"]), 2)
 
-        store_id = list(DebugToolbar._store)[0]
-        self.assertIn(html.escape(store_id), data["requests"][0]["content"])
+        store_ids = list(DebugToolbar._store)
+        self.assertIn(html.escape(store_ids[0]), data["requests"][0]["content"])
+        self.assertIn(html.escape(store_ids[1]), data["requests"][1]["content"])
 
         for val in ["foo", "bar"]:
             self.assertIn(val, data["requests"][0]["content"])
+
+        for val in ["spam", "eggs"]:
+            self.assertIn(val, data["requests"][1]["content"])


### PR DESCRIPTION
While testing I noticed that the Refresh button on the history panel was ordering the requests backwards. I'm unsure when that broke, but modified the test case to cover that regression to prevent it in the future.