### PR TITLE
Add async tests

### DIFF
--- a/example/README.rst
+++ b/example/README.rst
@@ -46,3 +46,13 @@ environment variable::
 
     $ DB_BACKEND=postgresql python example/manage.py migrate
     $ DB_BACKEND=postgresql python example/manage.py runserver
+
+Using an asynchronous (ASGI) server:
+
+Install [Daphne](https://pypi.org/project/daphne/) first:
+
+    $ python -m pip install daphne
+
+Then run the Django development server:
+
+    $ ASYNC_SERVER=true python example/manage.py runserver

--- a/example/asgi.py
+++ b/example/asgi.py
@@ -1,0 +1,9 @@
+"""ASGI config for example project."""
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "example.settings")
+
+application = get_asgi_application()

--- a/example/settings.py
+++ b/example/settings.py
@@ -18,6 +18,7 @@ INTERNAL_IPS = ["127.0.0.1", "::1"]
 # Application definition
 
 INSTALLED_APPS = [
+    *(["daphne"] if os.getenv("ASYNC_SERVER", False) else []),  # noqa: FBT003
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -66,6 +67,7 @@ TEMPLATES = [
 USE_TZ = True
 
 WSGI_APPLICATION = "example.wsgi.application"
+ASGI_APPLICATION = "example.asgi.application"
 
 
 # Cache and database
@@ -103,7 +105,6 @@ if os.environ.get("DB_BACKEND", "").lower() == "mysql":
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "example", "static")]
 
-
 # Only enable the toolbar when we're in debug mode and we're
 # not running tests. Django will change DEBUG to be False for
 # tests, so we can't rely on DEBUG alone.
@@ -117,3 +118,26 @@ if ENABLE_DEBUG_TOOLBAR:
     ]
     # Customize the config to support turbo and htmx boosting.
     DEBUG_TOOLBAR_CONFIG = {"ROOT_TAG_EXTRA_ATTRS": "data-turbo-permanent hx-preserve"}
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "WARNING",
+    },
+    "loggers": {
+        # Log when an asynchronous handler is adapted for middleware.
+        # See warning here: https://docs.djangoproject.com/en/4.2/topics/async/#async-views
+        "django.request": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_REQUEST_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+    },
+}

--- a/example/settings.py
+++ b/example/settings.py
@@ -118,26 +118,3 @@ if ENABLE_DEBUG_TOOLBAR:
     ]
     # Customize the config to support turbo and htmx boosting.
     DEBUG_TOOLBAR_CONFIG = {"ROOT_TAG_EXTRA_ATTRS": "data-turbo-permanent hx-preserve"}
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-        },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "WARNING",
-    },
-    "loggers": {
-        # Log when an asynchronous handler is adapted for middleware.
-        # See warning here: https://docs.djangoproject.com/en/4.2/topics/async/#async-views
-        "django.request": {
-            "handlers": ["console"],
-            "level": os.getenv("DJANGO_REQUEST_LOG_LEVEL", "INFO"),
-            "propagate": False,
-        },
-    },
-}

--- a/example/templates/async_db.html
+++ b/example/templates/async_db.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Async DB</title>
+  </head>
+  <body>
+    <h1>Async DB</h1>
+    <p>
+      <span>Value </span>
+      <span>{{ user_count }}</span>
+    </p>
+  </body>
+</html>

--- a/example/urls.py
+++ b/example/urls.py
@@ -3,7 +3,13 @@ from django.urls import path
 from django.views.generic import TemplateView
 
 from debug_toolbar.toolbar import debug_toolbar_urls
-from example.views import increment, jinja2_view
+from example.views import (
+    async_db,
+    async_db_concurrent,
+    async_home,
+    increment,
+    jinja2_view,
+)
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html"), name="home"),
@@ -13,6 +19,9 @@ urlpatterns = [
         name="bad_form",
     ),
     path("jinja/", jinja2_view, name="jinja"),
+    path("async/", async_home, name="async_home"),
+    path("async/db/", async_db, name="async_db"),
+    path("async/db-concurrent/", async_db_concurrent, name="async_db_concurrent"),
     path("jquery/", TemplateView.as_view(template_name="jquery/index.html")),
     path("mootools/", TemplateView.as_view(template_name="mootools/index.html")),
     path("prototype/", TemplateView.as_view(template_name="prototype/index.html")),

--- a/example/views.py
+++ b/example/views.py
@@ -1,3 +1,7 @@
+import asyncio
+
+from asgiref.sync import sync_to_async
+from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.shortcuts import render
 
@@ -13,3 +17,26 @@ def increment(request):
 
 def jinja2_view(request):
     return render(request, "index.jinja", {"foo": "bar"}, using="jinja2")
