### PR TITLE
Update to 'debug_toolbar.middleware.show_toolbar'

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -4,6 +4,7 @@ Debug Toolbar middleware
 
 import re
 from functools import lru_cache
+from ipaddress import IPv4Address, IPv4Network, AddressValueError
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -18,8 +19,14 @@ def show_toolbar(request):
     """
     Default function to determine whether to show the toolbar on a given page.
     """
-    return settings.DEBUG and request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS
-
+    if settings.DEBUG is True and hasattr(settings, 'INTERNAL_IPS'):
+        for ip in settings.INTERNAL_IPS:
+            try:
+                if IPv4Address(request.META.get("REMOTE_ADDR")) in IPv4Network(ip):
+                    return True
+            except AddressValueError:
+                pass
+    return False
 
 @lru_cache()
 def get_show_toolbar():


### PR DESCRIPTION
I seem to remember reading somewhere that you wanted to be able to check if the REMOTE_ADDR was in a network range... I needed that too, so coded this up. The 'ipaddress' module is a standard module with Python3 and was introduced in v3.3.