### PR TITLE
Reduce SQL panel overhead

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -289,7 +289,5 @@ class SQLPanel(Panel):
         )
 
     def generate_server_timing(self, request, response):
-        stats = self.get_stats()
-        title = "SQL {} queries".format(len(stats.get("queries", [])))
-        value = stats.get("sql_time", 0)
-        self.record_server_timing("sql_time", title, value)
+        title = f"SQL {len(self._queries)} queries"
+        self.record_server_timing("sql_time", title, self._sql_time)

--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from collections import defaultdict
 from copy import copy
@@ -12,7 +13,11 @@ from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql import views
 from debug_toolbar.panels.sql.forms import SQLSelectForm
 from debug_toolbar.panels.sql.tracking import unwrap_cursor, wrap_cursor
-from debug_toolbar.panels.sql.utils import contrasting_color_generator, reformat_sql
+from debug_toolbar.panels.sql.utils import (
+    contrasting_color_generator,
+    decode_param,
+    reformat_sql,
+)
 from debug_toolbar.utils import render_stacktrace
 
 
@@ -196,6 +201,14 @@ class SQLPanel(Panel):
             trans_id = None
             for alias, recorded_query in self._queries:
                 query = dict(recorded_query)
+
+                try:
+                    params = json.dumps(decode_param(query["raw_params"]))
+                except TypeError:
+                    # object not JSON serializable
+                    params = ""
+                query["params"] = params
+
                 query_similar[alias][similar_key(query)] += 1
                 query_duplicates[alias][duplicate_key(query)] += 1
 

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -126,8 +126,6 @@ class NormalCursorWrapper(BaseCursorWrapper):
                 "raw_sql": sql,
                 "raw_params": params,
                 "stacktrace": stacktrace,
-                "is_slow": duration > dt_settings.get_config()["SQL_WARNING_THRESHOLD"],
-                "is_select": sql.lower().strip().startswith("select"),
                 "template_info": template_info,
             }
 

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -148,7 +148,7 @@ class NormalCursorWrapper(BaseCursorWrapper):
             # For logging purposes, make sure it's str.
             sql = str(sql)
 
-            params = {
+            kwargs = {
                 "vendor": vendor,
                 "alias": alias,
                 "sql": self.db.ops.last_executed_query(
@@ -174,7 +174,7 @@ class NormalCursorWrapper(BaseCursorWrapper):
                     iso_level = conn.isolation_level
                 except conn.InternalError:
                     iso_level = "unknown"
-                params.update(
+                kwargs.update(
                     {
                         "trans_id": self.logger.get_transaction_id(alias),
                         "trans_status": conn.get_transaction_status(),
@@ -184,7 +184,7 @@ class NormalCursorWrapper(BaseCursorWrapper):
                 )
 
             # We keep `sql` to maintain backwards compatibility
-            self.logger.record(**params)
+            self.logger.record(**kwargs)
 
     def callproc(self, procname, params=None):
         return self._record(self.cursor.callproc, procname, params)

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -159,8 +159,6 @@ class NormalCursorWrapper(BaseCursorWrapper):
                 "params": _params,
                 "raw_params": params,
                 "stacktrace": stacktrace,
-                "start_time": start_time,
-                "stop_time": stop_time,
                 "is_slow": duration > dt_settings.get_config()["SQL_WARNING_THRESHOLD"],
                 "is_select": sql.lower().strip().startswith("select"),
                 "template_info": template_info,

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -176,9 +176,7 @@ class SQLPanelTestCase(BaseTestCase):
 
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
-
-        # ensure query was logged
-        self.assertEqual(len(self.panel._queries), 3)
+        queries = self.panel.get_context()["queries"]
 
         if connection.vendor == "mysql" and django.VERSION >= (4, 1):
             # Django 4.1 started passing true/false back for boolean
@@ -194,7 +192,7 @@ class SQLPanelTestCase(BaseTestCase):
             expected_datetime = '["2017-12-22 16:07:01"]'
 
         self.assertEqual(
-            tuple(q[1]["params"] for q in self.panel._queries),
+            tuple(q["params"] for q in queries),
             (
                 expected_bools,
                 "[10, 1]",


### PR DESCRIPTION
The existing `SQLPanel.generate_stats()` method can be rather expensive if there are a lot of SQL queries.  This PR defers that expense by moving that code to a new `generate_context()` method, which only gets called if the panel's `.content` attribute is accessed.  Thus requests in which the user does not need to see the SQL Panel content get faster.

It also moves some code from the `NormalCursorWrapper._record()` function to the `SQLPanel.generate_context()` method to reduce the runtime overhead of recording SQL queries.