### PR TITLE
Check JavaScript files content type.

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -182,12 +182,8 @@ def js_mimetype_check(app_configs, **kwargs):
     """
     Check that JavaScript files are resolving to the correct content type.
     """
-    javascript_types = {
-        # Macs
-        "application/javascript",
-        # Windows
-        "text/javascript",
-    }
+    # Those types are fine. Different OSes return different types.
+    javascript_types = {"application/javascript", "text/javascript"}
     check_failed = not set(mimetypes.guess_type("toolbar.js")).intersection(
         javascript_types
     )

--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -182,7 +182,8 @@ def js_mimetype_check(app_configs, **kwargs):
     """
     Check that JavaScript files are resolving to the correct content type.
     """
-    # Those types are fine. Different OSes return different types.
+    # Ideally application/javascript is returned, but text/javascript is
+    # acceptable.
     javascript_types = {"application/javascript", "text/javascript"}
     check_failed = not set(mimetypes.guess_type("toolbar.js")).intersection(
         javascript_types
@@ -196,11 +197,11 @@ def js_mimetype_check(app_configs, **kwargs):
                 "https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/#static-file-development-view\n"
                 "\n"
                 "This typically occurs on Windows machines. The suggested solution is to modify "
-                "HKEY_CLASSES_ROOT in the registry.\n"
+                "HKEY_CLASSES_ROOT in the registry to specify the content type for JavaScript "
+                "files.\n"
                 "\n"
-                "; Specify ContentType for JavaScript files\n"
                 "[HKEY_CLASSES_ROOT\\.js]\n"
-                '"Content Type"="text/javascript"',
+                '"Content Type"="application/javascript"',
                 id="debug_toolbar.W007",
             )
         ]

--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -1,4 +1,5 @@
 import inspect
+import mimetypes
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -174,3 +175,37 @@ def check_panels(app_configs, **kwargs):
             )
         )
     return errors
+
+
+@register()
+def js_mimetype_check(app_configs, **kwargs):
+    """
+    Check that JavaScript files are resolving to the correct content type.
+    """
+    javascript_types = {
+        # Macs
+        "application/javascript",
+        # Windows
+        "text/javascript",
+    }
+    check_failed = not set(mimetypes.guess_type("toolbar.js")).intersection(
+        javascript_types
+    )
+    if check_failed:
+        return [
+            Warning(
+                "JavaScript files are resolving to the wrong content type.",
+                hint="The Django Debug Toolbar may not load properly while mimetypes are misconfigured. "
+                "See the Django documentation for an explanation of why this occurs.\n"
+                "https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/#static-file-development-view\n"
+                "\n"
+                "This typically occurs on Windows machines. The suggested solution is to modify "
+                "HKEY_CLASSES_ROOT in the registry.\n"
+                "\n"
+                "; Specify ContentType for JavaScript files\n"
+                "[HKEY_CLASSES_ROOT\\.js]\n"
+                '"Content Type"="text/javascript"',
+                id="debug_toolbar.W007",
+            )
+        ]
+    return []

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Pending
   ``djdt.cookie.set``.
 * Converted ``StaticFilesPanel`` to no longer use a thread collector. Instead,
   it collects the used static files in a ``ContextVar``.
+* Added check ``debug_toolbar.W007`` to warn when JavaScript files are
+  resolving to the wrong content type.
 
 4.1.0 (2023-05-15)
 ------------------

--- a/docs/checks.rst
+++ b/docs/checks.rst
@@ -18,3 +18,6 @@ Django Debug Toolbar setup and configuration:
   configuration needs to have
   ``django.template.loaders.app_directories.Loader`` included in
   ``["OPTIONS"]["loaders"]`` or ``APP_DIRS`` set to ``True``.
+* **debug_toolbar.W007**: JavaScript files are resolving to the wrong content
+  type. Refer to :external:ref:`Django's explanation of
+  mimetypes on Windows <staticfiles-development-view>`.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -249,11 +249,11 @@ class ChecksTestCase(SimpleTestCase):
                     "https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/#static-file-development-view\n"
                     "\n"
                     "This typically occurs on Windows machines. The suggested solution is to modify "
-                    "HKEY_CLASSES_ROOT in the registry.\n"
+                    "HKEY_CLASSES_ROOT in the registry to specify the content type for JavaScript "
+                    "files.\n"
                     "\n"
-                    "; Specify ContentType for JavaScript files\n"
                     "[HKEY_CLASSES_ROOT\\.js]\n"
-                    '"Content Type"="text/javascript"',
+                    '"Content Type"="application/javascript"',
                     id="debug_toolbar.W007",
                 )
             ],

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import patch
 
 import django
 from django.conf import settings
@@ -227,3 +228,33 @@ class ChecksTestCase(SimpleTestCase):
     )
     def test_check_w006_valid_nested_loaders(self):
         self.assertEqual(run_checks(), [])
+
+    @patch("debug_toolbar.apps.mimetypes.guess_type")
+    def test_check_w007_valid(self, mocked_guess_type):
+        mocked_guess_type.return_value = ("text/javascript", None)
+        self.assertEqual(run_checks(), [])
+        mocked_guess_type.return_value = ("application/javascript", None)
+        self.assertEqual(run_checks(), [])
+
+    @patch("debug_toolbar.apps.mimetypes.guess_type")
+    def test_check_w007_invalid(self, mocked_guess_type):
+        mocked_guess_type.return_value = ("text/plain", None)
+        self.assertEqual(
+            run_checks(),
+            [
+                Warning(
+                    "JavaScript files are resolving to the wrong content type.",
+                    hint="The Django Debug Toolbar may not load properly while mimetypes are misconfigured. "
+                    "See the Django documentation for an explanation of why this occurs.\n"
+                    "https://docs.djangoproject.com/en/stable/ref/contrib/staticfiles/#static-file-development-view\n"
+                    "\n"
+                    "This typically occurs on Windows machines. The suggested solution is to modify "
+                    "HKEY_CLASSES_ROOT in the registry.\n"
+                    "\n"
+                    "; Specify ContentType for JavaScript files\n"
+                    "[HKEY_CLASSES_ROOT\\.js]\n"
+                    '"Content Type"="text/javascript"',
+                    id="debug_toolbar.W007",
+                )
+            ],
+        )


### PR DESCRIPTION
A common problem with windows set ups is that the registry is misconfigured when resolving the content type for a JavaScript file. This check captures this sooner to explain why the toolbar doesn't show and attempts to tell the user what to change to make it work.

Fixes #1764

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
