### PR TITLE
Switch StaticFilesPanel to use ContextVar.

### DIFF
--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -14,12 +14,6 @@ from django.utils.safestring import SafeString, mark_safe
 
 from debug_toolbar import _stubs as stubs, settings as dt_settings
 
-try:
-    import threading
-except ImportError:
-    threading = None
-
-
 _local_data = Local()
 
 
@@ -357,33 +351,3 @@ def get_stack_trace(*, skip=0):
 def clear_stack_trace_caches():
     if hasattr(_local_data, "stack_trace_recorder"):
         del _local_data.stack_trace_recorder
-
-
-class ThreadCollector:
-    def __init__(self):
-        if threading is None:
-            raise NotImplementedError(
-                "threading module is not available, "
-                "this panel cannot be used without it"
-            )
-        self.collections = {}  # a dictionary that maps threads to collections
-
-    def get_collection(self, thread=None):
-        """
-        Returns a list of collected items for the provided thread, of if none
-        is provided, returns a list for the current thread.
-        """
-        if thread is None:
-            thread = threading.current_thread()
-        if thread not in self.collections:
-            self.collections[thread] = []
-        return self.collections[thread]
-
-    def clear_collection(self, thread=None):
-        if thread is None:
-            thread = threading.current_thread()
-        if thread in self.collections:
-            del self.collections[thread]
-
-    def collect(self, item, thread=None):
-        self.get_collection(thread).append(item)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,8 @@ Pending
   <https://beta.ruff.rs/>`__.
 * Converted cookie keys to lowercase. Fixed the ``samesite`` argument to
   ``djdt.cookie.set``.
+* Converted ``StaticFilesPanel`` to no longer use a thread collector. Instead,
+  it collects the used static files in a ``ContextVar``.
 
 4.1.0 (2023-05-15)
 ------------------


### PR DESCRIPTION
The StaticFilesPanel thread collector was not closing connections to the database. This approach allows those connections to be closed while still collecting context across threads.

The test case is to hit an admin login screen with

    ab -n 200 http://localhost:8000/admin/login/

As far as I can tell, all the static files are collected properly and connections don't stay open.

Fixes #1799

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
