### PR TITLE
SQL query formatting improvements

### DIFF
--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -1,8 +1,8 @@
 import re
 from functools import lru_cache
+from html import escape
 
 import sqlparse
-from django.utils.html import escape
 from sqlparse import tokens as T
 
 from debug_toolbar import settings as dt_settings
@@ -16,7 +16,7 @@ class BoldKeywordFilter:
             is_keyword = token_type in T.Keyword
             if is_keyword:
                 yield T.Text, "<strong>"
-            yield token_type, escape(value)
+            yield token_type, escape(value, quote=False)
             if is_keyword:
                 yield T.Text, "</strong>"
 

--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -12,7 +12,6 @@ class BoldKeywordFilter:
     """sqlparse filter to bold SQL keywords"""
 
     def process(self, stream):
-        """Process the token stream"""
         for token_type, value in stream:
             is_keyword = token_type in T.Keyword
             if is_keyword:
@@ -55,7 +54,7 @@ def get_filter_stack(prettify, aligned_indent):
         stack.stmtprocess.append(
             sqlparse.filters.AlignedIndentFilter(char="&nbsp;", n="<br/>")
         )
-    stack.preprocess.append(BoldKeywordFilter())  # add our custom filter
+    stack.preprocess.append(BoldKeywordFilter())
     stack.postprocess.append(sqlparse.filters.SerializerUnicode())  # tokens -> strings
     return stack
 

--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -111,11 +111,11 @@ def _parse_sql(sql, *, prettify, simplify):
 @lru_cache(maxsize=None)
 def get_filter_stack(*, prettify, simplify):
     stack = sqlparse.engine.FilterStack()
-    if prettify:
-        stack.enable_grouping()
     if simplify:
         stack.preprocess.append(ElideSelectListsFilter())
     else:
+        if prettify:
+            stack.enable_grouping()
         stack.stmtprocess.append(
             sqlparse.filters.AlignedIndentFilter(char="&nbsp;", n="<br/>")
         )

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,9 @@ Pending
   is rendered, so that the correct values will be displayed in the rendered
   stack trace, as they may have changed between the time the stack trace was
   captured and when it is rendered.
+* Improved SQL statement formatting performance.  Additionally, fixed the
+  indentation of ``CASE`` statements and stopped simplifying ``.count()``
+  queries.
 
 3.8.1 (2022-12-03)
 ------------------

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -495,6 +495,21 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertEqual(len(self.panel._queries), 1)
         self.assertEqual(pretty_sql, self.panel._queries[-1]["sql"])
 
+    def test_simplification(self):
+        """
+        Test case to validate that select lists for .count() and .exist() queries do not
+        get elided, but other select lists do.
+        """
+        User.objects.count()
+        User.objects.exists()
+        list(User.objects.values_list("id"))
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+        self.assertEqual(len(self.panel._queries), 3)
+        self.assertNotIn("\u2022", self.panel._queries[0]["sql"])
+        self.assertNotIn("\u2022", self.panel._queries[1]["sql"])
+        self.assertIn("\u2022", self.panel._queries[2]["sql"])
+
     @override_settings(
         DEBUG=True,
     )


### PR DESCRIPTION
# Description

Various improvements to the code which formats SQL statements for the SQL panel.  The majority are performance improvements, with an overall 35% reduction in formatting time on my system.  However, there is also an improvement in indentation for queries which use the `CASE` keyword, and better simplification of queries generated by `.count()` querysets.

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
