### PR TITLE
Use tox allowlist_externals for make command.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ setenv =
     DB_HOST = {env:DB_HOST:localhost}
     DB_PASSWORD =  {env:DB_PASSWORD:debug_toolbar}
     DJANGO_SETTINGS_MODULE = tests.settings
-whitelist_externals = make
+allowlist_externals = make
 pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 


### PR DESCRIPTION
Tox deprecated and removed whitelist_externals.

Docs reference: https://tox.wiki/en/latest/config.html#conf-allowlist_externals