+
+
+async def async_home(request):
+    return await sync_to_async(render)(request, "index.html")
+
+
+async def async_db(request):
+    user_count = await User.objects.acount()
+
+    return await sync_to_async(render)(
+        request, "async_db.html", {"user_count": user_count}
+    )
+
+
+async def async_db_concurrent(request):
+    # Do database queries concurrently
+    (user_count, _) = await asyncio.gather(
+        User.objects.acount(), User.objects.filter(username="test").acount()
+    )
+
+    return await sync_to_async(render)(
+        request, "async_db.html", {"user_count": user_count}
+    )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,6 +12,10 @@ selenium
 tox
 black
 
+# Integration support
+
+daphne # async in Example app
+
 # Documentation
 
 Sphinx

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -32,6 +32,20 @@ def sql_call(*, use_iterator=False):
     return list(qs)
 
 
+async def async_sql_call(*, use_iterator=False):
+    qs = User.objects.all()
+    if use_iterator:
+        qs = qs.iterator()
+    return await sync_to_async(list)(qs)
+
+
+async def concurrent_async_sql_call(*, use_iterator=False):
+    qs = User.objects.all()
+    if use_iterator:
+        qs = qs.iterator()
+    return await asyncio.gather(sync_to_async(list)(qs), User.objects.acount())
+
+
 class SQLPanelTestCase(BaseTestCase):
     panel_id = "SQLPanel"
 
@@ -56,6 +70,39 @@ class SQLPanelTestCase(BaseTestCase):
 
         # ensure the stacktrace is populated
         self.assertTrue(len(query["stacktrace"]) > 0)
+
+    async def test_recording_async(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        await async_sql_call()
+
+        # ensure query was logged
+        self.assertEqual(len(self.panel._queries), 1)
+        query = self.panel._queries[0]
+        self.assertEqual(query["alias"], "default")
+        self.assertTrue("sql" in query)
+        self.assertTrue("duration" in query)
+        self.assertTrue("stacktrace" in query)
+
+        # ensure the stacktrace is populated
+        self.assertTrue(len(query["stacktrace"]) > 0)
+
+    async def test_recording_concurrent_async(self):
+        self.assertEqual(len(self.panel._queries), 0)
+
+        await concurrent_async_sql_call()
+
+        # ensure query was logged
+        self.assertEqual(len(self.panel._queries), 2)
+        query = self.panel._queries[0]
+        self.assertEqual(query["alias"], "default")
+        self.assertTrue("sql" in query)
+        self.assertTrue("duration" in query)
+        self.assertTrue("stacktrace" in query)
+
+        # ensure the stacktrace is populated
+        self.assertTrue(len(query["stacktrace"]) > 0)
+
 
     @unittest.skipUnless(
         connection.vendor == "postgresql", "Test valid only on PostgreSQL"

--- a/tests/panels/test_sql.py
+++ b/tests/panels/test_sql.py
@@ -103,7 +103,6 @@ class SQLPanelTestCase(BaseTestCase):
         # ensure the stacktrace is populated
         self.assertTrue(len(query["stacktrace"]) > 0)
 
-
     @unittest.skipUnless(
         connection.vendor == "postgresql", "Test valid only on PostgreSQL"
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -252,15 +252,21 @@ class DebugToolbarTestCase(BaseTestCase):
 
     def test_sql_page(self):
         response = self.client.get("/execute_sql/")
-        self.assertEqual(len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 1)
+        self.assertEqual(
+            len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 1
+        )
 
     def test_async_sql_page(self):
         response = self.client.get("/async_execute_sql/")
-        self.assertEqual(len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 1)
+        self.assertEqual(
+            len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 1
+        )
 
     def test_concurrent_async_sql_page(self):
         response = self.client.get("/async_execute_sql_concurrently/")
-        self.assertEqual(len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 2)
+        self.assertEqual(
+            len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 2
+        )
 
 
 @override_settings(DEBUG=True)
@@ -858,27 +864,26 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
 
     def test_async_sql_action(self):
         self.get("/async_execute_sql/")
-        sql_panel = self.selenium.find_element(By.ID, "SQLPanel")
-        debug_window = self.selenium.find_element(By.ID, "djDebugWindow")
+        self.selenium.find_element(By.ID, "SQLPanel")
+        self.selenium.find_element(By.ID, "djDebugWindow")
 
         # Click to show the SQL panel
         self.selenium.find_element(By.CLASS_NAME, "SQLPanel").click()
 
         # SQL panel loads
-        button = self.wait.until(
+        self.wait.until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, ".remoteCall"))
         )
 
-
     def test_concurrent_async_sql_action(self):
         self.get("/async_execute_sql_concurrently/")
-        sql_panel = self.selenium.find_element(By.ID, "SQLPanel")
-        debug_window = self.selenium.find_element(By.ID, "djDebugWindow")
+        self.selenium.find_element(By.ID, "SQLPanel")
+        self.selenium.find_element(By.ID, "djDebugWindow")
 
         # Click to show the SQL panel
         self.selenium.find_element(By.CLASS_NAME, "SQLPanel").click()
 
         # SQL panel loads
-        button = self.wait.until(
+        self.wait.until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, ".remoteCall"))
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -250,6 +250,18 @@ class DebugToolbarTestCase(BaseTestCase):
         )
         self.assertIn("Please reload the page and retry.", response.json()["content"])
 
