### PR TITLE
Check if djdt-store-id is in all headers before usage.

### DIFF
--- a/debug_toolbar/panels/history/panel.py
+++ b/debug_toolbar/panels/history/panel.py
@@ -24,7 +24,7 @@ class HistoryPanel(Panel):
         observe_request = self.toolbar.get_observe_request()
         store_id = getattr(self.toolbar, "store_id")
         if store_id and observe_request(request):
-            headers["DJDT-STORE-ID"] = store_id
+            headers["djdt-store-id"] = store_id
         return headers
 
     @property

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -264,8 +264,13 @@ const djdt = {
         const origOpen = XMLHttpRequest.prototype.open;
         XMLHttpRequest.prototype.open = function () {
             this.addEventListener("load", function () {
-                let store_id = this.getResponseHeader("djdt-store-id");
-                if (store_id !== null) {
+                // Chromium emits a "Refused to get unsafe header" uncatchable warning
+                // when the header can't be fetched. While it doesn't impede execution
+                // it's worrisome to developers.
+                if (
+                    this.getAllResponseHeaders().indexOf("djdt-store-id") >= 0
+                ) {
+                    let store_id = this.getResponseHeader("djdt-store-id");
                     store_id = encodeURIComponent(store_id);
                     const dest = `${sidebar_url}?store_id=${store_id}`;
                     slowjax(dest).then(function (data) {

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -142,7 +142,7 @@ Toolbar options
 
 * ``OBSERVE_REQUEST_CALLBACK``
 
-  Default: ``'debug_toolbar.middleware.observe_request'``
+  Default: ``'debug_toolbar.toolbar.observe_request'``
 
   This is the dotted path to a function used for determining whether the
   toolbar should update on AJAX requests or not. The default checks are that

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -99,6 +99,20 @@ class HistoryViewsTestCase(IntegrationTestCase):
         response = self.client.get(reverse("djdt:history_sidebar"))
         self.assertEqual(response.status_code, 400)
 
+    def test_history_headers(self):
+        """Validate the headers injected from the history panel."""
+        response = self.client.get("/json_view/")
+        store_id = list(DebugToolbar._store)[0]
+        self.assertEqual(response.headers["djdt-store-id"], store_id)
+
+    @override_settings(
+        DEBUG_TOOLBAR_CONFIG={"OBSERVE_REQUEST_CALLBACK": lambda request: False}
+    )
+    def test_history_headers_unobserved(self):
+        """Validate the headers aren't injected from the history panel."""
+        response = self.client.get("/json_view/")
+        self.assertNotIn("djdt-store-id", response.headers)
+
     def test_history_sidebar(self):
         """Validate the history sidebar view."""
         self.client.get("/json_view/")


### PR DESCRIPTION
Chromium throws an uncatchable warning when a header that
can't be accessed is used. While it's not problematic, it's
worrisome to developers. This avoids that by first checking
that it exists.

Fixes https://github.com/jazzband/django-debug-toolbar/issues/1647

- Change header to djdt-store-id.
- Includes some tests to validate the HistoryPanel.get_headers
- method.
- Correct OBSERVE_REQUEST_CALLBACK default value in docs. 