### PR TITLE
Create one-time mouseup listener for each mousedown

### DIFF
--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -189,21 +189,23 @@ const djdt = {
                 baseY = handle.offsetTop - startPageY;
                 document.addEventListener("mousemove", onHandleMove);
 
-                document.addEventListener("mouseup", function (event) {
-                    document.removeEventListener("mousemove", onHandleMove);
-                    if (djdt.handleDragged) {
-                        event.preventDefault();
-                        localStorage.setItem("djdt.top", handle.offsetTop);
-                        requestAnimationFrame(function () {
-                            djdt.handleDragged = false;
-                        });
-                        djdt.ensureHandleVisibility();
-                    }
-                }, {once: true});
-
+                document.addEventListener(
+                    "mouseup",
+                    function (event) {
+                        document.removeEventListener("mousemove", onHandleMove);
+                        if (djdt.handleDragged) {
+                            event.preventDefault();
+                            localStorage.setItem("djdt.top", handle.offsetTop);
+                            requestAnimationFrame(function () {
+                                djdt.handleDragged = false;
+                            });
+                            djdt.ensureHandleVisibility();
+                        }
+                    },
+                    { once: true }
+                );
             }
         );
-
 
         const djDebug = getDebugElement();
         // Make sure the debug element is rendered at least once.

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -188,20 +188,23 @@ const djdt = {
                 startPageY = event.pageY;
                 baseY = handle.offsetTop - startPageY;
                 document.addEventListener("mousemove", onHandleMove);
+
+                document.addEventListener("mouseup", function (event) {
+                    document.removeEventListener("mousemove", onHandleMove);
+                    if (djdt.handleDragged) {
+                        event.preventDefault();
+                        localStorage.setItem("djdt.top", handle.offsetTop);
+                        requestAnimationFrame(function () {
+                            djdt.handleDragged = false;
+                        });
+                        djdt.ensureHandleVisibility();
+                    }
+                }, {once: true});
+
             }
         );
 
-        document.addEventListener("mouseup", function (event) {
-            document.removeEventListener("mousemove", onHandleMove);
-            if (djdt.handleDragged) {
-                event.preventDefault();
-                localStorage.setItem("djdt.top", handle.offsetTop);
-                requestAnimationFrame(function () {
-                    djdt.handleDragged = false;
-                });
-                djdt.ensureHandleVisibility();
-            }
-        });
+
         const djDebug = getDebugElement();
         // Make sure the debug element is rendered at least once.
         // showToolbar will continue to show it in the future if the


### PR DESCRIPTION
Move the creation on the mouseup event handler to inside the mousedown and add {once: true} so that is is removed after each use.  This prevents multiple mouseup events from getting attached to `document` (which breaks mouseup behavior) when using libraries that update page content without reloading the page like Hotwire Turbo, htmx, and Unpoly.