### PR TITLE
Formalize support for Python 3.11.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           # Use latest, so it understands all syntax.
-          python-version: "3.10"
+          python-version: "3.11"
 
       - run: python -m pip install --upgrade coverage[toml]
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,7 @@ Pending
 * Update package metadata to use Hatchling.
 * Fix highlighting on history panel so odd rows are highlighted when
   selected.
+* Formalize support for Python 3.11.
 
 3.7.0 (2022-09-25)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 [project.urls]


### PR DESCRIPTION
We were already largely testing against 3.11, but this adds the classifier and uses py3.11 for the coverage CI job.