### PR TITLE
Profiling panel improvements

### DIFF
--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -44,7 +44,8 @@ class FunctionCall:
             file_name, _, _ = self.func
             return (
                 str(settings.BASE_DIR) in file_name
-                and "/site-packages" not in file_name
+                and "/site-packages/" not in file_name
+                and "/dist-packages/" not in file_name
             )
         return None
 
@@ -139,6 +140,7 @@ class ProfilingPanel(Panel):
     title = _("Profiling")
 
     template = "debug_toolbar/panels/profiling.html"
+    capture_project_code = dt_settings.get_config()["PROFILER_CAPTURE_PROJECT_CODE"]
 
     def process_request(self, request):
         self.profiler = cProfile.Profile()
@@ -151,7 +153,9 @@ class ProfilingPanel(Panel):
             for subfunc in func.subfuncs():
                 # Always include the user's code
                 if subfunc.stats[3] >= cum_time or (
-                    subfunc.is_project_func() and subfunc.stats[3] > 0
+                    self.capture_project_code
+                    and subfunc.is_project_func()
+                    and subfunc.stats[3] > 0
                 ):
                     func.has_subfuncs = True
                     self.add_node(func_list, subfunc, max_depth, cum_time)

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -33,6 +33,7 @@ CONFIG_DEFAULTS = {
         "django.utils.functional",
     ),
     "PRETTIFY_SQL": True,
+    "PROFILER_CAPTURE_PROJECT_CODE": True,
     "PROFILER_MAX_DEPTH": 10,
     "PROFILER_THRESHOLD_RATIO": 8,
     "SHOW_TEMPLATE_CONTEXT": True,

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -34,6 +34,7 @@ CONFIG_DEFAULTS = {
     ),
     "PRETTIFY_SQL": True,
     "PROFILER_MAX_DEPTH": 10,
+    "PROFILER_THRESHOLD_RATIO": 8,
     "SHOW_TEMPLATE_CONTEXT": True,
     "SKIP_TEMPLATE_PREFIXES": ("django/forms/widgets/", "admin/widgets/"),
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -614,6 +614,12 @@
 #djDebug .djdt-highlighted {
     background-color: lightgrey;
 }
