### PR TITLE
panels(templates): avoid evaluating LazyObject

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -133,10 +133,15 @@ class TemplatesPanel(Panel):
             if pformatted is None:
                 temp_layer = {}
                 for key, value in context_layer.items():
+                    # Do not force evaluating LazyObject
+                    if hasattr(value, "_wrapped"):
+                        # SimpleLazyObject has __repr__ which includes actual value
+                        # if it has been already evaluated
+                        temp_layer[key] = repr(value)
                     # Replace any request elements - they have a large
                     # Unicode representation and the request data is
                     # already made available from the Request panel.
-                    if isinstance(value, http.HttpRequest):
+                    elif isinstance(value, http.HttpRequest):
                         temp_layer[key] = "<<request>>"
                     # Replace the debugging sql_queries element. The SQL
                     # data is already made available from the SQL panel.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,7 +8,8 @@ Pending
 * Avoided the unnecessary work of recursively quoting SQL parameters.
 * Postponed context process in templates panel to include lazy evaluated
   content.
-* Fixed template panel to avoid evaluating ``LazyObject`` when not already evaluated.
+* Fixed template panel to avoid evaluating ``LazyObject`` when not already 
+  evaluated.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,7 +8,7 @@ Pending
 * Avoided the unnecessary work of recursively quoting SQL parameters.
 * Postponed context process in templates panel to include lazy evaluated
   content.
-* Fixed template panel to avoid evaluating ``LazyObject`` when not already 
+* Fixed template panel to avoid evaluating ``LazyObject`` when not already
   evaluated.
 
 4.2.0 (2023-08-10)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Pending
 * Removed outdated third-party panels from the list.
 * Postponed context process in templates panel to include lazy evaluated
   content.
+* Fixed template panel to avoid evaluating ``LazyObject`` when not already evaluated.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,6 +5,8 @@ Pending
 -------
 
 * Removed outdated third-party panels from the list.
+* Postponed context process in templates panel to include lazy evaluated
+  content.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -21,6 +21,7 @@ class TemplatesPanelTestCase(BaseTestCase):
         super().tearDown()
 
     def test_queryset_hook(self):
+        response = self.panel.process_request(self.request)
         t = Template("No context variables here!")
         c = Context(
             {
@@ -29,12 +30,13 @@ class TemplatesPanelTestCase(BaseTestCase):
             }
         )
         t.render(c)
+        self.panel.generate_stats(self.request, response)
 
         # ensure the query was NOT logged
         self.assertEqual(len(self.sql_panel._queries), 0)
 
         self.assertEqual(
-            self.panel.templates[0]["context"],
+            self.panel.templates[0]["context_list"],
             [
                 "{'False': False, 'None': None, 'True': True}",
                 "{'deep_queryset': '<<triggers database query>>',\n"
@@ -99,13 +101,15 @@ class TemplatesPanelTestCase(BaseTestCase):
             self.assertFalse(self.panel.enabled)
 
     def test_empty_context(self):
+        response = self.panel.process_request(self.request)
         t = Template("")
         c = Context({})
         t.render(c)
+        self.panel.generate_stats(self.request, response)
 
         # Includes the builtin context but not the empty one.
         self.assertEqual(
-            self.panel.templates[0]["context"],
+            self.panel.templates[0]["context_list"],
             ["{'False': False, 'None': None, 'True': True}"],
         )
 


### PR DESCRIPTION
# Description

LazyObject is typically used for something expensive to evaluate, so avoid evaluating it just for showing it in the debug toolbar.

Fixes # (issue)

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

I will look at writing tests once I get an approval, that this is a viable approach.