### PR TITLE
Reduce stacktrace capture overhead

### DIFF
--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -90,7 +90,12 @@ hidden_paths = [
 ]
 
 
+# os.path.realpath() is expensive since it has to hit the filesystem.  Since
+# omit_path() is called for each stack frame in tidy_stacktrace(), apply the
+# LRUCache() decorator to reduce the cost.
+@LRUCache()
 def omit_path(path):
+    path = os.path.realpath(path)
     return any(path.startswith(hidden_path) for hidden_path in hidden_paths)
 
 
@@ -105,7 +110,7 @@ def tidy_stacktrace(stack):
     """
     trace = []
     for frame, path, line_no, func_name, text in (f[:5] for f in stack):
-        if omit_path(os.path.realpath(path)):
+        if omit_path(path):
             continue
         text = "".join(text).strip() if text else ""
         frame_locals = (

--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -167,19 +167,18 @@ def get_name_from_obj(obj):
     return name
 
 
-def getframeinfo(frame, context=1):
+def getframeinfo(frame):
     """
     Get information about a frame or traceback object.
 
     A tuple of five things is returned: the filename, the line number of
     the current line, the function name, a list of lines of context from
     the source code, and the index of the current line within that list.
-    The optional second argument specifies the number of lines of context
-    to return, which are centered around the current line.
 
     This originally comes from ``inspect`` but is modified to handle issues
     with ``findsource()``.
     """
+    context = 1
     if inspect.istraceback(frame):
         lineno = frame.tb_lineno
         frame = frame.tb_frame
@@ -232,7 +231,7 @@ def get_sorted_request_variable(variable):
         return [(k, variable.getlist(k)) for k in sorted(variable)]
 
 
-def get_stack(context=1):
+def get_stack():
     """
     Get a list of records for a frame and all higher (calling) frames.
 
@@ -244,7 +243,7 @@ def get_stack(context=1):
     frame = sys._getframe(1)
     framelist = []
     while frame:
-        framelist.append((frame,) + getframeinfo(frame, context))
+        framelist.append((frame,) + getframeinfo(frame))
         frame = frame.f_back
     return framelist
 


### PR DESCRIPTION
The overhead of the SQL panel when `ENABLE_STACKTRACES` is enabled (the default) can be significant when there are a large number of queries.  After profiling, I found that nearly all the overhead was due to filesystem access in `debug_toolbar.utils.getframeinfo()` (called via `debug_toolbar.utils.get_stack()`), and the call to `os.path.realpath()` in `debug_toolbar.utils.tidy_stacktrace()`.  Applying LRU caching to both of those situations reduced the overhead to be almost negligible.

I had to implement a custom LRU cache rather than using Python's `functools.lru_cache`, as using frame objects directly as cache keys would cause them (and their associated locals) to stay in memory indefinitely.  The custom LRU cache takes a function which transform the frame argument into a suitable cache key.