### PR TITLE
Make tox pass selenium environment variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ passenv=
     DB_PASSWORD
     DB_HOST
     DB_PORT
+    DISPLAY
+    DJANGO_SELENIUM_TESTS
     GITHUB_*
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
# Description

When running tox, pass through the user's `DISPLAY` and `DJANGO_SELENIUM_TESTS` environment variables, so that

    DJANGO_SELENIUM_TESTS=true tox

will actually run the Selenuim integration tests.  Without this change, the test suite never sees the `DJANGO_SELENIUM_TESTS` variable and thus skips the integration tests.  Without `DISPLAY`, the integration tests will error out (unless `CI` is present in the environment to instruct the test suite to run the Selenium webdriver in headless mode).

# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
