### PR TITLE
do not quote SQL params before passing them to mogrify

### DIFF
--- a/debug_toolbar/panels/sql/tracking.py
+++ b/debug_toolbar/panels/sql/tracking.py
@@ -109,21 +109,6 @@ class NormalCursorMixin(DjDTCursorWrapperMixin):
     Wraps a cursor and logs queries.
     """
 
-    def _quote_expr(self, element):
-        if isinstance(element, str):
-            return "'%s'" % element.replace("'", "''")
-        else:
-            return repr(element)
-
-    def _quote_params(self, params):
-        if not params:
-            return params
-        if isinstance(params, dict):
-            return {key: self._quote_expr(value) for key, value in params.items()}
-        if isinstance(params, tuple):
-            return tuple(self._quote_expr(p) for p in params)
-        return [self._quote_expr(p) for p in params]
-
     def _decode(self, param):
         if PostgresJson and isinstance(param, PostgresJson):
             # psycopg3
@@ -157,9 +142,7 @@ class NormalCursorMixin(DjDTCursorWrapperMixin):
         # process during the .last_executed_query() call.
         self.db._djdt_logger = None
         try:
-            return self.db.ops.last_executed_query(
-                self.cursor, sql, self._quote_params(params)
-            )
+            return self.db.ops.last_executed_query(self.cursor, sql, params)
         finally:
             self.db._djdt_logger = self.logger
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Pending
 -------
 
 * Removed outdated third-party panels from the list.
+* Do not quote SQL params before passing them to mogrify() for display in SQL
+  panel.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,8 +5,7 @@ Pending
 -------
 
 * Removed outdated third-party panels from the list.
-* Do not quote SQL params before passing them to mogrify() for display in SQL
-  panel.
+* Avoided the unnecessary work of recursively quoting SQL parameters.
 
 4.2.0 (2023-08-10)
 ------------------


### PR DESCRIPTION
# Description

SQL params should be adapted to the correct database representation by the corresponding driver's mogrify() for display in the SQL panel. Using the default Python representation works only for simple data types.

Fixes #1831

# Checklist:

- [x] I have added no tests for this change - no new functionality, current tests pass.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
