### PR TITLE
Fix CI tests with MariaDB.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           MARIADB_ROOT_PASSWORD: debug_toolbar
         options: >-
-          --health-cmd "mysqladmin ping"
+          --health-cmd "mariadb-admin ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       mariadb:
         image: mariadb
         env:
-          MYSQL_ROOT_PASSWORD: debug_toolbar
+          MARIADB_ROOT_PASSWORD: debug_toolbar
         options: >-
           --health-cmd "mysqladmin ping"
           --health-interval 10s


### PR DESCRIPTION
# Description

The docker image now uses MARIADB_ROOT_PASSWORD for the environment variable for the password rather than MYSQL_ROOT_PASSWORD.

# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
