### PR TITLE
Fix Docker instruction when host IP has more than 1 digit

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -141,7 +141,7 @@ option.
             import os  # only if you haven't already imported this
             import socket  # only if you haven't already imported this
             hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-            INTERNAL_IPS = [ip[:-1] + '1' for ip in ips] + ['127.0.0.1', '10.0.2.2']
+            INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
Instead of replacing the last char with `1`: replace everything starting from the last dot with `.1`. 

For instance, my Docker assigned the IP `172.30.0.14` to the interface which resulted to the wrong gateway IP `172.30.0.11`