### PR TITLE
Tweak get_stack_trace() API

### DIFF
--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -135,7 +135,7 @@ class CachePanel(Panel):
             return_value=value,
             args=args,
             kwargs=kwargs,
-            trace=get_stack_trace(),
+            trace=get_stack_trace(skip=2),
             template_info=get_template_info(),
             backend=cache,
         )

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -176,7 +176,7 @@ class NormalCursorWrapper(BaseCursorWrapper):
                 "raw_sql": sql,
                 "params": _params,
                 "raw_params": params,
-                "stacktrace": get_stack_trace(),
+                "stacktrace": get_stack_trace(skip=2),
                 "start_time": start_time,
                 "stop_time": stop_time,
                 "is_slow": duration > dt_settings.get_config()["SQL_WARNING_THRESHOLD"],

--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -308,18 +308,17 @@ class _StackTraceRecorder:
 
 def get_stack_trace(*, depth=1):
     config = dt_settings.get_config()
-    if config["ENABLE_STACKTRACES"]:
-        stack_trace_recorder = getattr(_local_data, "stack_trace_recorder", None)
-        if stack_trace_recorder is None:
-            stack_trace_recorder = _StackTraceRecorder()
-            _local_data.stack_trace_recorder = stack_trace_recorder
-        return stack_trace_recorder.get_stack_trace(
-            excluded_modules=config["HIDE_IN_STACKTRACES"],
-            include_locals=config["ENABLE_STACKTRACES_LOCALS"],
-            depth=depth,
-        )
-    else:
+    if not config["ENABLE_STACKTRACES"]:
         return []
+    stack_trace_recorder = getattr(_local_data, "stack_trace_recorder", None)
+    if stack_trace_recorder is None:
+        stack_trace_recorder = _StackTraceRecorder()
+        _local_data.stack_trace_recorder = stack_trace_recorder
+    return stack_trace_recorder.get_stack_trace(
+        excluded_modules=config["HIDE_IN_STACKTRACES"],
+        include_locals=config["ENABLE_STACKTRACES_LOCALS"],
+        depth=depth,
+    )
 
 
 def clear_stack_trace_caches():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,12 @@
 import unittest
 
+from django.test import override_settings
+
+import debug_toolbar.utils
 from debug_toolbar.utils import (
     get_name_from_obj,
     get_stack,
+    get_stack_trace,
     render_stacktrace,
     tidy_stacktrace,
 )
@@ -55,6 +59,20 @@ class RenderStacktraceTestCase(unittest.TestCase):
 
 
 class StackTraceTestCase(unittest.TestCase):
+    @override_settings(DEBUG_TOOLBAR_CONFIG={"HIDE_IN_STACKTRACES": []})
+    def test_get_stack_trace_skip(self):
+        stack_trace = get_stack_trace(skip=-1)
+        self.assertTrue(len(stack_trace) > 2)
+        self.assertEqual(stack_trace[-1][0], debug_toolbar.utils.__file__)
+        self.assertEqual(stack_trace[-1][2], "get_stack_trace")
+        self.assertEqual(stack_trace[-2][0], __file__)
+        self.assertEqual(stack_trace[-2][2], "test_get_stack_trace_skip")
+
+        stack_trace = get_stack_trace()
+        self.assertTrue(len(stack_trace) > 1)
+        self.assertEqual(stack_trace[-1][0], __file__)
+        self.assertEqual(stack_trace[-1][2], "test_get_stack_trace_skip")
+
     def test_deprecated_functions(self):
         with self.assertWarns(DeprecationWarning):
             stack = get_stack()


### PR DESCRIPTION
Replace the `depth` argument to `get_stack_trace()` with a more intuitive `skip` argument.  Update the cache and SQL panels to supply a `skip` argument to `get_stack_trace()` to ensure that the stack traces are clean even when `HIDE_IN_STACKTRACES` is empty.