### PR TITLE
Fixed signature of views decorated with signed_data_view

### DIFF
--- a/debug_toolbar/decorators.py
+++ b/debug_toolbar/decorators.py
@@ -32,4 +32,8 @@ def signed_data_view(view):
             )
         return HttpResponseBadRequest("Invalid signature")
 
+    # We have changed the signature, so need to remove `__wrapped__` to
+    # avoid confusing type checking tools
+    del inner.__wrapped__
+
     return inner

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
+import inspect
 import unittest
 
 from django.test import override_settings
 
 import debug_toolbar.utils
+from debug_toolbar.decorators import signed_data_view
 from debug_toolbar.utils import (
     get_name_from_obj,
     get_stack,
@@ -80,3 +82,22 @@ class StackTraceTestCase(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             stack_trace = tidy_stacktrace(reversed(stack))
         self.assertEqual(stack_trace[-1][0], __file__)
+
+
+class DecoratorsTestCase(unittest.TestCase):
+    def test_signed_data_view_signature(self):
+        # Ensure signed_data_view decorator sets an appropriate signature
+
+        # This matters only to tools that type-check the URLconf, (e.g.
+        # django-urlconfchecks), to avoid the nuisance of those tools flagging
+        # django-debug-toolbar views as incorrectly typed.
+
+        def some_view(request, verified_data):
+            pass
+
+        decorated_view = signed_data_view(some_view)
+
+        # `verified_data` is a parameter to some_view:
+        self.assertIn("verified_data", inspect.signature(some_view).parameters)
+        # but not to the decorated_view:
+        self.assertNotIn("verified_data", inspect.signature(decorated_view).parameters)


### PR DESCRIPTION
This fixes a nuisance when using django-debug-toolbar with [django-urlconfchecks](https://github.com/AliSayyah/django-urlconfchecks/) which type checks URLconfs, and possibly other tools. Otherwise it has little effect.

Basically, the `@functools.wraps()` call within the `signed_data_view` decorator makes views like `sql_explain` appear to have an external signature of `sql_explain(request, verified_data)` to tools like [inspect.signature](https://docs.python.org/3/library/inspect.html#inspect.signature). If this was really the case, then the function would fail when used from the urlconf, because the `verified_data` parameter is not passed. 

So, django-urlconfchecks raises an error for these views. 

In reality `signed_data_view` is providing that argument, and so changing the effective signature of the function.

With the patch, the signature is changed to `sql_explain(request, *args, **kwargs)`, which is not as accurate as it could be, but at least django-urlconfchecks now just issues a warning (about `*args` / `**kwargs` preventing signature checking), and not an error.

An alternative fix is to remove the `@functools.wraps` call entirely in the implementation of `signed_data_view`, but that would potentially produce more problems.

A test is added for this.