### PR TITLE
Allow Language Selection on the Toolbar

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -40,6 +40,7 @@ CONFIG_DEFAULTS = {
     "SKIP_TEMPLATE_PREFIXES": ("django/forms/widgets/", "admin/widgets/"),
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
     "OBSERVE_REQUEST_CALLBACK": "debug_toolbar.toolbar.observe_request",
+    "TOOLBAR_LANGUAGE": None,
 }
 
 

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -14,6 +14,7 @@ from django.template.loader import render_to_string
 from django.urls import path, resolve
 from django.urls.exceptions import Resolver404
 from django.utils.module_loading import import_string
+from django.utils.translation import get_language, override as lang_override
 
 from debug_toolbar import APP_NAME, settings as dt_settings
 
@@ -76,7 +77,9 @@ class DebugToolbar:
             self.store()
         try:
             context = {"toolbar": self}
-            return render_to_string("debug_toolbar/base.html", context)
+            lang = self.config["TOOLBAR_LANGUAGE"] or get_language()
+            with lang_override(lang):
+                return render_to_string("debug_toolbar/base.html", context)
         except TemplateSyntaxError:
             if not apps.is_installed("django.contrib.staticfiles"):
                 raise ImproperlyConfigured(

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -149,7 +149,18 @@ Toolbar options
   the request doesn't originate from the toolbar itself, EG that
   ``is_toolbar_request`` is false for a given request.
 
+* ``TOOLBAR_LANGUAGE``
 
+  Default: ``None``
+
+  The language used to render the toolbar. If no value is supplied, then the
+  application's current language will be used. This setting can be used to
+  render the toolbar in a different language than what the application is
+  rendered in. For example, if you wish to use English for development,
+  but want to render your application in French, you would set this to
+  ``"en-us"`` and `settings.LANGUAGE_CODE`_ to ``"fr"``.
+
+.. _settings.LANGUAGE_CODE: https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-LANGUAGE_CODE
 
 Panel options
 ~~~~~~~~~~~~~

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -665,3 +665,14 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         self.selenium.find_element(By.CLASS_NAME, "BuggyPanel").click()
         self.wait.until(EC.visibility_of(debug_window))
         self.assertEqual(debug_window.text, "»\n500: Internal Server Error")
+
+    def test_toolbar_language_will_render_to_default_language_when_not_set(self):
+        self.get("/regular/basic/")
+        hide_button = self.selenium.find_element(By.ID, "djHideToolBarButton")
+        assert hide_button.text == "Hide »"
+
+    @override_settings(DEBUG_TOOLBAR_CONFIG={"TOOLBAR_LANGUAGE": "pt-br"})
+    def test_toolbar_language_will_render_to_locale_when_set(self):
+        self.get("/regular/basic/")
+        hide_button = self.selenium.find_element(By.ID, "djHideToolBarButton")
+        assert hide_button.text == "Esconder »"


### PR DESCRIPTION
closes #991

Added a new optional setting `TOOLBAR_LANGUAGE` that can be set by a user to define in which language the toolbar is displayed.
Modified the `render_toolbar` method from `DebugToolbar` class to use the `django.utils.translations.override`, so the language is set either: To the defined language on the `TOOLBAR_LANGUAGE` or the current language (No breaking changes). After the template is rendered, the language is set back to the previous.

Added two tests cases:
One that checks if the toolbar is rendered accordingly when this setting was not defined, the default behavior. 
Other that checks if the toolbar was rendered to the set language.

Updated documentation on `configuration.rst` on how to set this value.