### PR TITLE
Reimplement HIDE_IN_STACKTRACES machinery

### DIFF
--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -6,7 +6,6 @@ import warnings
 from importlib import import_module
 from pprint import pformat
 
-import django
 from asgiref.local import Local
 from django.core.exceptions import ImproperlyConfigured
 from django.template import Node
@@ -22,10 +21,6 @@ except ImportError:
 
 
 _local_data = Local()
-
-
-# Figure out some paths
-django_path = os.path.realpath(os.path.dirname(django.__file__))
 
 
 def get_module_path(module_name):


### PR DESCRIPTION
The pre-existing `HIDE_IN_STACKTRACES` machinery was based on file system paths, but was rather inefficient because it required a file system operation (`os.path.realpath()`) for each stack frame.  In addition, it would not work properly for namespace packages since they can have multiple file system hierarchies.

The new implementation avoids using paths altogether and instead uses the `__name__` variable found in each frame's `f_globals` attribute to determine the associated module name, and compares that directly with the list of module names provided in the `HIDE_IN_STACKTRACES` setting.