### PR TITLE
Patch CursorWrapper dynamically to allow multiple base classes.

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -59,7 +59,7 @@ def wrap_cursor(connection):
             cursor = connection._djdt_cursor(*args, **kwargs)
             if logger is None:
                 return cursor
-            mixin = NormalCursorWrapper if allow_sql.get() else ExceptionCursorWrapper
+            mixin = NormalCursorMixin if allow_sql.get() else ExceptionCursorMixin
             return patch_cursor_wrapper_with_mixin(cursor.__class__, mixin)(
                 cursor.cursor, connection, logger
             )
@@ -70,10 +70,7 @@ def wrap_cursor(connection):
             logger = connection._djdt_logger
             cursor = connection._djdt_chunked_cursor(*args, **kwargs)
             if logger is not None and not isinstance(cursor, DjDTCursorWrapperMixin):
-                if allow_sql.get():
-                    mixin = NormalCursorWrapper
-                else:
-                    mixin = ExceptionCursorWrapper
+                mixin = NormalCursorMixin if allow_sql.get() else ExceptionCursorMixin
                 return patch_cursor_wrapper_with_mixin(cursor.__class__, mixin)(
                     cursor.cursor, connection, logger
                 )
@@ -97,7 +94,7 @@ class DjDTCursorWrapperMixin:
         self.logger = logger
 
 
-class ExceptionCursorWrapper(DjDTCursorWrapperMixin):
+class ExceptionCursorMixin(DjDTCursorWrapperMixin):
     """
     Wraps a cursor and raises an exception on any operation.
     Used in Templates panel.
@@ -107,7 +104,7 @@ class ExceptionCursorWrapper(DjDTCursorWrapperMixin):
         raise SQLQueryTriggered()
 
 
-class NormalCursorWrapper(DjDTCursorWrapperMixin):
+class NormalCursorMixin(DjDTCursorWrapperMixin):
     """
     Wraps a cursor and logs queries.
     """

--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -5,7 +5,6 @@ import json
 from time import perf_counter
 
 import django.test.testcases
-from django.db.backends.utils import CursorWrapper
 from django.utils.encoding import force_str
 
 from debug_toolbar.utils import get_stack_trace, get_template_info
@@ -60,34 +59,45 @@ def wrap_cursor(connection):
             cursor = connection._djdt_cursor(*args, **kwargs)
             if logger is None:
                 return cursor
-            wrapper = NormalCursorWrapper if allow_sql.get() else ExceptionCursorWrapper
-            return wrapper(cursor.cursor, connection, logger)
+            mixin = NormalCursorWrapper if allow_sql.get() else ExceptionCursorWrapper
+            return patch_cursor_wrapper_with_mixin(cursor.__class__, mixin)(
+                cursor.cursor, connection, logger
+            )
 
         def chunked_cursor(*args, **kwargs):
             # prevent double wrapping
             # solves https://github.com/jazzband/django-debug-toolbar/issues/1239
             logger = connection._djdt_logger
             cursor = connection._djdt_chunked_cursor(*args, **kwargs)
-            if logger is not None and not isinstance(cursor, DjDTCursorWrapper):
+            if logger is not None and not isinstance(cursor, DjDTCursorWrapperMixin):
                 if allow_sql.get():
-                    wrapper = NormalCursorWrapper
+                    mixin = NormalCursorWrapper
                 else:
-                    wrapper = ExceptionCursorWrapper
-                return wrapper(cursor.cursor, connection, logger)
+                    mixin = ExceptionCursorWrapper
+                return patch_cursor_wrapper_with_mixin(cursor.__class__, mixin)(
+                    cursor.cursor, connection, logger
+                )
             return cursor
 
         connection.cursor = cursor
         connection.chunked_cursor = chunked_cursor
 
 
-class DjDTCursorWrapper(CursorWrapper):
+def patch_cursor_wrapper_with_mixin(base_wrapper, mixin):
+    class DjDTCursorWrapper(mixin, base_wrapper):
+        pass
+
+    return DjDTCursorWrapper
+
+
+class DjDTCursorWrapperMixin:
     def __init__(self, cursor, db, logger):
         super().__init__(cursor, db)
         # logger must implement a ``record`` method
         self.logger = logger
 
 
-class ExceptionCursorWrapper(DjDTCursorWrapper):
+class ExceptionCursorWrapper(DjDTCursorWrapperMixin):
     """
     Wraps a cursor and raises an exception on any operation.
     Used in Templates panel.
