### PR TITLE
Version 4.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Here's a screenshot of the toolbar in action:
 In addition to the built-in panels, a number of third-party panels are
 contributed by the community.
 
-The current stable version of the Debug Toolbar is 3.8.1. It works on
+The current stable version of the Debug Toolbar is 4.0.0. It works on
 Django ≥ 3.2.4.
 
 Documentation, including installation and configuration instructions, is

--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -4,7 +4,7 @@ APP_NAME = "djdt"
 
 # Do not use pkg_resources to find the version but set it here directly!
 # see issue #1446
-VERSION = "3.8.1"
+VERSION = "4.0.0"
 
 # Code that discovers files or modules in INSTALLED_APPS imports this module.
 urls = "debug_toolbar.urls", APP_NAME

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Change log
 Pending
 -------
 
+4.0.0 (2023-03-14)
+------------------
+
 * Added Django 4.2a1 to the CI.
 * Dropped support for Python 3.7.
 * Fixed PostgreSQL raw query with a tuple parameter during on explain.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = "{}, Django Debug Toolbar developers and contributors"
 copyright = copyright.format(datetime.date.today().year)
 
 # The full version, including alpha/beta/rc tags
-release = "3.8.1"
+release = "4.0.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
# Description

Upgrades Django Debug Toolbar to version 4.0.

The major version change is due to the internal logic change of how stacktrace frames are formatted. While it is internal logic, it's a bit of a change. I'd rather error on the side of caution.

Additionally it drops support for Python 3.7

Fixes # (issue)

# Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
