### PR TITLE
1843 new ajax request resets whole view if historypanel is enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args:
         - --fix
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.1.9'
+    rev: 'v0.1.11'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -42,6 +42,7 @@ CONFIG_DEFAULTS = {
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
     "OBSERVE_REQUEST_CALLBACK": "debug_toolbar.toolbar.observe_request",
     "TOOLBAR_LANGUAGE": None,
+    "UDPATE_ON_AJAX": False,
 }
 
 

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -42,7 +42,7 @@ CONFIG_DEFAULTS = {
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
     "OBSERVE_REQUEST_CALLBACK": "debug_toolbar.toolbar.observe_request",
     "TOOLBAR_LANGUAGE": None,
-    "UPDATE_ON_FETCH": True,
+    "UPDATE_ON_FETCH": False,
 }
 
 

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -42,7 +42,7 @@ CONFIG_DEFAULTS = {
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
     "OBSERVE_REQUEST_CALLBACK": "debug_toolbar.toolbar.observe_request",
     "TOOLBAR_LANGUAGE": None,
-    "UDPATE_ON_AJAX": False,
+    "UPDATE_ON_FETCH": True,
 }
 
 

--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -104,5 +104,6 @@ $$.on(djDebug, "click", ".refreshHistory", function (event) {
     event.preventDefault();
     refreshHistory();
 });
-// As we don't refresh the whole toolbar each fetch or ajax request we need to refresh the history when we open the panel
+// We don't refresh the whole toolbar each fetch or ajax request,
+// so we need to refresh the history when we open the panel
 $$.onPanelRender(djDebug, "HistoryPanel", refreshHistory);

--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -104,4 +104,5 @@ $$.on(djDebug, "click", ".refreshHistory", function (event) {
     event.preventDefault();
     refreshHistory();
 });
+// As we don't refresh the whole toolbar each fetch or ajax request we need to refresh the history when we open the panel
 $$.onPanelRender(djDebug, "HistoryPanel", refreshHistory);

