### PR TITLE
Include all files in sdist archives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,6 @@ dependencies = [
 Download = "https://pypi.org/project/django-debug-toolbar/"
 Homepage = "https://github.com/jazzband/django-debug-toolbar"
 
-[tool.hatch.build.targets.sdist]
-include = [
-    "/debug_toolbar",
-    "/CONTRIBUTING.md",
-]
-
 [tool.hatch.build.targets.wheel]
 packages = ["debug_toolbar"]
 


### PR DESCRIPTION
# Description

Remove the restriction on files inclduded in sdist archives in order to include documentation sources and tests there.  This is the default hatchling behavior and it is helpful to packagers (such as Linux distributions or Conda) as it permits using sdist archives to do packaging (instead of GitHub archives that are not guaranteed to be reproducible).  Most of the ordinary users will not be affected since starlette is a pure Python package and therefore pip will prefer wheels to install it everywhere.

# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
