### PR TITLE
Rename SQLPanel context var to control SQL access.

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -13,7 +13,7 @@ from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
 from debug_toolbar.panels import Panel
-from debug_toolbar.panels.sql.tracking import SQLQueryTriggered, recording
+from debug_toolbar.panels.sql.tracking import SQLQueryTriggered, allow_sql
 from debug_toolbar.panels.templates import views
 
 # Monkey-patch to enable the template_rendered signal. The receiver returns
@@ -118,7 +118,7 @@ class TemplatesPanel(Panel):
                                 value.model._meta.label,
                             )
                         else:
-                            token = recording.set(False)
+                            token = allow_sql.set(False)
                             try:
                                 saferepr(value)  # this MAY trigger a db query
                             except SQLQueryTriggered:
@@ -130,7 +130,7 @@ class TemplatesPanel(Panel):
                             else:
                                 temp_layer[key] = value
                             finally:
-                                recording.reset(token)
+                                allow_sql.reset(token)
                     pformatted = pformat(temp_layer)
                     self.pformat_layers.append((context_layer, pformatted))
                 context_list.append(pformatted)


### PR DESCRIPTION
The current build started failing for py3.8+ because the inner
exception SQLQueryTriggered was raised in the test
test_cursor_wrapper_asyncio_ctx.

This was identified as being caused by sql.tracking.recording
being set to false. The name recording made it seem as if
this context var was controlling whether recording was occurring
or not. However, it's true functionality was preventing SQL
queries from being sent during the template panel's processing.

Renaming that context var to allow_sql is more indicative of
its purpose and makes the fixed test change clearer.