### PR TITLE
The djdt handle shouldn't be stuck at the top of the browser window initially #1853

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -220,7 +220,7 @@
     background-color: #fff;
     border: 1px solid #111;
     border-bottom: 0;
-    top: 0;
+    top: 268px;
     right: 0;
     z-index: 100000000;
     opacity: 0.75;

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -220,7 +220,7 @@
     background-color: #fff;
     border: 1px solid #111;
     border-bottom: 0;
-    top: 268px;
+    top: 0;
     right: 0;
     z-index: 100000000;
     opacity: 0.75;

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -226,7 +226,7 @@ const djdt = {
         const handle = document.getElementById("djDebugToolbarHandle");
         // set handle position
         const handleTop = Math.min(
-            localStorage.getItem("djdt.top") || 0,
+            localStorage.getItem("djdt.top") || 265,
             window.innerHeight - handle.offsetWidth
         );
         handle.style.top = handleTop + "px";

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,8 @@ Pending
   ``django.contrib.admindocs.utils.get_view_name``.
 * Switched from black to the `ruff formatter
   <https://astral.sh/blog/the-ruff-formatter>`__.
+* Changed the default position of the toolbar from top to the upper top
+  position.
 
 4.2.0 (2023-08-10)
 ------------------


### PR DESCRIPTION
# Description
The issue was as much as the toolbar can be moved, it would be preferred if its position was on the upper top instead of the top.

Fixes # (issue)
The issue is mentioned here #1853 
# Checklist:

- [X] I have added the relevant tests for this change.
- [X] I have added an item to the Pending section of ``docs/changes.rst``.
