### PR TITLE
Use the new STORAGES setting in Django 4.2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Change log
 Pending
 -------
 
+* Added support for the new STORAGES setting in Django 4.2 for static files.
+
 4.0.0 (2023-04-03)
 ------------------
 


### PR DESCRIPTION
In Django 4.2 the `django.core.files.storage.get_storage_class()` function is deprecated as well as the `STATICFILES_STORAGE` setting in favor of `STORAGES["staticfiles"]`.

Use `django.core.files.storage.storages` to get the configured storage class for static files instead.

For Django versions prior to 4.2 keep using the `django.core.files.storage.get_storage_class()` function for backwards compatibility.

Fixes #1758