### PR TITLE
Allow per-DB port specification for tox

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,10 @@ Pending
   is rendered, so that the correct values will be displayed in the rendered
   stack trace, as they may have changed between the time the stack trace was
   captured and when it is rendered.
+* Enabled per-DB port specification for tox.  Tox will now check the
+  ``MYSQL_DB_PORT``, ``POSTGRESQL_DB_PORT``, and ``POSTGIS_DB_PORT``
+  environment variables to override the DB port for mysql, postgresql, and
+  postgis environments, respectively.
 
 3.8.1 (2022-12-03)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -54,20 +54,20 @@ commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
-    DB_PORT = {env:DB_PORT:5432}
+    DB_PORT = {env:POSTGRESQL_DB_PORT:{env:DB_PORT:5432}}
 
 
 [testenv:py{38,39,310,311}-dj{32,40,41,42,main}-postgis]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgis
-    DB_PORT = {env:DB_PORT:5432}
+    DB_PORT = {env:POSTGIS_DB_PORT:{env:DB_PORT:5432}}
 
 [testenv:py{38,39,310,311}-dj{32,40,41,42,main}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
-    DB_PORT = {env:DB_PORT:3306}
+    DB_PORT = {env:MYSQL_DB_PORT:{env:DB_PORT:5432}}
 
 [testenv:py{38,39,310,311}-dj{32,40,41,42,main}-sqlite]
 setenv =


### PR DESCRIPTION
As currently written, tox.ini allows specifying the DB port to use to connect to the test DB using a `DB_PORT` environment variable.  However, it uses the same variable for the mysql, postgresql, and postgis environments.  Thus if specifying a custom `DB_PORT` environment variable when running the full combination of tox environments, the mysql, postgresql, and postgis environments will all attempt to use the same DB port, which is unlikely to result in happiness.

Fix by checking for three new environment variables, `POSTGRESQL_DB_PORT`, `POSTGIS_DB_PORT`, and `MYSQL_DB_PORT` in the respective environments, falling back to `DB_PORT` (and then the hard-coded default) for backwards compatibility.

The motivation for this change is that I wanted to run postgresql within a container listening on a non-standard port for testing, but didn't have a way to run all tox over all the environments while setting the port for postgresql/postgis without also affecting the port for mysql.

- [x] I have added an item to the Pending section of ``docs/changes.rst``.