--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -76,6 +76,7 @@ function switchHistory(newStoreId) {
     const formTarget = djDebug.querySelector(
         ".switchHistory[data-store-id='" + newStoreId + "']"
     );
+    djdt.history_storeId = newStoreId
     const tbody = formTarget.closest("tbody");
 
     const highlighted = tbody.querySelector(".djdt-highlighted");
@@ -104,3 +105,5 @@ $$.on(djDebug, "click", ".refreshHistory", function (event) {
     event.preventDefault();
     refreshHistory();
 });
+
+export { refreshHistory };

--- a/debug_toolbar/static/debug_toolbar/js/history.js
+++ b/debug_toolbar/static/debug_toolbar/js/history.js
@@ -76,7 +76,6 @@ function switchHistory(newStoreId) {
     const formTarget = djDebug.querySelector(
         ".switchHistory[data-store-id='" + newStoreId + "']"
     );
-    djdt.history_storeId = newStoreId
     const tbody = formTarget.closest("tbody");
 
     const highlighted = tbody.querySelector(".djdt-highlighted");
@@ -105,5 +104,4 @@ $$.on(djDebug, "click", ".refreshHistory", function (event) {
     event.preventDefault();
     refreshHistory();
 });
-
-export { refreshHistory };
+$$.onPanelRender(djDebug, "HistoryPanel", refreshHistory);

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -19,7 +19,7 @@ const djdt = {
     handleDragged: false,
     init() {
         const djDebug = getDebugElement();
-        window.djdt.update_on_ajax = djDebug.getAttribute("update-on-ajax") === "True"
+        window.djdt.update_on_ajax = djDebug.getAttribute("update-on-ajax") === "True";
         $$.on(djDebug, "click", "#djDebugPanelList li a", function (event) {
             event.preventDefault();
             if (!this.className) {

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -1,4 +1,5 @@
 import { $$, ajax, replaceToolbarState, debounce } from "./utils.js";
+import { refreshHistory } from "./history.js"
 
 function onKeyDown(event) {
     if (event.keyCode === 27) {
@@ -19,6 +20,7 @@ const djdt = {
     handleDragged: false,
     init() {
         const djDebug = getDebugElement();
+        console.log(djDebug)
         $$.on(djDebug, "click", "#djDebugPanelList li a", function (event) {
             event.preventDefault();
             if (!this.className) {
@@ -49,12 +51,16 @@ const djdt = {
                         inner.previousElementSibling.remove(); // Remove AJAX loader
                         inner.innerHTML = data.content;
                         $$.executeScripts(data.scripts);
+                        if (panelId == "HistoryPanel"){
+                            refreshHistory();
+                        }
                         $$.applyStyles(inner);
                         djDebug.dispatchEvent(
                             new CustomEvent("djdt.panel.render", {
                                 detail: { panelId: panelId },
                             })
                         );
+
                     });
                 } else {
                     djDebug.dispatchEvent(
@@ -62,6 +68,9 @@ const djdt = {
                             detail: { panelId: panelId },
                         })
                     );
+                    if (panelId == "HistoryPanel"){
+                            refreshHistory();
+                        }
                 }
             }
         });
@@ -274,7 +283,9 @@ const djdt = {
             storeId = encodeURIComponent(storeId);
             const dest = `${sidebarUrl}?store_id=${storeId}`;
             slowjax(dest).then(function (data) {
-                replaceToolbarState(storeId, data);
+                if (window.djdt.history_storeId == null){
+                    replaceToolbarState(storeId, data);
+                }
             });
         }
 
@@ -356,6 +367,7 @@ window.djdt = {
     init: djdt.init,
     close: djdt.hideOneLevel,
     cookie: djdt.cookie,
+    history_storeId: null,  // StoreId if we choose to open a past request in the history
 };
 
 if (document.readyState !== "loading") {

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -1,5 +1,4 @@
 import { $$, ajax, replaceToolbarState, debounce } from "./utils.js";
-import { refreshHistory } from "./history.js"
 
 function onKeyDown(event) {
     if (event.keyCode === 27) {
@@ -20,6 +19,7 @@ const djdt = {
     handleDragged: false,
     init() {
         const djDebug = getDebugElement();
+        window.djdt.update_on_ajax = djDebug.getAttribute("update-on-ajax") === "True"
         $$.on(djDebug, "click", "#djDebugPanelList li a", function (event) {
             event.preventDefault();
             if (!this.className) {
@@ -50,9 +50,6 @@ const djdt = {
                         inner.previousElementSibling.remove(); // Remove AJAX loader
                         inner.innerHTML = data.content;
                         $$.executeScripts(data.scripts);
-                        if (panelId == "HistoryPanel"){
-                            refreshHistory();
-                        }
                         $$.applyStyles(inner);
                         djDebug.dispatchEvent(
                             new CustomEvent("djdt.panel.render", {
@@ -67,9 +64,6 @@ const djdt = {
                             detail: { panelId: panelId },
                         })
                     );
-                    if (panelId == "HistoryPanel"){
-                            refreshHistory();
-                        }
                 }
             }
         });
@@ -282,7 +276,7 @@ const djdt = {
             storeId = encodeURIComponent(storeId);
             const dest = `${sidebarUrl}?store_id=${storeId}`;
             slowjax(dest).then(function (data) {
-                if (window.djdt.history_storeId == null){
+                if (window.djdt.update_on_ajax){
                     replaceToolbarState(storeId, data);
                 }
             });
@@ -366,7 +360,7 @@ window.djdt = {
     init: djdt.init,
     close: djdt.hideOneLevel,
     cookie: djdt.cookie,
-    history_storeId: null,  // StoreId if we choose to open a past request in the history
+    update_on_ajax: false,
 };
 
 if (document.readyState !== "loading") {

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -20,7 +20,6 @@ const djdt = {
     handleDragged: false,
     init() {
         const djDebug = getDebugElement();
-        console.log(djDebug)
         $$.on(djDebug, "click", "#djDebugPanelList li a", function (event) {
             event.preventDefault();
             if (!this.className) {

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -57,7 +57,6 @@ const djdt = {
                                 detail: { panelId: panelId },
                             })
                         );
-
                     });
                 } else {
                     djDebug.dispatchEvent(

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -17,9 +17,10 @@ function getDebugElement() {
 
 const djdt = {
     handleDragged: false,
+    needUpdateOnFetch: false,
     init() {
         const djDebug = getDebugElement();
-        window.djdt.update_on_ajax = djDebug.getAttribute("update-on-ajax") === "True";
+        djdt.needUpdateOnFetch = djDebug.dataset.updateOnFetch === "True";
         $$.on(djDebug, "click", "#djDebugPanelList li a", function (event) {
             event.preventDefault();
             if (!this.className) {
@@ -276,7 +277,7 @@ const djdt = {
             storeId = encodeURIComponent(storeId);
             const dest = `${sidebarUrl}?store_id=${storeId}`;
             slowjax(dest).then(function (data) {
-                if (window.djdt.update_on_ajax){
+                if (djdt.needUpdateOnFetch){
                     replaceToolbarState(storeId, data);
                 }
             });
@@ -360,7 +361,6 @@ window.djdt = {
     init: djdt.init,
     close: djdt.hideOneLevel,
     cookie: djdt.cookie,
-    update_on_ajax: false,
 };
 
 if (document.readyState !== "loading") {

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -16,7 +16,7 @@
      data-sidebar-url="{{ history_url }}"
      {% endif %}
      data-default-show="{% if toolbar.config.SHOW_COLLAPSED %}false{% else %}true{% endif %}"
-     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}  update-on-ajax="{{ toolbar.config.UDPATE_ON_AJAX|safe }}">
+     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}  data-update-on-fetch="{{ toolbar.config.UPDATE_ON_FETCH|safe }}">
   <div class="djdt-hidden" id="djDebugToolbar">
     <ul id="djDebugPanelList">
       <li><a id="djHideToolBarButton" href="#" title="{% trans 'Hide toolbar' %}">{% trans "Hide" %} »</a></li>

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -16,7 +16,7 @@
      data-sidebar-url="{{ history_url }}"
      {% endif %}
      data-default-show="{% if toolbar.config.SHOW_COLLAPSED %}false{% else %}true{% endif %}"
-     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>
+     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}  update-on-ajax="{{ toolbar.config.UDPATE_ON_AJAX|safe }}">
   <div class="djdt-hidden" id="djDebugToolbar">
     <ul id="djDebugPanelList">
       <li><a id="djHideToolBarButton" href="#" title="{% trans 'Hide toolbar' %}">{% trans "Hide" %} »</a></li>

--- a/debug_toolbar/templates/debug_toolbar/base.html
+++ b/debug_toolbar/templates/debug_toolbar/base.html
@@ -16,7 +16,7 @@
      data-sidebar-url="{{ history_url }}"
      {% endif %}
      data-default-show="{% if toolbar.config.SHOW_COLLAPSED %}false{% else %}true{% endif %}"
-     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}  data-update-on-fetch="{{ toolbar.config.UPDATE_ON_FETCH|safe }}">
+     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}  data-update-on-fetch="{{ toolbar.config.UPDATE_ON_FETCH }}">
   <div class="djdt-hidden" id="djDebugToolbar">
     <ul id="djDebugPanelList">
       <li><a id="djHideToolBarButton" href="#" title="{% trans 'Hide toolbar' %}">{% trans "Hide" %} »</a></li>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Pending
   ``django.contrib.admindocs.utils.get_view_name``.
 * Switched from black to the `ruff formatter
   <https://astral.sh/blog/the-ruff-formatter>`__.
+* Add a setting for refresh or not the toolbar if an ajax request occurs.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,7 +19,7 @@ Pending
   <https://astral.sh/blog/the-ruff-formatter>`__.
 * Changed the default position of the toolbar from top to the upper top
   position.
-* Added the setting, ``UPDATE_ON_FETCH`` to control whether the 
+* Added the setting, ``UPDATE_ON_FETCH`` to control whether the
   toolbar automatically updates to the latest AJAX request or not.
   It defaults to ``False``.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,7 +19,9 @@ Pending
   <https://astral.sh/blog/the-ruff-formatter>`__.
 * Changed the default position of the toolbar from top to the upper top
   position.
-* Add a setting for refresh or not the toolbar if an ajax request occurs.
+* Added the setting, ``UPDATE_ON_FETCH`` to control whether the 
+  toolbar automatically updates to the latest AJAX request or not.
+  It defaults to ``False``.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -169,8 +169,9 @@ Toolbar options
 
   Default: ``False``
 
-  This setting specifies if  the whole toolbar need to be refresh if an ajax
-  request is done.
+  This controls whether the toolbar should update to the latest AJAX request when it occurs.
+  This is useful to enable if when "boosting" the web application with a JavaScript library such
+  as htmx.
 
 Panel options
 ~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -169,9 +169,9 @@ Toolbar options
 
   Default: ``False``
 
-  This controls whether the toolbar should update to the latest AJAX request when it occurs.
-  This is useful to enable if when "boosting" the web application with a JavaScript library such
-  as htmx.
+  This controls whether the toolbar should update to the latest AJAX
+  request when it occurs. This is useful to enable if when "boosting"
+  the web application with a JavaScript library such as htmx.
 
 Panel options
 ~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -163,6 +163,15 @@ Toolbar options
   but want to render your application in French, you would set this to
   ``"en-us"`` and :setting:`LANGUAGE_CODE` to ``"fr"``.
 
+.. _UDPATE_ON_AJAX:
+
+* ``UDPATE_ON_AJAX``
+
+  Default: ``False``
+
+  This setting specifies if  the whole toolbar need to be refresh if an ajax
+  request is done.
+
 Panel options
 ~~~~~~~~~~~~~
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -170,8 +170,8 @@ Toolbar options
   Default: ``False``
 
   This controls whether the toolbar should update to the latest AJAX
-  request when it occurs. This is useful to enable if when "boosting"
-  the web application with a JavaScript library such as htmx.
+  request when it occurs. This is especially useful when using htmx
+  boosting or similar JavaScript techniques.
 
 Panel options
 ~~~~~~~~~~~~~

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -163,9 +163,9 @@ Toolbar options
   but want to render your application in French, you would set this to
   ``"en-us"`` and :setting:`LANGUAGE_CODE` to ``"fr"``.
 
-.. _UDPATE_ON_AJAX:
+.. _UPDATE_ON_FETCH:
 
-* ``UDPATE_ON_AJAX``
+* ``UPDATE_ON_FETCH``
 
   Default: ``False``
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -57,3 +57,4 @@ tox
 uWSGI
 unhashable
 validator
+ajax

--- a/tests/templates/ajax/ajax.html
+++ b/tests/templates/ajax/ajax.html
@@ -4,7 +4,7 @@
 
   <script>
 
-  let click_for_ajax = document.getElementById("click_for_ajax")
+  let click_for_ajax = document.getElementById("click_for_ajax");
   function send_ajax() {
     let xhr = new XMLHttpRequest();
     let url = '/json_view/';

--- a/tests/templates/ajax/ajax.html
+++ b/tests/templates/ajax/ajax.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+  <div id="click_for_ajax">click for ajax</div>
+
+  <script>
+
+  let click_for_ajax = document.getElementById("click_for_ajax")
+  function send_ajax() {
+    let xhr = new XMLHttpRequest();
+    let url = '/json_view/';
+    xhr.open("GET", url, true);
+    xhr.onreadystatechange = function () {
+        if (this.readyState == 4 && this.status == 200) {
+            console.log(this.responseText);
+        }
+    }
+    xhr.send();
+  }
+  document.addEventListener("click", (event) => {send_ajax()});
+  </script>
+{% endblock %}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -751,19 +751,18 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         self.assertIn("Action", table.text)
 
     def test_ajax_dont_refresh(self):
-        self.get('/ajax/')
+        self.get("/ajax/")
         make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")
         make_ajax.click()
         history_panel = self.selenium.find_element(By.ID, "djdt-HistoryPanel")
-        self.assertIn('/ajax/', history_panel.text)
-        self.assertNotIn('/json_view/', history_panel.text)
+        self.assertIn("/ajax/", history_panel.text)
+        self.assertNotIn("/json_view/", history_panel.text)
 
     @override_settings(DEBUG_TOOLBAR_CONFIG={"UDPATE_ON_AJAX": True})
     def test_ajax_refresh(self):
-        self.get('/ajax/')
+        self.get("/ajax/")
         make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")
         make_ajax.click()
         history_panel = self.selenium.find_element(By.ID, "djdt-HistoryPanel")
-        self.assertNotIn('/ajax/', history_panel.text)
-        self.assertIn('/json_view/', history_panel.text)
-
+        self.assertNotIn("/ajax/", history_panel.text)
+        self.assertIn("/json_view/", history_panel.text)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -756,9 +756,6 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")
         make_ajax.click()
         history_panel = self.selenium.find_element(By.ID, "djdt-HistoryPanel")
-        self.wait.until(
-            lambda selenium: self.selenium.find_element(By.CLASS_NAME, "data_success")
-        )
         self.assertIn("/ajax/", history_panel.text)
         self.assertNotIn("/json_view/", history_panel.text)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -749,3 +749,21 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         )
         self.assertIn("Query", table.text)
         self.assertIn("Action", table.text)
+
+    def test_ajax_dont_refresh(self):
+        self.get('/ajax/')
+        make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")
+        make_ajax.click()
+        history_panel = self.selenium.find_element(By.ID, "djdt-HistoryPanel")
+        self.assertIn('/ajax/', history_panel.text)
+        self.assertNotIn('/json_view/', history_panel.text)
+
+    @override_settings(DEBUG_TOOLBAR_CONFIG={"UDPATE_ON_AJAX": True})
+    def test_ajax_refresh(self):
+        self.get('/ajax/')
+        make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")
+        make_ajax.click()
+        history_panel = self.selenium.find_element(By.ID, "djdt-HistoryPanel")
+        self.assertNotIn('/ajax/', history_panel.text)
+        self.assertIn('/json_view/', history_panel.text)
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -758,7 +758,7 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         self.assertIn("/ajax/", history_panel.text)
         self.assertNotIn("/json_view/", history_panel.text)
 
-    @override_settings(DEBUG_TOOLBAR_CONFIG={"UDPATE_ON_AJAX": True})
+    @override_settings(DEBUG_TOOLBAR_CONFIG={"UPDATE_ON_FETCH": True})
     def test_ajax_refresh(self):
         self.get("/ajax/")
         make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 import unittest
 
 import html5lib
@@ -755,6 +756,9 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")
         make_ajax.click()
         history_panel = self.selenium.find_element(By.ID, "djdt-HistoryPanel")
+        self.wait.until(
+            lambda selenium: self.selenium.find_element(By.CLASS_NAME, "data_success")
+        )
         self.assertIn("/ajax/", history_panel.text)
         self.assertNotIn("/json_view/", history_panel.text)
 
@@ -763,6 +767,10 @@ class DebugToolbarLiveTestCase(StaticLiveServerTestCase):
         self.get("/ajax/")
         make_ajax = self.selenium.find_element(By.ID, "click_for_ajax")
         make_ajax.click()
-        history_panel = self.selenium.find_element(By.ID, "djdt-HistoryPanel")
+        # Need to wait until the ajax request is over and json_view is displayed on the toolbar
+        time.sleep(2)
+        history_panel = self.wait.until(
+            lambda selenium: self.selenium.find_element(By.ID, "djdt-HistoryPanel")
+        )
         self.assertNotIn("/ajax/", history_panel.text)
         self.assertIn("/json_view/", history_panel.text)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path("cached_low_level_view/", views.cached_low_level_view),
     path("json_view/", views.json_view),
     path("redirect/", views.redirect_view),
+    path("ajax/", views.ajax_view),
     path("login_without_redirect/", LoginView.as_view(redirect_field_name=None)),
     path("admin/", admin.site.urls),
     path("__debug__/", include("debug_toolbar.urls")),

--- a/tests/views.py
+++ b/tests/views.py
@@ -58,3 +58,7 @@ def listcomp_view(request):
 
 def redirect_view(request):
     return HttpResponseRedirect("/regular/redirect/")
+
+
+def ajax_view(request):
+    return render(request, "ajax/ajax.html")


### PR DESCRIPTION
# Description

[+] Create a setting which enable or disable the automatic refresh when an ajax request occurs.

Fixes #1843

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
