### PR TITLE
Fix highlighting on history panel

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -621,7 +621,7 @@
 #djDebug .djdt-max-height-100 {
     max-height: 100%;
 }
-#djDebug .djdt-highlighted{
+#djDebug .djdt-highlighted {
     background-color: lightgrey;
 }
 #djDebug tr.djdt-highlighted.djdt-profile-row {

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -622,7 +622,7 @@
     max-height: 100%;
 }
 #djDebug .djdt-highlighted {
-    background-color: lightgrey;
+    background-color: lightgrey!important;
 }
 #djDebug tr.djdt-highlighted.djdt-profile-row {
     background-color: #ffc;

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -356,7 +356,7 @@
     margin-top: 0.8em;
     overflow: auto;
 }
-#djDebug .djdt-panelContent tbody > tr:nth-child(odd) {
+#djDebug .djdt-panelContent tbody > tr:nth-child(odd):not(.djdt-highlighted) {
     background-color: #f5f5f5;
 }
 #djDebug .djdt-panelContent tbody td,
@@ -621,8 +621,8 @@
 #djDebug .djdt-max-height-100 {
     max-height: 100%;
 }
-#djDebug .djdt-highlighted {
-    background-color: lightgrey !important;
+#djDebug .djdt-highlighted{
+    background-color: lightgrey;
 }
 #djDebug tr.djdt-highlighted.djdt-profile-row {
     background-color: #ffc;

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -622,7 +622,7 @@
     max-height: 100%;
 }
 #djDebug .djdt-highlighted {
-    background-color: lightgrey!important;
+    background-color: lightgrey !important;
 }
 #djDebug tr.djdt-highlighted.djdt-profile-row {
     background-color: #ffc;


### PR DESCRIPTION
`#djDebug .djdt-panelContent tbody > tr:nth-child(odd)` is overriding `#djDebug .djdt-highlighted` on the history panel so every odd row will not take on a highlighted appearance.   