### PR TITLE
Don't try to undo cache method monkey patching

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,9 @@ Pending
   indentation of ``CASE`` statements and stopped simplifying ``.count()``
   queries.
 * Added support for the new STORAGES setting in Django 4.2 for static files.
+* Reworked the cache panel instrumentation code to no longer attempt to undo
+  monkey patching of cache methods, as that turned out to be fragile in the
+  presence of other code which also monkey patches those methods.
 
 4.0.0 (2023-04-03)
 ------------------


### PR DESCRIPTION
# Description

Trying to undo the monkey patch of cache methods in the `CachePanel.disable_instrumentation()` method is fragile in the presence of other code which may also monkey patch the same methods (such as Sentry's Django integration), and there are theoretically situations where it is actually impossible to do correctly.  Thus once a cache has been monkey-patched, leave it that way, and instead rely on checking in the patched methods to see if recording needs to happen.  This is done via a `_djdt_panel` attribute which is set to the current panel in the `enable_instrumentation()` method and then set to `None` in the `disable_instrumentation()` method.

Fixes #1769

# Checklist:

- [ ] I have added the relevant tests for this change.
- [X] I have added an item to the Pending section of ``docs/changes.rst``.
