### PR TITLE
The path may not always be a true path for stacktraces.

### DIFF
--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -72,10 +72,16 @@ def render_stacktrace(trace):
     show_locals = dt_settings.get_config()["ENABLE_STACKTRACES_LOCALS"]
     html = ""
     for abspath, lineno, func, code, locals_ in trace:
-        directory, filename = abspath.rsplit(os.path.sep, 1)
+        if os.path.sep in abspath:
+            directory, filename = abspath.rsplit(os.path.sep, 1)
+            # We want the separator to appear in the UI so add it back.
+            directory += os.path.sep
+        else:
+            directory = ""
+            filename = abspath
         html += format_html(
             (
-                '<span class="djdt-path">{}/</span>'
+                '<span class="djdt-path">{}</span>'
                 + '<span class="djdt-file">{}</span> in'
                 + ' <span class="djdt-func">{}</span>'
                 + '(<span class="djdt-lineno">{}</span>)\n'

--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -77,6 +77,7 @@ def render_stacktrace(trace):
             # We want the separator to appear in the UI so add it back.
             directory += os.path.sep
         else:
+            # abspath could be something like "<frozen importlib._bootstrap>"
             directory = ""
             filename = abspath
         html += format_html(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from debug_toolbar.utils import get_name_from_obj
+from debug_toolbar.utils import get_name_from_obj, render_stacktrace
 
 
 class GetNameFromObjTestCase(unittest.TestCase):
@@ -21,3 +21,29 @@ class GetNameFromObjTestCase(unittest.TestCase):
 
         res = get_name_from_obj(A)
         self.assertEqual(res, "tests.test_utils.A")
+
+
+class RenderStacktraceTestCase(unittest.TestCase):
+    def test_importlib_path_issue_1612(self):
+        trace = [
+            ("/server/app.py", 1, "foo", ["code line 1", "code line 2"], {"foo": "bar"})
+        ]
+        result = render_stacktrace(trace)
+        self.assertIn('<span class="djdt-path">/server/</span>', result)
+        self.assertIn('<span class="djdt-file">app.py</span> in', result)
+
+        trace = [
+            (
+                "<frozen importlib._bootstrap>",
+                1,
+                "foo",
+                ["code line 1", "code line 2"],
+                {"foo": "bar"},
+            )
+        ]
+        result = render_stacktrace(trace)
+        self.assertIn('<span class="djdt-path"></span>', result)
+        self.assertIn(
+            '<span class="djdt-file">&lt;frozen importlib._bootstrap&gt;</span> in',
+            result,
+        )


### PR DESCRIPTION
Occassionally we will get a stacktrace that's an importlib instance string
representation. While we may be able to put the python path or something else
it's likely easier (and more logical) to simply pass that onto the user.

I was unable to reproduce the issue in our tests, so I've mocked the case
in test_importlib_path_issue_1612.

Fixes #1612