### PR TITLE
'djdt' is not a registered namespace #1405

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -1,9 +1,10 @@
 import inspect
 import mimetypes
+import sys
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.core.checks import Warning, register
+from django.core.checks import Error, Warning, register
 from django.middleware.gzip import GZipMiddleware
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
@@ -206,3 +207,23 @@ def js_mimetype_check(app_configs, **kwargs):
             )
         ]
     return []
+
+
+@register()
+def debug_toolbar_namespace_check(app_configs, **kwargs):
+    """
+    Check that the Django Debug Toolbar is registered as a namespace.
+    """
+    if (
+        settings.DEBUG is False
+        and dt_settings.get_config()["DEBUG_TOOLBAR_CONFIG"] == "test" in sys.argv
+    ):
+        return [
+            Error(
+                "django debug toolbar  is not a registered namespace ",
+                hint="The Django Debug Toolbar is misconfigured, check the documentation for proper configuration and run the tests.",
+                id="debug_toolbar.W008",
+            )
+        ]
+    else:
+        return []

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 from functools import lru_cache
 
@@ -42,6 +43,7 @@ CONFIG_DEFAULTS = {
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
     "OBSERVE_REQUEST_CALLBACK": "debug_toolbar.toolbar.observe_request",
     "TOOLBAR_LANGUAGE": None,
+    "DEBUG_TOOLBAR_CONFIG": "test" in sys.argv,
 }
 
 

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -220,7 +220,7 @@
     background-color: #fff;
     border: 1px solid #111;
     border-bottom: 0;
-    top: 0;
+    top: 268px;
     right: 0;
     z-index: 100000000;
     opacity: 0.75;

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -220,7 +220,7 @@
     background-color: #fff;
     border: 1px solid #111;
     border-bottom: 0;
-    top: 268px;
+    top: 0;
     right: 0;
     z-index: 100000000;
     opacity: 0.75;

--- a/debug_toolbar/static/debug_toolbar/js/toolbar.js
+++ b/debug_toolbar/static/debug_toolbar/js/toolbar.js
@@ -226,7 +226,7 @@ const djdt = {
         const handle = document.getElementById("djDebugToolbarHandle");
         // set handle position
         const handleTop = Math.min(
-            localStorage.getItem("djdt.top") || 0,
+            localStorage.getItem("djdt.top") || 265,
             window.innerHeight - handle.offsetWidth
         );
         handle.style.top = handleTop + "px";

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,6 +8,7 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
 
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,8 @@ Pending
   <https://astral.sh/blog/the-ruff-formatter>`__.
 * Changed the default position of the toolbar from top to the upper top
   position.
+* Fixed the bug causing ``'djdt' is not a registered namespace`` and updated
+  docs to help in initial configuration.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,8 @@ Pending
   ``django.contrib.admindocs.utils.get_view_name``.
 * Switched from black to the `ruff formatter
   <https://astral.sh/blog/the-ruff-formatter>`__.
+* Changed the default position of the toolbar from top to the upper top
+  position.
 
 4.2.0 (2023-08-10)
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -99,7 +99,34 @@ Add django-debug-toolbar's URLs to your project's URLconf:
 This example uses the ``__debug__`` prefix, but you can use any prefix that
 doesn't clash with your application's URLs.
 
-5. Add the Middleware
+5. Configure django-debug-toolbar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add the following configuration for django-debug-toolbar in your setting:
+
+.. code-block:: python
+
+    import sys
+
+    DEBUG = bool({"runserver"}.intersection(sys.argv))
+
+    DEBUG_TOOLBAR_CONFIG = "test" in sys.argv
+
+    DEBUG_TOOLBAR = DEBUG and not DEBUG_TOOLBAR_CONFIG
+
+
+To explicitly check the ``settings.DEBUG_TOOLBAR_CONFIG``variable before
+including the URLs, add the following code in your ``urls`` file.
+
+.. code-block:: python
+
+    if settings.DEBUG_TOOLBAR_CONFIG:
+
+        import debug_toolbar
+
+        urlpatterns += [path('__debug__/', include(debug_toolbar.urls))]
+
+6. Add the Middleware
 ^^^^^^^^^^^^^^^^^^^^^
 
 The Debug Toolbar is mostly implemented in a middleware. Add it to your
@@ -122,7 +149,7 @@ The Debug Toolbar is mostly implemented in a middleware. Add it to your
 
 .. _internal-ips:
 
-6. Configure Internal IPs
+7. Configure Internal IPs
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Debug Toolbar is shown only if your IP address is listed in Django’s

--- a/example/settings.py
+++ b/example/settings.py
@@ -1,15 +1,25 @@
 """Django settings for example project."""
 
 import os
+import sys
+
+import environ
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
 # Quick-start development settings - unsuitable for production
 
+env = environ.Env()
+environ.Env.read_env()
+
 SECRET_KEY = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
-DEBUG = True
+# DEBUG = True
+
+DEBUG = env("DEBUG", default=bool({"runserver"}.intersection(sys.argv)))
+DEBUG_TOOLBAR_CONFIG = env("DEBUG_TOOLBAR_CONFIG", default="test" in sys.argv)
+DEBUG_TOOLBAR = DEBUG and not DEBUG_TOOLBAR_CONFIG
 
 INTERNAL_IPS = ["127.0.0.1", "::1"]
 


### PR DESCRIPTION
# Description

The error was `'djdt' is not a registered namespace`. It occurred due to misconfiguration of the toolbar settings as well as the debug settings.

Fixes # ([issue 1405](https://github.com/jazzband/django-debug-toolbar/issues/1405))
- Added a check to result in an official error 
- Added tests for the check
- Updated the docs with the right way to configure the toolbar to work with debug without an issue

# Checklist:

- [X] I have added the relevant tests for this change.
- [X] I have added an item to the Pending section of ``docs/changes.rst``.
