### PR TITLE
Use @lru_cache(maxsize=None) when appropriate

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -22,7 +22,7 @@ def show_toolbar(request):
     return settings.DEBUG and request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def get_show_toolbar():
     # If SHOW_TOOLBAR_CALLBACK is a string, which is the recommended
     # setup, resolve it to the corresponding callable.

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -45,7 +45,7 @@ CONFIG_DEFAULTS = {
 }
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def get_config():
     USER_CONFIG = getattr(settings, "DEBUG_TOOLBAR_CONFIG", {})
     CONFIG = CONFIG_DEFAULTS.copy()
@@ -70,7 +70,7 @@ PANELS_DEFAULTS = [
 ]
 
 
-@lru_cache
+@lru_cache(maxsize=None)
 def get_panels():
     try:
         PANELS = list(settings.DEBUG_TOOLBAR_PANELS)

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -166,7 +166,7 @@ class DebugToolbar:
         return resolver_match.namespaces and resolver_match.namespaces[-1] == APP_NAME
 
     @staticmethod
-    @lru_cache(maxsize=128)
+    @lru_cache(maxsize=None)
     def get_observe_request():
         # If OBSERVE_REQUEST_CALLBACK is a string, which is the recommended
         # setup, resolve it to the corresponding callable.


### PR DESCRIPTION
For functions which do not take arguments, there is no need to limit the maximum size of the cache used by `@lru_cache` (since it will never have more than one entry).  By using `@lru_cache(maxsize=None)`, a simpler, faster cache implementation is used internally.