### PR TITLE
Minor testing cleanups

### DIFF
--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -21,7 +21,7 @@ except ImportError:
     psycopg = None
 
 from ..base import BaseMultiDBTestCase, BaseTestCase
-from ..models import PostgresJSON
+from ..models import Binary, PostgresJSON
 
 
 def sql_call(use_iterator=False):
@@ -149,7 +149,7 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertEqual(len(self.panel._queries), 2)
 
         # non-ASCII bytes parameters
-        list(User.objects.filter(username="café".encode()))
+        list(Binary.objects.filter(field__in=["café".encode()]))
         self.assertEqual(len(self.panel._queries), 3)
 
         response = self.panel.process_request(self.request)
@@ -335,7 +335,7 @@ class SQLPanelTestCase(BaseTestCase):
         Test that the panel only inserts content after generate_stats and
         not the process_request.
         """
-        list(User.objects.filter(username="café".encode()))
+        list(User.objects.filter(username="café"))
         response = self.panel.process_request(self.request)
         # ensure the panel does not have content yet.
         self.assertNotIn("café", self.panel.content)
@@ -351,7 +351,7 @@ class SQLPanelTestCase(BaseTestCase):
         Test that the panel inserts locals() content.
         """
         local_var = "<script>alert('test');</script>"  # noqa: F841
-        list(User.objects.filter(username="café".encode()))
+        list(User.objects.filter(username="café"))
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
         self.assertIn("local_var", self.panel.content)
@@ -365,7 +365,7 @@ class SQLPanelTestCase(BaseTestCase):
         """
         Test that the panel does not insert locals() content.
         """
-        list(User.objects.filter(username="café".encode()))
+        list(User.objects.filter(username="café"))
         response = self.panel.process_request(self.request)
         self.panel.generate_stats(self.request, response)
         self.assertNotIn("djdt-locals", self.panel.content)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -533,7 +533,8 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
     def setUpClass(cls):
         super().setUpClass()
         options = Options()
-        options.headless = bool(os.environ.get("CI"))
+        if os.environ.get("CI"):
+            options.add_argument("-headless")
         cls.selenium = webdriver.Firefox(options=options)
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -3,23 +3,22 @@ isolated_build = true
 envlist =
     docs
     packaging
-    py{38,39,310}-dj{32}-{sqlite,postgresql,postgis,mysql}
-    py{310}-dj{40}-{sqlite}
-    py{310,311}-dj{41}-{sqlite,postgresql,postgis,mysql}
-    py{310,311}-dj{42,main}-{sqlite,postgresql,postgis,mysql}
-    py{310,311}-dj{42,main}-psycopg3
+    py{38,39,310}-dj32-{sqlite,postgresql,postgis,mysql}
+    py310-dj40-sqlite
+    py{310,311}-dj41-{sqlite,postgresql,postgis,mysql}
+    py{310,311}-dj{42,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
 
 [testenv]
 deps =
     dj32: django~=3.2.9
     dj40: django~=4.0.0
     dj41: django~=4.1.3
-    dj42: django>=4.2a1,<5
+    dj42: django~=4.2.1
+    djmain: https://github.com/django/django/archive/main.tar.gz
     postgresql: psycopg2-binary
     psycopg3: psycopg[binary]
     postgis: psycopg2-binary
     mysql: mysqlclient
-    djmain: https://github.com/django/django/archive/main.tar.gz
     coverage[toml]
     Jinja2
     html5lib
@@ -40,7 +39,7 @@ setenv =
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = d
     py39-dj32-postgresql: DJANGO_SELENIUM_TESTS = true
-    py310-dj41-postgresql: DJANGO_SELENIUM_TESTS = true
+    py311-dj42-postgresql: DJANGO_SELENIUM_TESTS = true
     DB_NAME = {env:DB_NAME:debug_toolbar}
     DB_USER = {env:DB_USER:debug_toolbar}
     DB_HOST = {env:DB_HOST:localhost}
@@ -55,7 +54,6 @@ setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
-
 
 [testenv:py{38,39,310,311}-dj{32,40,41,42,main}-postgis]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ deps =
     Jinja2
     html5lib
     pygments
-    selenium
+    selenium>=4.8.0
     sqlparse
 passenv=
     CI


### PR DESCRIPTION
Make some minor tweaks to the `tox.ini` file (the only functional change is enabling selenium tests for Python 3.11/Django 4.2 instead of for Python 3.10/Django 4.1), and fix a few warnings generated by the tests.