+    def test_sql_page(self):
+        response = self.client.get("/execute_sql/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 1)
+
+    def test_async_sql_page(self):
+        response = self.client.get("/async_execute_sql/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 1)
+
+    def test_concurrent_async_sql_page(self):
+        response = self.client.get("/async_execute_sql_concurrently/")
+        self.assertEqual(len(response.toolbar.get_panel_by_id("SQLPanel").get_stats()["queries"]), 2)
+
 
 @override_settings(DEBUG=True)
 class DebugToolbarIntegrationTestCase(IntegrationTestCase):
@@ -843,3 +855,30 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         self.get("/regular/basic/")
         toolbar = self.selenium.find_element(By.ID, "djDebug")
         self.assertEqual(toolbar.get_attribute("data-theme"), "light")
+
+    def test_async_sql_action(self):
+        self.get("/async_execute_sql/")
+        sql_panel = self.selenium.find_element(By.ID, "SQLPanel")
+        debug_window = self.selenium.find_element(By.ID, "djDebugWindow")
+
+        # Click to show the SQL panel
+        self.selenium.find_element(By.CLASS_NAME, "SQLPanel").click()
+
+        # SQL panel loads
+        button = self.wait.until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".remoteCall"))
+        )
+
+
+    def test_concurrent_async_sql_action(self):
+        self.get("/async_execute_sql_concurrently/")
+        sql_panel = self.selenium.find_element(By.ID, "SQLPanel")
+        debug_window = self.selenium.find_element(By.ID, "djDebugWindow")
+
+        # Click to show the SQL panel
+        self.selenium.find_element(By.CLASS_NAME, "SQLPanel").click()
+
+        # SQL panel loads
+        button = self.wait.until(
+            EC.visibility_of_element_located((By.CSS_SELECTOR, ".remoteCall"))
+        )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
     path("non_ascii_request/", views.regular_view, {"title": NonAsciiRepr()}),
     path("new_user/", views.new_user),
     path("execute_sql/", views.execute_sql),
+    path("async_execute_sql/", views.async_execute_sql),
+    path("async_execute_sql_concurrently/", views.async_execute_sql_concurrently),
     path("cached_view/", views.cached_view),
     path("cached_low_level_view/", views.cached_low_level_view),
     path("json_view/", views.json_view),

--- a/tests/views.py
+++ b/tests/views.py
@@ -24,7 +24,6 @@ async def async_execute_sql_concurrently(request):
     return render(request, "base.html")
 
 
-
 def regular_view(request, title):
     return render(request, "basic.html", {"title": title})
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,3 +1,6 @@
+import asyncio
+
+from asgiref.sync import sync_to_async
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.http import HttpResponseRedirect, JsonResponse
@@ -9,6 +12,17 @@ from django.views.decorators.cache import cache_page
 def execute_sql(request):
     list(User.objects.all())
     return render(request, "base.html")
+
+
+async def async_execute_sql(request):
+    await sync_to_async(list)(User.objects.all())
+    return render(request, "base.html")
+
+
+async def async_execute_sql_concurrently(request):
+    await asyncio.gather(sync_to_async(list)(User.objects.all()), User.objects.acount())
+    return render(request, "base.html")
+
 
 
 def regular_view(request, title):


### PR DESCRIPTION
As discussed with @tim-schilling in #1828 a good start towards adding async support is adding tests involving async views and async ORM usage.

Unfortunately, none of the automated tests showcase the problem described in #1828 as there is no ASGI equivalent of `LiveServerTestCase` and the issue seems to be specific to running an actual ASGI server. 

Therefore, despite all tests are green, async support is still not there. Running the example app with an ASGI server using `ASYNC_SERVER=true python example/manage.py runserver` and visiting http://127.0.0.1:8000/async/db-concurrent/ does exhibit the deadlock though.

See also [#1819](https://github.com/jazzband/django-debug-toolbar/issues/1819).