### PR TITLE
Fix and improve .assertValidHTML() test method

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -35,7 +35,7 @@ class BaseTestCase(TestCase):
         parser = html5lib.HTMLParser()
         parser.parseFragment(content)
         if parser.errors:
-            msg_parts = ["Content is invalid HTML:"]
+            msg_parts = ["Invalid HTML:"]
             lines = content.split("\n")
             for position, errorcode, datavars in parser.errors:
                 msg_parts.append("  %s" % html5lib.constants.E[errorcode] % datavars)

--- a/tests/base.py
+++ b/tests/base.py
@@ -31,18 +31,16 @@ class BaseTestCase(TestCase):
     def get_response(self, request):
         return self._get_response(request)
 
-    def assertValidHTML(self, content, msg=None):
+    def assertValidHTML(self, content):
         parser = html5lib.HTMLParser()
         parser.parseFragment(content)
         if parser.errors:
-            default_msg = ["Content is invalid HTML:"]
+            msg_parts = ["Content is invalid HTML:"]
             lines = content.split("\n")
             for position, errorcode, datavars in parser.errors:
-                default_msg.append("  %s" % html5lib.constants.E[errorcode] % datavars)
-                default_msg.append("    %s" % lines[position[0] - 1])
-
-            msg = self._formatMessage(msg, "\n".join(default_msg))
-            raise self.failureException(msg)
+                msg_parts.append("  %s" % html5lib.constants.E[errorcode] % datavars)
+                msg_parts.append("    %s" % lines[position[0] - 1])
+            raise self.failureException("\n".join(msg_parts))
 
 
 class IntegrationTestCase(TestCase):

--- a/tests/base.py
+++ b/tests/base.py
@@ -33,7 +33,7 @@ class BaseTestCase(TestCase):
 
     def assertValidHTML(self, content, msg=None):
         parser = html5lib.HTMLParser()
-        parser.parseFragment(self.panel.content)
+        parser.parseFragment(content)
         if parser.errors:
             default_msg = ["Content is invalid HTML:"]
             lines = content.split("\n")

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -47,7 +47,7 @@ class TemplatesPanelTestCase(BaseTestCase):
 
         User.objects.create(username="admin")
         bad_repr = TemplateReprForm()
-        t = Template("{{ bad_repr }}")
+        t = Template("<table>{{ bad_repr }}</table>")
         c = Context({"bad_repr": bad_repr})
         html = t.render(c)
         self.assertIsNotNone(html)


### PR DESCRIPTION
The `BaseTestCase.assertValidHTML()` helper method was not parsing the passed in `content` argument, but instead `self.panel.content`.  Fix this issue, and also remove the `msg` argument which was never supplied by can callers.  Finally, fix a test case failure exposed by changing the method to parse the supplied `content`.