### PR TITLE
Fix #1858 -- Drop support for Django 4.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,7 @@ Change log
 Pending
 -------
 
+* Dropped support for Django 4.0.
 * Added Python 3.12 to test matrix.
 * Removed outdated third-party panels from the list.
 * Avoided the unnecessary work of recursively quoting SQL parameters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Framework :: Django",
   "Framework :: Django :: 3.2",
-  "Framework :: Django :: 4.0",
   "Framework :: Django :: 4.1",
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.0",

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,12 @@ envlist =
     docs
     packaging
     py{38,39,310}-dj32-{sqlite,postgresql,postgis,mysql}
-    py310-dj40-sqlite
     py{310,311}-dj41-{sqlite,postgresql,postgis,mysql}
     py{310,311,312}-dj{42,50,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
 
 [testenv]
 deps =
     dj32: django~=3.2.9
-    dj40: django~=4.0.0
     dj41: django~=4.1.3
     dj42: django~=4.2.1
     dj50: django~=5.0a1
@@ -51,28 +49,28 @@ pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
 
-[testenv:py{38,39,310,311,312}-dj{32,40,41,42,50,main}-{postgresql,psycopg3}]
+[testenv:py{38,39,310,311,312}-dj{32,41,42,50,main}-{postgresql,psycopg3}]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{38,39,310,311,312}-dj{32,40,41,42,50,main}-postgis]
+[testenv:py{38,39,310,311,312}-dj{32,41,42,50,main}-postgis]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgis
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{38,39,310,311,312}-dj{32,40,41,42,50,main}-mysql]
+[testenv:py{38,39,310,311,312}-dj{32,41,42,50,main}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
     DB_PORT = {env:DB_PORT:3306}
 
 
-[testenv:py{38,39,310,311,312}-dj{32,40,41,42,50,main}-sqlite]
+[testenv:py{38,39,310,311,312}-dj{32,41,42,50,main}-sqlite]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3


### PR DESCRIPTION
# Description

Drop support for Django 4.0

Fixes #1858 

# Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
