### PR TITLE
docs: Fix a few typos

### DIFF
--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -69,7 +69,7 @@ def simplify(sql):
 
 def contrasting_color_generator():
     """
-    Generate constrasting colors by varying most significant bit of RGB first,
+    Generate contrasting colors by varying most significant bit of RGB first,
     and then vary subsequent bits systematically.
     """
 

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -444,7 +444,7 @@ class SQLPanelTestCase(BaseTestCase):
 
         # Reset the queries
         self.panel._queries = []
-        # Run it again, but with prettyify off. Verify that it's different.
+        # Run it again, but with prettify off. Verify that it's different.
         dt_settings.get_config()["PRETTIFY_SQL"] = False
         list(User.objects.filter(username__istartswith="spam"))
         response = self.panel.process_request(self.request)
@@ -453,7 +453,7 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertNotEqual(pretty_sql, self.panel._queries[-1]["sql"])
 
         self.panel._queries = []
-        # Run it again, but with prettyify back on.
+        # Run it again, but with prettify back on.
         # This is so we don't have to check what PRETTIFY_SQL does exactly,
         # but we know it's doing something.
         dt_settings.get_config()["PRETTIFY_SQL"] = True


### PR DESCRIPTION
There are small typos in:
- debug_toolbar/panels/sql/utils.py
- tests/panels/test_sql.py

Fixes:
- Should read `prettify` rather than `prettyify`.
- Should read `contrasting` rather than `constrasting`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md