### PR TITLE
Include panel scripts in content when RENDER_PANELS=True

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/timer.js
+++ b/debug_toolbar/static/debug_toolbar/js/timer.js
@@ -1,7 +1,6 @@
 import { $$ } from "./utils.js";
 
 function insertBrowserTiming() {
-    console.log(["inserted"]);
     const timingOffset = performance.timing.navigationStart,
         timingEnd = performance.timing.loadEventEnd,
         totalTime = timingEnd - timingOffset;

--- a/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
+++ b/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
@@ -8,7 +8,7 @@
     </div>
     <div class="djDebugPanelContent">
       {% if toolbar.should_render_panels %}
-        {% for script in panel.scripts %}<script src="{{ script }}"></script>{% endfor %}
+        {% for script in panel.scripts %}<script type="module" src="{{ script }}" async></script>{% endfor %}
         <div class="djdt-scroll">{{ panel.content }}</div>
       {% else %}
         <div class="djdt-loader"></div>

--- a/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
+++ b/debug_toolbar/templates/debug_toolbar/includes/panel_content.html
@@ -8,6 +8,7 @@
     </div>
     <div class="djDebugPanelContent">
       {% if toolbar.should_render_panels %}
+        {% for script in panel.scripts %}<script src="{{ script }}"></script>{% endfor %}
         <div class="djdt-scroll">{{ panel.content }}</div>
       {% else %}
         <div class="djdt-loader"></div>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -472,8 +472,10 @@ class DebugToolbarIntegrationTestCase(IntegrationTestCase):
     def test_timer_panel(self):
         response = self.client.get("/regular/basic/")
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "/debug_toolbar/js/timer.js")
-        # print(response.content.decode("utf-8"))
+        self.assertContains(
+            response,
+            '<script type="module" src="/static/debug_toolbar/js/timer.js" async>',
+        )
 
     def test_auth_login_view_without_redirect(self):
         response = self.client.get("/login_without_redirect/")


### PR DESCRIPTION
It seems to me that panel scripts aren't included at all when using `RENDER_PANELS=True` at the moment. This would probably be a bug. I don't use `RENDER_PANELS` anywhere and therefore cannot really test if this change would be correct.

I found this while trying to write a test for the timer panel (because I wanted a green build, re. code coverage)