### PR TITLE
django-debug-toolbar 3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Here's a screenshot of the toolbar in action:
 In addition to the built-in panels, a number of third-party panels are
 contributed by the community.
 
-The current stable version of the Debug Toolbar is 3.4.0. It works on
+The current stable version of the Debug Toolbar is 3.5.0. It works on
 Django ≥ 3.2.
 
 Documentation, including installation and configuration instructions, is

--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -4,7 +4,7 @@ APP_NAME = "djdt"
 
 # Do not use pkg_resources to find the version but set it here directly!
 # see issue #1446
-VERSION = "3.4.0"
+VERSION = "3.5.0"
 
 # Code that discovers files or modules in INSTALLED_APPS imports this module.
 urls = "debug_toolbar.urls", APP_NAME

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,9 @@
 Change log
 ==========
 
+3.5.0 (2022-06-23)
+------------------
+
 * Properly implemented tracking and display of PostgreSQL transactions.
 * Removed third party panels which have been archived on GitHub.
 * Added Django 4.1b1 to the CI matrix.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = "{}, Django Debug Toolbar developers and contributors"
 copyright = copyright.format(datetime.date.today().year)
 
 # The full version, including alpha/beta/rc tags
-release = "3.4.0"
+release = "3.5.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-debug-toolbar
-version = 3.4.0
+version = 3.5.0
 description = A configurable set of panels that display various debug information about the current request/response.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
I think it's time to release 3.5; no major version bump despite all these changes because I'm somewhat sure that we didn't break anything.