### PR TITLE
Add theming support

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -1,3 +1,38 @@
+/* Varible definitions */
+:root {
+    --font-family-primary: /* Same as in Django admin/css/base.css */
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        system-ui,
+        Roboto,
+        "Helvetica Neue",
+        Arial,
+        sans-serif,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        "Noto Color Emoji";
+    --font-family-monospace:  /* Same as in Django admin/css/base.css */
+        ui-monospace,
+        Menlo,
+        Monaco,
+        "Cascadia Mono",
+        "Segoe UI Mono",
+        "Roboto Mono",
+        "Oxygen Mono",
+        "Ubuntu Monospace",
+        "Source Code Pro",
+        "Fira Mono",
+        "Droid Sans Mono",
+        "Courier New",
+        monospace,
+        "Apple Color Emoji",
+        "Segoe UI Emoji",
+        "Segoe UI Symbol",
+        "Noto Color Emoji";
+}
+
 /* Debug Toolbar CSS Reset, adapted from Eric Meyer's CSS Reset */
 #djDebug {
     color: #000;
@@ -77,9 +112,7 @@
     color: #000;
     vertical-align: baseline;
     background-color: transparent;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
-        Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji",
-        "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-family: var(--font-family-primary);
     text-align: left;
     text-shadow: none;
     white-space: normal;
@@ -179,7 +212,7 @@
 
 #djDebug #djDebugToolbar li.djdt-active:before {
     content: "▶";
-    font-family: sans-serif;
+    font-family: var(--font-family-primary);
     position: absolute;
     left: 0;
     top: 50%;
@@ -244,11 +277,7 @@
 #djDebug pre,
 #djDebug code {
     display: block;
-    font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
-        "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
-        "Fira Mono", "Droid Sans Mono", "Courier New", monospace,
-        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-        "Noto Color Emoji";
+    font-family: var(--font-family-monospace);
     overflow: auto;
 }
 

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -3,6 +3,7 @@
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/print.css' %}" media="print">
 <link rel="stylesheet" href="{% static 'debug_toolbar/css/toolbar.css' %}">
 {% endblock %}
+{% block extrastyle %}{% endblock %}
 {% block js %}
 <script type="module" src="{% static 'debug_toolbar/js/toolbar.js' %}" async></script>
 {% endblock %}


### PR DESCRIPTION
# Description

This PR adds theming support to the Django debug toolbar that works the same way as https://docs.djangoproject.com/en/4.2/ref/contrib/admin/#theming-support.

Fixes #1757.

# Checklist:

- [x] I have added the relevant tests for this change. (Existing tests should be sufficient as this is just a simple refactoring at this point.)
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
