### PR TITLE
Preserve logs that LoggingPanel would previously overwrite

### DIFF
--- a/tests/panels/test_logging.py
+++ b/tests/panels/test_logging.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import patch
 
 from debug_toolbar.panels.logging import (
     MESSAGE_IF_STRING_REPRESENTATION_INVALID,
@@ -86,3 +87,10 @@ class LoggingPanelTestCase(BaseTestCase):
         self.assertEqual(
             MESSAGE_IF_STRING_REPRESENTATION_INVALID, records[0]["message"]
         )
+
+    @patch("sys.stderr")
+    def test_fallback_logging(self, mock_stderr):
+        # make sure the log reaches stderr even though logging set up
+        # its own handler during its import
+        self.logger.warning("hello")
+        mock_stderr.write.assert_called_once_with("hello\n")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,7 +11,10 @@ SECRET_KEY = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
 INTERNAL_IPS = ["127.0.0.1"]
 
-LOGGING_CONFIG = None  # avoids spurious output in tests
+LOGGING = {  # avoids spurious output in tests
+    "version": 1,
+    "disable_existing_loggers": True,
+}
 
 
 # Application definition


### PR DESCRIPTION
This might solve the root cause of issues reported in https://github.com/jazzband/django-debug-toolbar/issues/695 https://github.com/jazzband/django-debug-toolbar/issues/1078 and https://github.com/jazzband/django-debug-toolbar/issues/1300

-----

Summary:
LoggingPanel upon its import, changes the Python interpreter's root logger to log into a handler that collects its records for the LoggingPanel's display. However for users that don't explicitly configure the root logger this looks like the Debug Toolbar suppresses their logs that previously went to standard error.
With this commit, the logs will still keep going to standard error even if the LoggingPanel is installed, but only if the root logger has not been explicitly configured with a handler yet.
This behavior will make it so that installing DDT won't break logging neither for users that already have logging customizations nor for users that have an out-of-the-box django default logging setup.

Also: change LOGGING config in tests/settings.py because now DDT's own test suite would show more logs without an explicit config.
