### PR TITLE
Refactor is_project_func method for Windows compatibility

### DIFF
--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -42,10 +42,17 @@ class FunctionCall:
         """
         if hasattr(settings, "BASE_DIR"):
             file_name, _, _ = self.func
+            base_dir = str(settings.BASE_DIR)
+
+            file_name = os.path.normpath(file_name)
+            base_dir = os.path.normpath(base_dir)
+
             return (
-                str(settings.BASE_DIR) in file_name
-                and "/site-packages/" not in file_name
-                and "/dist-packages/" not in file_name
+                file_name.startswith(base_dir)
+                and not any(
+                    directory in file_name.split(os.path.sep)
+                    for directory in ["site-packages", "dist-packages"]
+                )
             )
         return None
 

--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -47,12 +47,9 @@ class FunctionCall:
             file_name = os.path.normpath(file_name)
             base_dir = os.path.normpath(base_dir)
 
-            return (
-                file_name.startswith(base_dir)
-                and not any(
-                    directory in file_name.split(os.path.sep)
-                    for directory in ["site-packages", "dist-packages"]
-                )
+            return file_name.startswith(base_dir) and not any(
+                directory in file_name.split(os.path.sep)
+                for directory in ["site-packages", "dist-packages"]
             )
         return None
 


### PR DESCRIPTION
The previous implementation of the is_project_func method had issues related to path handling on Windows systems, potentially leading to incorrect identification of project code. 

Changes made:
- Utilized os.path.normpath() for path normalization.
- Modified file path comparison to correctly identify project code.
- Implemented exclusion of 'site-packages' and 'dist-packages' directories.

Fixes: #1836 
