### PR TITLE
Cache panel work

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -17,9 +17,10 @@ class DebugToolbarConfig(AppConfig):
     def ready(self):
         from debug_toolbar.toolbar import DebugToolbar
 
-        # Import the panels when the app is ready. This allows panels
-        # like CachePanel to enable the instrumentation immediately.
-        DebugToolbar.get_panel_classes()
+        # Import the panels when the app is ready and call their ready() methods.  This
+        # allows panels like CachePanel to enable their instrumentation immediately.
+        for cls in DebugToolbar.get_panel_classes():
+            cls.ready()
 
 
 def check_template_config(config):

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -114,6 +114,19 @@ class Panel:
         """
         return []
 
+    # Panel early initialization
+
+    @classmethod
+    def ready(cls):
+        """
+        Perform early initialization for the panel.
+
+        This should only include initialization or instrumentation that needs to
+        be done unconditionally for the panel regardless of whether it is
+        enabled for a particular request.  It should be idempotent.
+        """
+        pass
+
     # URLs for panel-specific views
 
     @classmethod

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
+from django.dispatch import Signal
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
 from django.urls import path, resolve
@@ -18,6 +19,9 @@ from debug_toolbar import APP_NAME, settings as dt_settings
 
 
 class DebugToolbar:
+    # for internal testing use only
+    _created = Signal()
+
     def __init__(self, request, get_response):
         self.request = request
         self.config = dt_settings.get_config().copy()
@@ -38,6 +42,7 @@ class DebugToolbar:
         self.stats = {}
         self.server_timing_stats = {}
         self.store_id = None
+        self._created.send(request, toolbar=self)
 
     # Manage panels
 

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -352,6 +352,8 @@ unauthorized access. There is no public CSS API at this time.
 
     .. autoattribute:: debug_toolbar.panels.Panel.scripts
 
+    .. automethod:: debug_toolbar.panels.Panel.ready
+
     .. automethod:: debug_toolbar.panels.Panel.get_urls
 
     .. automethod:: debug_toolbar.panels.Panel.enable_instrumentation

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ classifiers =
 [options]
 python_requires = >=3.7
 install_requires =
+    asgiref >= 3.3.2, < 4
     Django >= 3.2
     sqlparse >= 0.2.0
 packages = find:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -109,10 +109,10 @@ class DebugToolbarTestCase(BaseTestCase):
         # Clear the cache before testing the views. Other tests that use cached_view
         # may run earlier and cause fewer cache calls.
         cache.clear()
-        self.client.get("/cached_view/")
-        self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 3)
-        self.client.get("/cached_view/")
-        self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 5)
+        response = self.client.get("/cached_view/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("CachePanel").calls), 3)
+        response = self.client.get("/cached_view/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("CachePanel").calls), 2)
 
     @override_settings(ROOT_URLCONF="tests.urls_use_package_urls")
     def test_include_package_urls(self):
@@ -120,17 +120,17 @@ class DebugToolbarTestCase(BaseTestCase):
         # Clear the cache before testing the views. Other tests that use cached_view
         # may run earlier and cause fewer cache calls.
         cache.clear()
-        self.client.get("/cached_view/")
-        self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 3)
-        self.client.get("/cached_view/")
-        self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 5)
+        response = self.client.get("/cached_view/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("CachePanel").calls), 3)
+        response = self.client.get("/cached_view/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("CachePanel").calls), 2)
 
     def test_low_level_cache_view(self):
         """Test cases when low level caching API is used within a request."""
-        self.client.get("/cached_low_level_view/")
-        self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 2)
-        self.client.get("/cached_low_level_view/")
-        self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 3)
+        response = self.client.get("/cached_low_level_view/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("CachePanel").calls), 2)
+        response = self.client.get("/cached_low_level_view/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("CachePanel").calls), 1)
 
     def test_cache_disable_instrumentation(self):
         """
@@ -139,10 +139,10 @@ class DebugToolbarTestCase(BaseTestCase):
         """
         self.assertIsNone(cache.set("UseCacheAfterToolbar.before", None))
         self.assertIsNone(cache.set("UseCacheAfterToolbar.after", None))
-        self.client.get("/execute_sql/")
+        response = self.client.get("/execute_sql/")
         self.assertEqual(cache.get("UseCacheAfterToolbar.before"), 1)
         self.assertEqual(cache.get("UseCacheAfterToolbar.after"), 1)
-        self.assertEqual(len(self.toolbar.get_panel_by_id("CachePanel").calls), 0)
+        self.assertEqual(len(response.toolbar.get_panel_by_id("CachePanel").calls), 0)
 
     def test_is_toolbar_request(self):
         self.request.path = "/__debug__/render_panel/"


### PR DESCRIPTION
This PR re-architects `CachePanel` call recording.  Using signals for monitoring cache calls gives incorrect results in the face of concurrency.  If two requests are being processed concurrently in different threads, they will store each other's cache calls because both panels will be subscribed to the same signal.  This PR updates the code to record the cache calls directly via a method on the panel instance rather than going through signals.

Additionally, it reworks the `enable_instrumentation()` mechanism to monkey patch methods on the cache instances directly instead of replacing the cache instances with wrapper classes.  This should eliminate the corner cases mentioned in the (now-removed) `disable_instrumentation()` comments.

One change I made as part of the preparatory work for these changes is adding a `ready()` class method to the panel API, to be called from the `DebugToolbarConfig.ready()` method.  This provides a clean way for panels to perform any initialization or instrumentation that needs to be done unconditionally for the panel regardless of whether it is enabled for a particular request.  This in theory could cause backwards compatibility issues if a third-party panel already had a `ready` method or attribute.  I did check all the third-party panels listed in the Debug Toolbar documentation, and none of them would be affected by this change.  However, if there are still backwards compatibility concerns about the addition of this method, I can rework this part of the PR.