### PR TITLE
Version 3.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Here's a screenshot of the toolbar in action:
 In addition to the built-in panels, a number of third-party panels are
 contributed by the community.
 
-The current stable version of the Debug Toolbar is 3.2.4. It works on
+The current stable version of the Debug Toolbar is 3.3.0. It works on
 Django ≥ 3.2.
 
 Documentation, including installation and configuration instructions, is

--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -4,7 +4,7 @@ APP_NAME = "djdt"
 
 # Do not use pkg_resources to find the version but set it here directly!
 # see issue #1446
-VERSION = "3.2.4"
+VERSION = "3.3.0"
 
 # Code that discovers files or modules in INSTALLED_APPS imports this module.
 urls = "debug_toolbar.urls", APP_NAME

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Change log
 Next version
 ------------
 
+3.3.0 (2022-04-28)
+------------------
+
 * Track calls to :py:meth:`django.core.caches.cache.get_or_set`.
 * Removed support for Django < 3.2.
 * Updated check ``W006`` to look for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = "{}, Django Debug Toolbar developers and contributors"
 copyright = copyright.format(datetime.date.today().year)
 
 # The full version, including alpha/beta/rc tags
-release = "3.2.4"
+release = "3.3.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-debug-toolbar
-version = 3.2.4
+version = 3.3.0
 description = A configurable set of panels that display various debug information about the current request/response.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
* Track calls to :py:meth:`django.core.caches.cache.get_or_set`.
* Removed support for Django < 3.2.
* Updated check ``W006`` to look for
  ``django.template.loaders.app_directories.Loader``.
* Reset settings when overridden in tests. Packages or projects using
  django-debug-toolbar can now use Django’s test settings tools, like
  ``@override_settings``, to reconfigure the toolbar during tests.
* Optimize rendering of SQL panel, saving about 30% of its run time.
* New records in history panel will flash green.
* Automatically update History panel on AJAX requests from client.

First time contributors:

- bellini666
- riwatt

Contributors to the release:

- adamchainz
- living180
- gone
- matthiask
- francoisfreitag
- pauloxnet