### PR TITLE
D9pouces wsgi.multiprocess 1

### DIFF
--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -95,9 +95,13 @@ class DebugToolbar:
 
         If False, the panels will be loaded via Ajax.
         """
-        render_panels = self.config["RENDER_PANELS"]
-        if render_panels is None:
-            render_panels = self.request.META.get("wsgi.multiprocess", False)
+        if (render_panels := self.config["RENDER_PANELS"]) is None:
+            # If wsgi.multiprocess isn't in the headers, then it's likely
+            # being served by ASGI. This type of set up is most likely
+            # incompatible with the toolbar until
+            # https://github.com/jazzband/django-debug-toolbar/issues/1430
+            # is resolved.
+            render_panels = self.request.META.get("wsgi.multiprocess", True)
         return render_panels
 
     # Handle storing toolbars in memory and fetching them later on

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -97,7 +97,7 @@ class DebugToolbar:
         """
         render_panels = self.config["RENDER_PANELS"]
         if render_panels is None:
-            render_panels = self.request.META["wsgi.multiprocess"]
+            render_panels = self.request.META.get("wsgi.multiprocess", False)
         return render_panels
 
     # Handle storing toolbars in memory and fetching them later on

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,12 @@ Pending
   presence of other code which also monkey patches those methods.
 * Update all timing code that used :py:func:`time.time()` to use
   :py:func:`time.perf_counter()` instead.
+* Made the check on ``request.META["wsgi.multiprocess"]`` optional, but
+  defaults to forcing the toolbar to render the panels on each request. This
+  is because it's likely an ASGI application that's serving the responses
+  and that's more likely to be an incompatible setup. If you find that this
+  is incorrect for you in particular, you can use the ``RENDER_PANELS``
+  setting to forcibly control this logic.
 
 4.0.0 (2023-04-03)
 ------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,6 +65,35 @@ class DebugToolbarTestCase(BaseTestCase):
         with self.settings(INTERNAL_IPS=[]):
             self.assertFalse(show_toolbar(self.request))
 
+    def test_should_render_panels_RENDER_PANELS(self):
+        """
+        The toolbar should force rendering panels on each request
+        based on the RENDER_PANELS setting.
+        """
+        toolbar = DebugToolbar(self.request, self.get_response)
+        self.assertFalse(toolbar.should_render_panels())
+        toolbar.config["RENDER_PANELS"] = True
+        self.assertTrue(toolbar.should_render_panels())
+        toolbar.config["RENDER_PANELS"] = None
+        self.assertTrue(toolbar.should_render_panels())
+
+    def test_should_render_panels_multiprocess(self):
+        """
+        The toolbar should render the panels on each request when wsgi.multiprocess
+        is True or missing.
+        """
+        request = rf.get("/")
+        request.META["wsgi.multiprocess"] = True
+        toolbar = DebugToolbar(request, self.get_response)
+        toolbar.config["RENDER_PANELS"] = None
+        self.assertTrue(toolbar.should_render_panels())
+
+        request.META["wsgi.multiprocess"] = False
+        self.assertFalse(toolbar.should_render_panels())
+
+        request.META.pop("wsgi.multiprocess")
+        self.assertTrue(toolbar.should_render_panels())
+
     def _resolve_stats(self, path):
         # takes stats from Request panel
         self.request.path = path


### PR DESCRIPTION
# Description

If you apply Django middlewares on a HttpRequest without "wsgi.multiprocess" in META, an exception is raised by DJT. 
This simple patch avoids this bug.


Fixes # (issue)

# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
