### PR TITLE
Remove signed_data_view decorator to support url type checking.

### DIFF
--- a/debug_toolbar/decorators.py
+++ b/debug_toolbar/decorators.py
@@ -1,6 +1,6 @@
 import functools
 
-from django.http import Http404, HttpResponseBadRequest
+from django.http import Http404
 
 
 def require_show_toolbar(view):
@@ -13,23 +13,5 @@ def require_show_toolbar(view):
             raise Http404
 
         return view(request, *args, **kwargs)
-
-    return inner
-
-
-def signed_data_view(view):
-    """Decorator that handles unpacking a signed data form"""
-
-    @functools.wraps(view)
-    def inner(request, *args, **kwargs):
-        from debug_toolbar.forms import SignedDataForm
-
-        data = request.GET if request.method == "GET" else request.POST
-        signed_form = SignedDataForm(data)
-        if signed_form.is_valid():
-            return view(
-                request, *args, verified_data=signed_form.verified_data(), **kwargs
-            )
-        return HttpResponseBadRequest("Invalid signature")
 
     return inner

--- a/debug_toolbar/forms.py
+++ b/debug_toolbar/forms.py
@@ -21,7 +21,6 @@ class SignedDataForm(forms.Form):
             panel_form = PanelForm(signed_form.verified_data)
             if panel_form.is_valid():
                 # Success
-    Or wrap the FBV with ``debug_toolbar.decorators.signed_data_view``
     """
 
     salt = "django_debug_toolbar"

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+Pending
+-------
+* Remove decorator ``signed_data_view`` as it was causing issues with
+  django-urlconfchecks.
+
 3.5.0 (2022-06-23)
 ------------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,8 +3,9 @@ Change log
 
 Pending
 -------
+
 * Remove decorator ``signed_data_view`` as it was causing issues with
-  django-urlconfchecks.
+  `django-urlconfchecks <https://github.com/AliSayyah/django-urlconfchecks/>`__.
 
 3.5.0 (2022-06-23)
 ------------------


### PR DESCRIPTION
The package django-urlconfchecks was erroring on the toolbar's
URLs because signed_data_view was injecting an extra parameter
for the views. The alternative to the decorator isn't terrible
so let's use that instead. Eventually this can be shortened
with the walrus operator when py37 support is dropped.

This is an alternative to #1657