### PR TITLE
Format frame locals when captured

### DIFF
--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -3,7 +3,7 @@ import linecache
 import os.path
 import sys
 import warnings
-from pprint import pformat
+from pprint import PrettyPrinter, pformat
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from asgiref.local import Local
@@ -62,7 +62,7 @@ def tidy_stacktrace(stack: List[stubs.InspectStack]) -> stubs.TidyStackTrace:
             continue
         text = "".join(text).strip() if text else ""
         frame_locals = (
-            frame.f_locals
+            pformat(frame.f_locals)
             if dt_settings.get_config()["ENABLE_STACKTRACES_LOCALS"]
             else None
         )
@@ -99,7 +99,7 @@ def render_stacktrace(trace: stubs.TidyStackTrace) -> SafeString:
         if show_locals:
             html += format_html(
                 '  <pre class="djdt-locals">{}</pre>\n',
-                pformat(locals_),
+                locals_,
             )
         html += "\n"
     return mark_safe(html)
@@ -266,6 +266,8 @@ def _stack_frames(*, skip=0):
 
 
 class _StackTraceRecorder:
+    pretty_printer = PrettyPrinter()
+
     def __init__(self):
         self.filename_cache = {}
 
@@ -315,7 +317,10 @@ class _StackTraceRecorder:
             else:
                 source_line = ""
 
-            frame_locals = frame.f_locals if include_locals else None
+            if include_locals:
+                frame_locals = self.pretty_printer.pformat(frame.f_locals)
+            else:
+                frame_locals = None
 
             trace.append((filename, line_no, func_name, source_line, frame_locals))
         trace.reverse()

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,11 @@ Pending
   environments (but not others). The maintainers judged that time and effort is
   better invested elsewhere.
 * Added support for psycopg3.
+* When ``ENABLE_STACKTRACE_LOCALS`` is ``True``, the stack frames' locals dicts
+  will be converted to strings when the stack trace is captured rather when it
+  is rendered, so that the correct values will be displayed in the rendered
+  stack trace, as they may have changed between the time the stack trace was
+  captured and when it is rendered.
 
 3.8.1 (2022-12-03)
 ------------------

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -3,6 +3,7 @@ backends
 backported
 checkbox
 contrib
+dicts
 django
 fallbacks
 flamegraph


### PR DESCRIPTION
Before this commit, if `ENABLE_STACKTRACES_LOCALS` was `True`, each stack frame's locals dict would be stored directly in the captured stack trace, and only converted to a string once the stack trace was rendered. This means that for panels, such as the SQL Panel, which do not render the stack traces until later after they have all been captured, it is quite possible that the values in the locals dicts at the point when the stack trace was rendered would no longer be the same as they were at the time when the stack trace was captured, resulting in incorrect values being displayed to the user.

Fix by converting the locals dict to a string immediately when it is captured (in the `get_stack_trace()` function as well as in the deprecated `tidy_stacktrace()` function) instead of in the `render_stacktrace()` function.

I realize that this represents an internal API change, as now the last item of the tuples returned by `get_stack_trace()` will now be a string rather than a dict.  However, this is not actually a documented public API and I do not expect any third-party panels to be trying to inspect or use the locals dicts from the stack traces directly, even if they are using `get_stack_trace()` (or more likely, `get_stack()` and `tidy_stacktrace()`).  But if there are concerns about this, I have some thoughts about possible ways to address it.
