### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     services:
       mariadb:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         database: [postgresql, postgis]
 
     services:
@@ -146,7 +146,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v3.3.1
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 -   repo: https://github.com/adamchainz/django-upgrade
     rev: 1.12.0
     hooks:
@@ -58,7 +58,7 @@ repos:
     hooks:
     -   id: black
         language_version: python3
-        entry: black --target-version=py37
+        entry: black --target-version=py38
 -   repo: https://github.com/tox-dev/pyproject-fmt
     rev: 0.4.1
     hooks:

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -22,7 +22,7 @@ def show_toolbar(request):
     return settings.DEBUG and request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS
 
 
-@lru_cache()
+@lru_cache
 def get_show_toolbar():
     # If SHOW_TOOLBAR_CALLBACK is a string, which is the recommended
     # setup, resolve it to the corresponding callable.

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -45,7 +45,7 @@ CONFIG_DEFAULTS = {
 }
 
 
-@lru_cache()
+@lru_cache
 def get_config():
     USER_CONFIG = getattr(settings, "DEBUG_TOOLBAR_CONFIG", {})
     CONFIG = CONFIG_DEFAULTS.copy()
@@ -70,7 +70,7 @@ PANELS_DEFAULTS = [
 ]
 
 
-@lru_cache()
+@lru_cache
 def get_panels():
     try:
         PANELS = list(settings.DEBUG_TOOLBAR_PANELS)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,7 @@ Pending
 -------
 
 * Added Django 4.2a1 to the CI.
+* Dropped support for Python 3.7.
 * Fixed PostgreSQL raw query with a tuple parameter during on explain.
 * Use ``TOOLBAR_LANGUAGE`` setting when rendering individual panels
   that are loaded via AJAX.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "BSD-3-Clause"}
 authors = [
     { name = "Rob Hudson" },
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
   "Django>=3.2.4",
   "sqlparse>=0.2",
@@ -27,13 +27,13 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
+    # "Framework :: Django :: 4.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ isolated_build = true
 envlist =
     docs
     packaging
-    py{37}-dj{32}-{sqlite,postgresql,postgis,mysql}
-    py{38,39,310}-dj{32,40,41,42}-{sqlite,postgresql,postgis,mysql}
+    py{38,39,310}-dj{32,41,42}-{sqlite,postgresql,postgis,mysql}
+    py{310}-dj{40}-{sqlite}
     py{310,311}-dj{41,42,main}-{sqlite,postgresql,postgis,mysql}
 
 [testenv]
@@ -37,7 +37,7 @@ setenv =
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = d
     py39-dj32-postgresql: DJANGO_SELENIUM_TESTS = true
-    py310-dj40-postgresql: DJANGO_SELENIUM_TESTS = true
+    py310-dj41-postgresql: DJANGO_SELENIUM_TESTS = true
     DB_NAME = {env:DB_NAME:debug_toolbar}
     DB_USER = {env:DB_USER:debug_toolbar}
     DB_HOST = {env:DB_HOST:localhost}
@@ -47,25 +47,25 @@ allowlist_externals = make
 pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
-[testenv:py{37,38,39,310,311}-dj{32,40,41,main}-postgresql]
+[testenv:py{38,39,310,311}-dj{32,40,41,42,main}-postgresql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
-[testenv:py{37,38,39,310,311}-dj{32,40,41,main}-postgis]
+[testenv:py{38,39,310,311}-dj{32,40,41,42,main}-postgis]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgis
     DB_PORT = {env:DB_PORT:5432}
 
-[testenv:py{37,38,39,310,311}-dj{32,40,41,main}-mysql]
+[testenv:py{38,39,310,311}-dj{32,40,41,42,main}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
     DB_PORT = {env:DB_PORT:3306}
 
-[testenv:py{37,38,39,310,311}-dj{32,40,41,main}-sqlite]
+[testenv:py{38,39,310,311}-dj{32,40,41,42,main}-sqlite]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3
@@ -88,7 +88,6 @@ skip_install = true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
# Description

This pull request drops support for Python 3.7. Older versions of the toolbar will still be usable by people still using 3.7. This also makes us use less CI resources, something which is a big plus for me.

Also, see https://pythonspeed.com/articles/stop-using-python-3.7/

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
