### PR TITLE
Replace OrderedDict

### DIFF
--- a/debug_toolbar/forms.py
+++ b/debug_toolbar/forms.py
@@ -47,7 +47,6 @@ class SignedDataForm(forms.Form):
 
     @classmethod
     def sign(cls, data):
-        items = sorted(data.items(), key=lambda item: item[0])
         return signing.Signer(salt=cls.salt).sign(
-            json.dumps({key: force_str(value) for key, value in items})
+            json.dumps({key: force_str(value) for key, value in data.items()})
         )

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -1,7 +1,6 @@
 import inspect
 import sys
 import time
-from collections import OrderedDict
 
 try:
     from django.utils.connection import ConnectionProxy
@@ -168,25 +167,23 @@ class CachePanel(Panel):
         self.hits = 0
         self.misses = 0
         self.calls = []
-        self.counts = OrderedDict(
-            (
-                ("add", 0),
-                ("get", 0),
-                ("set", 0),
-                ("get_or_set", 0),
-                ("touch", 0),
-                ("delete", 0),
-                ("clear", 0),
-                ("get_many", 0),
-                ("set_many", 0),
-                ("delete_many", 0),
-                ("has_key", 0),
-                ("incr", 0),
-                ("decr", 0),
-                ("incr_version", 0),
-                ("decr_version", 0),
-            )
-        )
+        self.counts = {
+            "add": 0,
+            "get": 0,
+            "set": 0,
+            "get_or_set": 0,
+            "touch": 0,
+            "delete": 0,
+            "clear": 0,
+            "get_many": 0,
+            "set_many": 0,
+            "delete_many": 0,
+            "has_key": 0,
+            "incr": 0,
+            "decr": 0,
+            "incr_version": 0,
+            "decr_version": 0,
+        }
         cache_called.connect(self._store_call_info)
 
     def _store_call_info(

--- a/debug_toolbar/panels/headers.py
+++ b/debug_toolbar/panels/headers.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.utils.translation import gettext_lazy as _
 
 from debug_toolbar.panels import Panel
@@ -36,21 +34,19 @@ class HeadersPanel(Panel):
 
     def process_request(self, request):
         wsgi_env = list(sorted(request.META.items()))
-        self.request_headers = OrderedDict(
-            (unmangle(k), v) for (k, v) in wsgi_env if is_http_header(k)
-        )
+        self.request_headers = {
+            unmangle(k): v for (k, v) in wsgi_env if is_http_header(k)
+        }
         if "Cookie" in self.request_headers:
             self.request_headers["Cookie"] = "=> see Request panel"
-        self.environ = OrderedDict(
-            (k, v) for (k, v) in wsgi_env if k in self.ENVIRON_FILTER
-        )
+        self.environ = {k: v for (k, v) in wsgi_env if k in self.ENVIRON_FILTER}
         self.record_stats(
             {"request_headers": self.request_headers, "environ": self.environ}
         )
         return super().process_request(request)
 
     def generate_stats(self, request, response):
-        self.response_headers = OrderedDict(sorted(response.items()))
+        self.response_headers = dict(sorted(response.items()))
         self.record_stats({"response_headers": self.response_headers})
 
 

--- a/debug_toolbar/panels/history/panel.py
+++ b/debug_toolbar/panels/history/panel.py
@@ -1,5 +1,4 @@
 import json
-from collections import OrderedDict
 
 from django.http.request import RawPostDataException
 from django.template.loader import render_to_string
@@ -87,7 +86,7 @@ class HistoryPanel(Panel):
 
         Fetch every store for the toolbar and include it in the template.
         """
-        stores = OrderedDict()
+        stores = {}
         for id, toolbar in reversed(self.toolbar._store.items()):
             stores[id] = {
                 "toolbar": toolbar,

--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from django.views.debug import get_default_exception_reporter_filter
@@ -23,9 +21,5 @@ class SettingsPanel(Panel):
 
     def generate_stats(self, request, response):
         self.record_stats(
-            {
-                "settings": OrderedDict(
-                    sorted(get_safe_settings().items(), key=lambda s: s[0])
-                )
-            }
+            {"settings": dict(sorted(get_safe_settings().items(), key=lambda s: s[0]))}
         )

--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -20,6 +20,4 @@ class SettingsPanel(Panel):
         return _("Settings from %s") % settings.SETTINGS_MODULE
 
     def generate_stats(self, request, response):
-        self.record_stats(
-            {"settings": dict(sorted(get_safe_settings().items(), key=lambda s: s[0]))}
-        )
+        self.record_stats({"settings": dict(sorted(get_safe_settings().items()))})

--- a/debug_toolbar/panels/signals.py
+++ b/debug_toolbar/panels/signals.py
@@ -76,7 +76,7 @@ class SignalsPanel(Panel):
 
     def generate_stats(self, request, response):
         signals = []
-        for name, signal in sorted(self.signals.items(), key=lambda x: x[0]):
+        for name, signal in sorted(self.signals.items()):
             receivers = []
             for receiver in signal.receivers:
                 receiver = receiver[1]

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from os.path import join, normpath
 
 from django.conf import settings
@@ -137,7 +136,7 @@ class StaticFilesPanel(panels.Panel):
         of relative and file system paths which that finder was able
         to find.
         """
-        finders_mapping = OrderedDict()
+        finders_mapping = {}
         for finder in finders.get_finders():
             try:
                 for path, finder_storage in finder.list([]):

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from contextlib import contextmanager
 from os.path import normpath
 from pprint import pformat, saferepr
@@ -39,7 +38,7 @@ def _request_context_bind_template(self, template):
     self.template = template
     # Set context processors according to the template engine's settings.
     processors = template.engine.template_context_processors + self._processors
-    self.context_processors = OrderedDict()
+    self.context_processors = {}
     updates = {}
     for processor in processors:
         name = f"{processor.__module__}.{processor.__name__}"

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -28,6 +28,9 @@ class DebugToolbar:
             if panel.enabled:
                 get_response = panel.process_request
         self.process_request = get_response
+        # Use OrderedDict for the _panels attribute so that items can be efficiently
+        # removed using FIFO order in the DebugToolbar.store() method.  The .popitem()
+        # method of Python's built-in dict only supports LIFO removal.
         self._panels = OrderedDict()
         while panels:
             panel = panels.pop()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -7,7 +7,7 @@ from debug_toolbar.forms import SignedDataForm
 
 SIGNATURE = "-WiogJKyy4E8Om00CrFSy0T6XHObwBa6Zb46u-vmeYE"
 
-DATA = {"value": "foo", "date": datetime(2020, 1, 1, tzinfo=timezone.utc)}
+DATA = {"date": datetime(2020, 1, 1, tzinfo=timezone.utc), "value": "foo"}
 SIGNED_DATA = f'{{"date": "2020-01-01 00:00:00+00:00", "value": "foo"}}:{SIGNATURE}'
 
 


### PR DESCRIPTION
Replace most usages of `OrderedDict` with plain Python dicts since as of Python 3.7, dicts are guaranteed to maintain insertion order.  Also make a couple of small improvements related to sorting dicts.