### PR TITLE
Fix psycopg3 tests

### DIFF
--- a/debug_toolbar/panels/sql/panel.py
+++ b/debug_toolbar/panels/sql/panel.py
@@ -10,7 +10,7 @@ from debug_toolbar.forms import SignedDataForm
 from debug_toolbar.panels import Panel
 from debug_toolbar.panels.sql import views
 from debug_toolbar.panels.sql.forms import SQLSelectForm
-from debug_toolbar.panels.sql.tracking import unwrap_cursor, wrap_cursor
+from debug_toolbar.panels.sql.tracking import wrap_cursor
 from debug_toolbar.panels.sql.utils import contrasting_color_generator, reformat_sql
 from debug_toolbar.utils import render_stacktrace
 
@@ -190,11 +190,12 @@ class SQLPanel(Panel):
     def enable_instrumentation(self):
         # This is thread-safe because database connections are thread-local.
         for connection in connections.all():
-            wrap_cursor(connection, self)
+            wrap_cursor(connection)
+            connection._djdt_logger = self
 
     def disable_instrumentation(self):
         for connection in connections.all():
-            unwrap_cursor(connection)
+            connection._djdt_logger = None
 
     def generate_stats(self, request, response):
         colors = contrasting_color_generator()

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -63,7 +63,6 @@ def wrap_cursor(connection, panel):
 
         connection.cursor = cursor
         connection.chunked_cursor = chunked_cursor
-        return cursor
 
 
 def unwrap_cursor(connection):


### PR DESCRIPTION
# Description

Several tests (such as `SQLPanelTestCase.test_cursor_wrapper_singleton`) are written to ensure that only a single cursor wrapper is instantiated during a test.  However, this fails when using psycopg3, since the `.last_executed_query()` call in `NormalCursorWrapper._record()` ends up creating an additional cursor (via [the `mogrify()` function](https://github.com/django/django/blob/fea17b76150688056d78818ea1ef47f1122dc165/django/db/backends/postgresql/psycopg_any.py#L21)).  To avoid this, use a `._djdt_in_record` attribute on the database wrapper.  Make the `NormalCursorWrapper._record()` method set `._djdt_in_record` to `True` on entry and reset it to `False` on exit.  Then in the overridden database wrapper `.cursor()` and `.chunked_cursor()` methods, check the `._djdt_in_record` attribute and return the original cursor without wrapping if the attribute is `True`.

# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.