### PR TITLE
Enabled Django 4.2 Trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
-    # "Framework :: Django :: 4.2",
+    "Framework :: Django :: 4.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
This is now available on PyPI: https://pypi.org/search/?q=&o=&c=Framework+%3A%3A+Django+%3A%3A+4.2