### PR TITLE
Handle logging queries encoded as bytes under PostgreSQL

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -180,7 +180,10 @@ class NormalCursorWrapper(DjDTCursorWrapper):
             # Sql might be an object (such as psycopg Composed).
             # For logging purposes, make sure it's str.
             if vendor == "postgresql" and not isinstance(sql, str):
-                sql = sql.as_string(conn)
+                if isinstance(sql, bytes):
+                    sql = sql.decode("utf-8")
+                else:
+                    sql = sql.as_string(conn)
             else:
                 sql = str(sql)
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -13,6 +13,8 @@ Pending
   it collects the used static files in a ``ContextVar``.
 * Added check ``debug_toolbar.W007`` to warn when JavaScript files are
   resolving to the wrong content type.
+* Fixed SQL statement recording under PostgreSQL for queries encoded as byte
+  strings.
 
 4.1.0 (2023-05-15)
 ------------------

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -158,6 +158,17 @@ class SQLPanelTestCase(BaseTestCase):
         # ensure the panel renders correctly
         self.assertIn("café", self.panel.content)
 
+    @unittest.skipUnless(
+        connection.vendor == "postgresql", "Test valid only on PostgreSQL"
+    )
+    def test_bytes_query(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        with connection.cursor() as cursor:
+            cursor.execute(b"SELECT 1")
+
+        self.assertEqual(len(self.panel._queries), 1)
+
     def test_param_conversion(self):
         self.assertEqual(len(self.panel._queries), 0)
 


### PR DESCRIPTION
# Description

Unlike SQLite, psycopg supports queries encoded as bytes, and uses this in its own methods such as in [`execute_values`](https://www.psycopg.org/docs/extras.html#psycopg2.extras.execute_values). But the SQL logging only expects strings or [Composables](https://www.psycopg.org/docs/sql.html#psycopg2.sql.Composable). This was causing an `AttributeError` such as this:

```
Traceback (most recent call last):
[snip]
  File "/home/lucidiot/.virtualenvs/tmp/lib/python3.10/site-packages/psycopg2/extras.py", line 1270, in execute_values
    cur.execute(b''.join(parts))
  File "/home/lucidiot/.virtualenvs/tmp/lib/python3.10/site-packages/debug_toolbar/panels/sql/tracking.py", line 246, in execute
    return self._record(super().execute, sql, params)
  File "/home/lucidiot/.virtualenvs/tmp/lib/python3.10/site-packages/debug_toolbar/panels/sql/tracking.py", line 181, in _record
    sql = sql.as_string(conn)
AttributeError: 'bytes' object has no attribute 'as_string'
```

This adds an extra condition to decode a `bytes` instance with `.decode()` instead of `.as_string()`.

Fixes #987 

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
