### PR TITLE
Auto-update History panel with JavaScript fetch requests.

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -286,8 +286,8 @@ const djdt = {
         };
 
         const origFetch = window.fetch;
-        window.fetch = function (url, options) {
-            const promise = origFetch(url, options);
+        window.fetch = function () {
+            const promise = origFetch.apply(this, arguments);
             promise.then(function (response) {
                 if (response.headers.get("djdt-store-id") !== null) {
                     handleAjaxResponse(response.headers.get("djdt-store-id"));

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Change log
 Pending
 -------
 
+* Auto-update History panel for JavaScript ``fetch`` requests.
+
+
 3.7.0 (2022-09-25)
 ------------------
 

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -18,17 +18,29 @@
     <p>
       <span>Value </span>
       <span id="session-value">{{ request.session.value|default:0 }}</span>
-      <button id="increment" data-url="{% url 'ajax_increment' %}" type="button">Increment</button>
+      <button id="incrementFetch" data-url="{% url 'ajax_increment' %}" type="button">Increment via fetch</button>
+      <button id="incrementXHR" data-url="{% url 'ajax_increment' %}" type="button">Increment via XHR</button>
     </p>
   <script>
-    const increment = document.querySelector("#increment");
+    const incrementFetch = document.querySelector("#incrementFetch");
+    const incrementXHR = document.querySelector("#incrementXHR");
     const value = document.querySelector("#session-value");
-    increment.addEventListener("click", function () {
-      fetch(increment.dataset.url).then( function (response) {
+    incrementFetch.addEventListener("click", function () {
+      fetch(incrementFetch.dataset.url).then( function (response) {
         response.json().then(function(data) {
           value.innerHTML = data.value;
         });
       });
+    });
+    incrementXHR.addEventListener("click", function () {
+      const xhr = new XMLHttpRequest();
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === 4) {
+          value.innerHTML = JSON.parse(xhr.response).value;
+        }
+      }
+      xhr.open('GET', incrementXHR.dataset.url, true);
+      xhr.send('');
     });
   </script>
   </body>


### PR DESCRIPTION
The fetch and XHR requests don't share internals in JavaScript. We should automatically capture both sets of requests as they occur.

Closes #1650