### PR TITLE
Get PostgreSQL transaction tracking working

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -67,14 +67,15 @@ class SQLPanel(Panel):
     def get_transaction_id(self, alias):
         if alias not in connections:
             return
-        conn = connections[alias].connection
+        connection = connections[alias]
+        conn = connection.connection
         if not conn:
             return
 
-        if conn.vendor == "postgresql":
+        if connection.vendor == "postgresql":
             cur_status = conn.get_transaction_status()
         else:
-            raise ValueError(conn.vendor)
+            raise ValueError(connection.vendor)
 
         last_status = self._transaction_status.get(alias)
         self._transaction_status[alias] = cur_status

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -158,7 +158,7 @@ class NormalCursorWrapper(BaseCursorWrapper):
 
             alias = self.db.alias
             conn = self.db.connection
-            vendor = getattr(conn, "vendor", "unknown")
+            vendor = self.db.vendor
 
             # Sql might be an object (such as psycopg Composed).
             # For logging purposes, make sure it's str.

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -61,6 +61,7 @@ def wrap_cursor(connection, panel):
 def unwrap_cursor(connection):
     if hasattr(connection, "_djdt_cursor"):
         del connection._djdt_cursor
+        del connection._djdt_chunked_cursor
         del connection.cursor
         del connection.chunked_cursor
 

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -156,7 +156,7 @@ class NormalCursorWrapper(BaseCursorWrapper):
                 pass  # object not JSON serializable
             template_info = get_template_info()
 
-            alias = getattr(self.db, "alias", "default")
+            alias = self.db.alias
             conn = self.db.connection
             vendor = getattr(conn, "vendor", "unknown")
 

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -221,7 +221,6 @@ class NormalCursorWrapper(BaseCursorWrapper):
                         "trans_id": trans_id,
                         "trans_status": conn.get_transaction_status(),
                         "iso_level": iso_level,
-                        "encoding": conn.encoding,
                     }
                 )
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,7 @@
 import html5lib
 from asgiref.local import Local
 from django.http import HttpResponse
-from django.test import Client, RequestFactory, TestCase
+from django.test import Client, RequestFactory, TestCase, TransactionTestCase
 
 from debug_toolbar.toolbar import DebugToolbar
 
@@ -29,7 +29,7 @@ class ToolbarTestClient(Client):
 rf = RequestFactory()
 
 
-class BaseTestCase(TestCase):
+class BaseMixin:
     client_class = ToolbarTestClient
 
     panel_id = None
@@ -65,6 +65,14 @@ class BaseTestCase(TestCase):
                 msg_parts.append("  %s" % html5lib.constants.E[errorcode] % datavars)
                 msg_parts.append("    %s" % lines[position[0] - 1])
             raise self.failureException("\n".join(msg_parts))
+
+
+class BaseTestCase(BaseMixin, TestCase):
+    pass
+
+
+class BaseMultiDBTestCase(BaseMixin, TransactionTestCase):
+    databases = {"default", "replica"}
 
 
 class IntegrationTestCase(TestCase):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -104,6 +104,20 @@ DATABASES = {
             "USER": "default_test",
         },
     },
+    "replica": {
+        "ENGINE": "django.{}db.backends.{}".format(
+            "contrib.gis." if USE_GIS else "", os.getenv("DB_BACKEND", "sqlite3")
+        ),
+        "NAME": os.getenv("DB_NAME", ":memory:"),
+        "USER": os.getenv("DB_USER"),
+        "PASSWORD": os.getenv("DB_PASSWORD"),
+        "HOST": os.getenv("DB_HOST", ""),
+        "PORT": os.getenv("DB_PORT", ""),
+        "TEST": {
+            "USER": "default_test",
+            "MIRROR": "default",
+        },
+    },
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ whitelist_externals = make
 pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
-[testenv:py{37,38,39,310}-dj{40,41,main}-postgresql]
+[testenv:py{37,38,39,310}-dj{32,40,41,main}-postgresql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql


### PR DESCRIPTION
There were bugs at multiple levels that prevented PostgreSQL transactions from being tracked properly.  This PR hopefully fixes all of those, plus adds a test for this functionality.