@@ -97,7 +107,7 @@ class ExceptionCursorWrapper(DjDTCursorWrapper):
         raise SQLQueryTriggered()
 
 
-class NormalCursorWrapper(DjDTCursorWrapper):
+class NormalCursorWrapper(DjDTCursorWrapperMixin):
     """
     Wraps a cursor and logs queries.
     """

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -15,6 +15,8 @@ Pending
   resolving to the wrong content type.
 * Fixed SQL statement recording under PostgreSQL for queries encoded as byte
   strings.
+* Patch the ``CursorWrapper`` class with a mixin class to support multiple
+  base wrapper classes.
 
 4.1.0 (2023-05-15)
 ------------------

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -30,6 +30,7 @@ memcache
 memcached
 middleware
 middlewares
+mixin
 mousedown
 mouseup
 multi

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -78,9 +78,9 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertIn(
             mock_patch_cursor_wrapper.mock_calls,
             [
-                [call(CursorWrapper, sql_tracking.NormalCursorWrapper)],
+                [call(CursorWrapper, sql_tracking.NormalCursorMixin)],
                 # CursorDebugWrapper is used if the test is called with `--debug-sql`
-                [call(CursorDebugWrapper, sql_tracking.NormalCursorWrapper)],
+                [call(CursorDebugWrapper, sql_tracking.NormalCursorMixin)],
             ],
         )
 
@@ -95,9 +95,9 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertIn(
             mock_patch_cursor_wrapper.mock_calls,
             [
-                [call(CursorWrapper, sql_tracking.NormalCursorWrapper)],
+                [call(CursorWrapper, sql_tracking.NormalCursorMixin)],
                 # CursorDebugWrapper is used if the test is called with `--debug-sql`
-                [call(CursorDebugWrapper, sql_tracking.NormalCursorWrapper)],
+                [call(CursorDebugWrapper, sql_tracking.NormalCursorMixin)],
             ],
         )
 
@@ -111,9 +111,9 @@ class SQLPanelTestCase(BaseTestCase):
         self.assertIn(
             mock_patch_cursor_wrapper.mock_calls,
             [
-                [call(CursorWrapper, sql_tracking.NormalCursorWrapper)],
+                [call(CursorWrapper, sql_tracking.NormalCursorMixin)],
                 # CursorDebugWrapper is used if the test is called with `--debug-sql`
-                [call(CursorDebugWrapper, sql_tracking.NormalCursorWrapper)],
+                [call(CursorDebugWrapper, sql_tracking.NormalCursorMixin)],
             ],
         )
 
@@ -142,13 +142,13 @@ class SQLPanelTestCase(BaseTestCase):
             mock_patch_cursor_wrapper.mock_calls,
             [
                 [
-                    call(CursorWrapper, sql_tracking.NormalCursorWrapper),
-                    call(CursorWrapper, sql_tracking.ExceptionCursorWrapper),
+                    call(CursorWrapper, sql_tracking.NormalCursorMixin),
+                    call(CursorWrapper, sql_tracking.ExceptionCursorMixin),
                 ],
                 # CursorDebugWrapper is used if the test is called with `--debug-sql`
                 [
-                    call(CursorDebugWrapper, sql_tracking.NormalCursorWrapper),
-                    call(CursorDebugWrapper, sql_tracking.ExceptionCursorWrapper),
+                    call(CursorDebugWrapper, sql_tracking.NormalCursorMixin),
+                    call(CursorDebugWrapper, sql_tracking.ExceptionCursorMixin),
                 ],
             ],
         )


### PR DESCRIPTION
When the debug SQL logs are enabled, the wrapper class is CursorDebugWrapper not CursorWrapper. Since we have inspections based on that specific class they are removing the CursorDebugWrapper causing the SQL logs to not appear.

This attempts to dynamically patch the CursorWrapper or CursorDebugWrapper with the functionality we need.

This doesn't do a full regression test, but it may be possible to get it to work with:

    TEST_ARGS='--debug-sql' make test

Which causes the current set of tests to fail since they are keyed to CursorWrapper.

Fixes #1814

# Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
