### PR TITLE
Single source 'djdt' app name

### DIFF
--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -1,8 +1,10 @@
-__all__ = ["VERSION"]
+__all__ = ["APP_NAME", "VERSION"]
+
+APP_NAME = "djdt"
 
 # Do not use pkg_resources to find the version but set it here directly!
 # see issue #1446
 VERSION = "3.2.4"
 
 # Code that discovers files or modules in INSTALLED_APPS imports this module.
-urls = "debug_toolbar.urls", "djdt"  # See debug_toolbar/urls.py
+urls = "debug_toolbar.urls", APP_NAME

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -14,7 +14,7 @@ from django.urls import path, resolve
 from django.urls.exceptions import Resolver404
 from django.utils.module_loading import import_string
 
-from debug_toolbar import settings as dt_settings
+from debug_toolbar import APP_NAME, settings as dt_settings
 
 
 class DebugToolbar:
@@ -144,8 +144,6 @@ class DebugToolbar:
         """
         Determine if the request is for a DebugToolbar view.
         """
-        from debug_toolbar.urls import app_name
-
         # The primary caller of this function is in the middleware which may
         # not have resolver_match set.
         try:
@@ -154,7 +152,7 @@ class DebugToolbar:
             )
         except Resolver404:
             return False
-        return resolver_match.namespaces and resolver_match.namespaces[-1] == app_name
+        return resolver_match.namespaces and resolver_match.namespaces[-1] == APP_NAME
 
     @staticmethod
     @lru_cache(maxsize=128)

--- a/debug_toolbar/urls.py
+++ b/debug_toolbar/urls.py
@@ -1,4 +1,5 @@
+from debug_toolbar import APP_NAME
 from debug_toolbar.toolbar import DebugToolbar
 
-app_name = "djdt"  # See debug_toolbar/__init__.py
+app_name = APP_NAME
 urlpatterns = DebugToolbar.get_urls()


### PR DESCRIPTION
Avoid needing to keep multiple constants in sync by defining an `APP_NAME` constant in `debug_toolbar.__init__` and referencing where it is needed.