+#djDebug tr.djdt-highlighted.djdt-profile-row {
+    background-color: #ffc;
+}
+#djDebug tr.djdt-highlighted.djdt-profile-row:nth-child(2n + 1) {
+    background-color: #dd9;
+}
 @keyframes djdt-flash-new {
     from {
         background-color: green;

--- a/debug_toolbar/templates/debug_toolbar/panels/profiling.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/profiling.html
@@ -12,7 +12,7 @@
   </thead>
   <tbody>
     {% for call in func_list %}
-      <tr class="{% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" id="profilingMain_{{ call.id }}">
+      <tr class="djdt-profile-row {% if call.is_project_func %}djdt-highlighted {% endif %} {% for parent_id in call.parent_ids %} djToggleDetails_{{ parent_id }}{% endfor %}" id="profilingMain_{{ call.id }}">
         <td>
           <div data-djdt-styles="paddingLeft:{{ call.indent }}px">
             {% if call.has_subfuncs %}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,11 @@ Change log
 Pending
 -------
 
+* Added Profiling panel setting ``PROFILER_THRESHOLD_RATIO`` to give users
+  better control over how many function calls are included. A higher value
+  will include more data, but increase render time.
+
+
 3.6.0 (2022-08-17)
 ------------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Pending
   will include more data, but increase render time.
 * Update Profiling panel to include try to always include user code. This
   code is more important to developers than dependency code.
+* Highlight the project function calls in the profiling panel.
 
 
 3.6.0 (2022-08-17)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,6 +10,10 @@ Pending
 * Update Profiling panel to include try to always include user code. This
   code is more important to developers than dependency code.
 * Highlight the project function calls in the profiling panel.
+* Added Profiling panel setting ``PROFILER_CAPTURE_PROJECT_CODE`` to allow
+  users to disable the inclusion of all project code. This will be useful
+  to project setups that have dependencies installed under
+  ``settings.BASE_DIR``.
 
 
 3.6.0 (2022-08-17)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,8 @@ Pending
 * Added Profiling panel setting ``PROFILER_THRESHOLD_RATIO`` to give users
   better control over how many function calls are included. A higher value
   will include more data, but increase render time.
+* Update Profiling panel to include try to always include user code. This
+  code is more important to developers than dependency code.
 
 
 3.6.0 (2022-08-17)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -270,7 +270,7 @@ Panel options
   render of the profiling panel, but will exclude data.
 
   This value is used to determine the threshold of cumulative time to include
-  the nested functions. The threshold is calculated by the root calls
+  the nested functions. The threshold is calculated by the root calls'
   cumulative time divided by this ratio.
 
 * ``SHOW_TEMPLATE_CONTEXT``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -261,7 +261,7 @@ Panel options
 
 * ``PROFILER_THRESHOLD_RATIO``
 
-  Default: ``10``
+  Default: ``8``
 
   Panel: profiling
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -259,6 +259,20 @@ Panel options
   This setting affects the depth of function calls in the profiler's
   analysis.
 
+* ``PROFILER_THRESHOLD_RATIO``
+
+  Default: ``10``
+
+  Panel: profiling
+
+  This setting affects the which calls are included in the profile. A higher
+  value will include more function calls. A lower value will result in a faster
+  render of the profiling panel, but will exclude data.
+
+  This value is used to determine the threshold of cumulative time to include
+  the nested functions. The threshold is calculated by the root calls
+  cumulative time divided by this ratio.
+
 * ``SHOW_TEMPLATE_CONTEXT``
 
   Default: ``True``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -250,6 +250,18 @@ Panel options
     WHERE "auth_user"."username" = '''test_username'''
     LIMIT 21
 
+* ``PROFILER_CAPTURE_PROJECT_CODE``
+
+  Default: ``True``
+
+  Panel: profiling
+
+  When enabled this setting will include all project function calls in the
+  panel. Project code is defined as files in the path defined at
+  ``settings.BASE_DIR``. If you install dependencies under
+  ``settings.BASE_DIR`` in a directory other than ``sites-packages`` or
+  ``dist-packages`` you may need to disable this setting.
+
 * ``PROFILER_MAX_DEPTH``
 
   Default: ``10``

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -133,7 +133,8 @@ with the ``DISABLE_PANELS`` configuration option.
 The panel will include all function calls made by your project if you're using
 the setting ``settings.BASE_DIR`` to point to your project's root directory.
 If a function is in a file within that directory and does not include
-``"/site-packages/"`` in the path, it will be included.
+``"/site-packages/"`` or ``"/dist-packages/"`` in the path, it will be
+included.
 
 Third-party panels
 ------------------

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -130,7 +130,7 @@ Profiling information for the processing of the request.
 This panel is included but inactive by default. You can activate it by default
 with the ``DISABLE_PANELS`` configuration option.
 
-The panel will include all function calls made by your project if your using
+The panel will include all function calls made by your project if you're using
 the setting ``settings.BASE_DIR`` to point to your project's root directory.
 If a function is in a file within that directory and does not include
 ``"/site-packages/"`` in the path, it will be included.

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -130,6 +130,11 @@ Profiling information for the processing of the request.
 This panel is included but inactive by default. You can activate it by default
 with the ``DISABLE_PANELS`` configuration option.
 
+The panel will include all function calls made by your project if your using
+the setting ``settings.BASE_DIR`` to point to your project's root directory.
+If a function is in a file within that directory and does not include
+``"/site-packages/"`` in the path, it will be included.
+
 Third-party panels
 ------------------
 

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -77,6 +77,8 @@ by disabling some configuration options that are enabled by default:
 
 - ``ENABLE_STACKTRACES`` for the SQL and cache panels,
 - ``SHOW_TEMPLATE_CONTEXT`` for the template panel.
+- ``PROFILER_CAPTURE_PROJECT_CODE`` and ``PROFILER_THRESHOLD_RATIO`` for the
+  profiling panel.
 
 Also, check ``SKIP_TEMPLATE_PREFIXES`` when you're using template-based
 form widgets.

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -35,6 +35,19 @@ class ProfilingPanelTestCase(BaseTestCase):
         self.assertIn("regular_view", content)
         self.assertValidHTML(content)
 
+    @override_settings(DEBUG_TOOLBAR_CONFIG={"PROFILER_THRESHOLD_RATIO": 1})
+    def test_cum_time_threshold(self):
+        """
+        Test that cumulative time threshold excludes calls
+        """
+        self._get_response = lambda request: regular_view(request, "profiling")
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        # ensure the panel renders but doesn't include our function.
+        content = self.panel.content
+        self.assertNotIn("regular_view", content)
+        self.assertValidHTML(content)
+
     def test_listcomp_escaped(self):
         self._get_response = lambda request: listcomp_view(request)
         response = self.panel.process_request(self.request)

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -33,7 +33,7 @@ class ProfilingPanelTestCase(BaseTestCase):
         # ensure the panel renders correctly.
         content = self.panel.content
         self.assertIn("regular_view", content)
-        self.assertIn("get_template", content)
+        self.assertIn("render", content)
         self.assertValidHTML(content)
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"PROFILER_THRESHOLD_RATIO": 1})
@@ -47,7 +47,7 @@ class ProfilingPanelTestCase(BaseTestCase):
         # ensure the panel renders but doesn't include our function.
         content = self.panel.content
         self.assertIn("regular_view", content)
-        self.assertNotIn("get_template", content)
+        self.assertNotIn("render", content)
         self.assertValidHTML(content)
 
     def test_listcomp_escaped(self):

--- a/tests/panels/test_profiling.py
+++ b/tests/panels/test_profiling.py
@@ -33,6 +33,7 @@ class ProfilingPanelTestCase(BaseTestCase):
         # ensure the panel renders correctly.
         content = self.panel.content
         self.assertIn("regular_view", content)
+        self.assertIn("get_template", content)
         self.assertValidHTML(content)
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"PROFILER_THRESHOLD_RATIO": 1})
@@ -45,7 +46,8 @@ class ProfilingPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, response)
         # ensure the panel renders but doesn't include our function.
         content = self.panel.content
-        self.assertNotIn("regular_view", content)
+        self.assertIn("regular_view", content)
+        self.assertNotIn("get_template", content)
         self.assertValidHTML(content)
 
     def test_listcomp_escaped(self):


### PR DESCRIPTION
* Added Profiling panel setting ``PROFILER_THRESHOLD_RATIO`` to give users
  better control over how many function calls are included. A higher value
  will include more data, but increase render time.
* Update Profiling panel to include try to always include user code. This
  code is more important to developers than dependency code.
* Highlight the project function calls in the profiling panel.