### PR TITLE
Remove obsolete tests

### DIFF
--- a/tests/panels/test_staticfiles.py
+++ b/tests/panels/test_staticfiles.py
@@ -1,10 +1,7 @@
 import os
-import unittest
 
-import django
 from django.conf import settings
 from django.contrib.staticfiles import finders
-from django.test.utils import override_settings
 
 from ..base import BaseTestCase
 
@@ -52,33 +49,3 @@ class StaticFilesPanelTestCase(BaseTestCase):
             "django.contrib.staticfiles.finders.AppDirectoriesFinder", content
         )
         self.assertValidHTML(content)
-
-    @unittest.skipIf(django.VERSION >= (4,), "Django>=4 handles missing dirs itself.")
-    @override_settings(
-        STATICFILES_DIRS=[PATH_DOES_NOT_EXIST] + settings.STATICFILES_DIRS,
-        STATIC_ROOT=PATH_DOES_NOT_EXIST,
-    )
-    def test_finder_directory_does_not_exist(self):
-        """Misconfigure the static files settings and verify the toolbar runs.
-
-        The test case is that the STATIC_ROOT is in STATICFILES_DIRS and that
-        the directory of STATIC_ROOT does not exist.
-        """
-        response = self.panel.process_request(self.request)
-        self.panel.generate_stats(self.request, response)
-        content = self.panel.content
-        self.assertIn(
-            "django.contrib.staticfiles.finders.AppDirectoriesFinder", content
-        )
-        self.assertNotIn(
-            "django.contrib.staticfiles.finders.FileSystemFinder (2 files)", content
-        )
-        self.assertEqual(self.panel.num_used, 0)
-        self.assertNotEqual(self.panel.num_found, 0)
-        expected_apps = ["django.contrib.admin", "debug_toolbar"]
-        if settings.USE_GIS:
-            expected_apps = ["django.contrib.gis"] + expected_apps
-        self.assertEqual(self.panel.get_staticfiles_apps(), expected_apps)
-        self.assertEqual(
-            self.panel.get_staticfiles_dirs(), finders.FileSystemFinder().locations
-        )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,8 +1,6 @@
 import os
-import unittest
 from unittest.mock import patch
 
-import django
 from django.conf import settings
 from django.core.checks import Warning, run_checks
 from django.test import SimpleTestCase, override_settings
@@ -90,23 +88,6 @@ class ChecksTestCase(SimpleTestCase):
                 id="debug_toolbar.W004",
             ),
             messages,
-        )
-
-    @unittest.skipIf(django.VERSION >= (4,), "Django>=4 handles missing dirs itself.")
-    @override_settings(
-        STATICFILES_DIRS=[PATH_DOES_NOT_EXIST],
-    )
-    def test_panel_check_errors(self):
-        messages = run_checks()
-        self.assertEqual(
-            messages,
-            [
-                Warning(
-                    "debug_toolbar requires the STATICFILES_DIRS directories to exist.",
-                    hint="Running manage.py collectstatic may help uncover the issue.",
-                    id="debug_toolbar.staticfiles.W001",
-                )
-            ],
         )
 
     @override_settings(DEBUG_TOOLBAR_PANELS=[])


### PR DESCRIPTION
# Description

There were two tests that were skipped on Django 4.0 and later. However, since the toolbar's minimum supported Django version is now 4.2, these tests will always be skipped and thus can be removed.

# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
