### PR TITLE
Type hints: toolbar/middleware

### DIFF
--- a/debug_toolbar/_stubs.py
+++ b/debug_toolbar/_stubs.py
@@ -1,6 +1,7 @@
-from typing import Any, List, NamedTuple, Optional, Tuple
+from typing import Any, List, NamedTuple, Optional, Protocol, Tuple
 
 from django import template as dj_template
+from django.http import HttpRequest, HttpResponse
 
 
 class InspectStack(NamedTuple):
@@ -22,3 +23,8 @@ class RenderContext(dj_template.context.RenderContext):
 class RequestContext(dj_template.RequestContext):
     template: dj_template.Template
     render_context: RenderContext
+
+
+class GetResponse(Protocol):
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        ...

--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -6,16 +6,19 @@ import re
 from functools import lru_cache
 
 from django.conf import settings
+from django.http import HttpRequest
 from django.utils.module_loading import import_string
 
 from debug_toolbar import settings as dt_settings
 from debug_toolbar.toolbar import DebugToolbar
 from debug_toolbar.utils import clear_stack_trace_caches
 
+from ._stubs import GetResponse
+
 _HTML_TYPES = ("text/html", "application/xhtml+xml")
 
 
-def show_toolbar(request):
+def show_toolbar(request: HttpRequest):
     """
     Default function to determine whether to show the toolbar on a given page.
     """
@@ -39,7 +42,7 @@ class DebugToolbarMiddleware:
     on outgoing response.
     """
 
-    def __init__(self, get_response):
+    def __init__(self, get_response: GetResponse):
         self.get_response = get_response
 
     def __call__(self, request):

--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -1,6 +1,7 @@
 from django.template.loader import render_to_string
 
 from debug_toolbar import settings as dt_settings
+from debug_toolbar._stubs import GetResponse
 from debug_toolbar.utils import get_name_from_obj
 
 
@@ -9,7 +10,7 @@ class Panel:
     Base class for panels.
     """
 
-    def __init__(self, toolbar, get_response):
+    def __init__(self, toolbar, get_response: GetResponse):
         self.toolbar = toolbar
         self.get_response = get_response
 

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from django.apps import apps
 from django.core.exceptions import ImproperlyConfigured
 from django.dispatch import Signal
+from django.http import HttpRequest
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
 from django.urls import path, resolve
@@ -18,12 +19,14 @@ from django.utils.translation import get_language, override as lang_override
 
 from debug_toolbar import APP_NAME, settings as dt_settings
 
+from ._stubs import GetResponse
+
 
 class DebugToolbar:
     # for internal testing use only
     _created = Signal()
 
-    def __init__(self, request, get_response):
+    def __init__(self, request: HttpRequest, get_response: GetResponse):
         self.request = request
         self.config = dt_settings.get_config().copy()
         panels = []


### PR DESCRIPTION
# Description

This PR adds type hints to the `middleware` and `toolbar` modules

Fixes #1705

# Checklist:

- [x] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
