### PR TITLE
Show toolbar for docker's internal IP address

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Change log
 Pending
 -------
 
+* Automatically support Docker rather than having the developer write a
+  workaround for ``INTERNAL_IPS``.
+
 4.3.0 (2024-02-01)
 ------------------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,12 +145,10 @@ option.
 
 .. warning::
 
-    If using Docker the following will set your ``INTERNAL_IPS`` correctly in Debug mode::
-
-        if DEBUG:
-            import socket  # only if you haven't already imported this
-            hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
-            INTERNAL_IPS = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
+    If using Docker, the toolbar will attempt to look up your host name
+    automatically and treat it as an allowable internal IP. If you're not
+    able to get the toolbar to work with your docker installation, review
+    the code in ``debug_toolbar.middleware.show_toolbar``.
 
 Troubleshooting
 ---------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import unittest
+from unittest.mock import patch
 
 import html5lib
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -65,6 +66,14 @@ class DebugToolbarTestCase(BaseTestCase):
     def test_show_toolbar_INTERNAL_IPS(self):
         with self.settings(INTERNAL_IPS=[]):
             self.assertFalse(show_toolbar(self.request))
+
+    @patch("socket.gethostbyname", return_value="127.0.0.255")
+    def test_show_toolbar_docker(self, mocked_gethostbyname):
+        with self.settings(INTERNAL_IPS=[]):
+            # Is true because REMOTE_ADDR is 127.0.0.1 and the 255
+            # is shifted to be 1.
+            self.assertTrue(show_toolbar(self.request))
+        mocked_gethostbyname.assert_called_once_with("host.docker.internal")
 
     def test_should_render_panels_RENDER_PANELS(self):
         """


### PR DESCRIPTION
# Description
This attempts to automatically look up the docker internal IP address for the developer.

Fixes #1854

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
