### PR TITLE
Deprecate OBSERVE_REQUEST_CALLBACK setting

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -206,3 +206,18 @@ def js_mimetype_check(app_configs, **kwargs):
             )
         ]
     return []
+
+
+@register()
+def check_settings(app_configs, **kwargs):
+    errors = []
+    USER_CONFIG = getattr(settings, "DEBUG_TOOLBAR_CONFIG", {})
+    if "OBSERVE_REQUEST_CALLBACK" in USER_CONFIG:
+        errors.append(
+            Warning(
+                "The deprecated OBSERVE_REQUEST_CALLBACK setting is present in DEBUG_TOOLBAR_CONFIG.",
+                hint="Use the UPDATE_ON_FETCH and/or SHOW_TOOLBAR_CALLBACK settings instead.",
+                id="debug_toolbar.W008",
+            )
+        )
+    return errors

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -185,4 +185,4 @@ def observe_request(request):
     """
     Determine whether to update the toolbar from a client side request.
     """
-    return not DebugToolbar.is_toolbar_request(request)
+    return True

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,9 @@ Pending
   :class:`StaticFilesPanel <debug_toolbar.panels.staticfiles.StaticFilesPanel>`
   since that check is made redundant by a similar check in Django 4.0 and
   later.
+* Deprecated the ``OBSERVE_REQUEST_CALLBACK`` setting and added check
+  ``debug_toolbar.W008`` to warn when it is present in
+  ``DEBUG_TOOLBAR_SETTINGS``.
 
 4.3.0 (2024-02-01)
 ------------------

--- a/docs/checks.rst
+++ b/docs/checks.rst
@@ -21,3 +21,6 @@ Django Debug Toolbar setup and configuration:
 * **debug_toolbar.W007**: JavaScript files are resolving to the wrong content
   type. Refer to :external:ref:`Django's explanation of
   mimetypes on Windows <staticfiles-development-view>`.
+* **debug_toolbar.W008**: The deprecated ``OBSERVE_REQUEST_CALLBACK`` setting
+  is present in ``DEBUG_TOOLBAR_CONFIG``.  Use the ``UPDATE_ON_FETCH`` and/or
+  ``SHOW_TOOLBAR_CALLBACK`` settings instead.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -146,9 +146,8 @@ Toolbar options
   Default: ``'debug_toolbar.toolbar.observe_request'``
 
   This is the dotted path to a function used for determining whether the
-  toolbar should update on AJAX requests or not. The default checks are that
-  the request doesn't originate from the toolbar itself, EG that
-  ``is_toolbar_request`` is false for a given request.
+  toolbar should update on AJAX requests or not. The default implementation
+  always returns ``True``.
 
 .. _TOOLBAR_LANGUAGE:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -145,6 +145,11 @@ Toolbar options
 
   Default: ``'debug_toolbar.toolbar.observe_request'``
 
+  .. note::
+
+     This setting is deprecated in favor of the ``UPDATE_ON_FETCH`` and
+     ``SHOW_TOOLBAR_CALLBACK`` settings.
+
   This is the dotted path to a function used for determining whether the
   toolbar should update on AJAX requests or not. The default implementation
   always returns ``True``.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -235,3 +235,11 @@ class ChecksTestCase(SimpleTestCase):
                 )
             ],
         )
+
+    @override_settings(
+        DEBUG_TOOLBAR_CONFIG={"OBSERVE_REQUEST_CALLBACK": lambda request: False}
+    )
+    def test_observe_request_callback_specified(self):
+        errors = run_checks()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "debug_toolbar.W008")


### PR DESCRIPTION
# Description

* Based on [this comment](https://github.com/jazzband/django-debug-toolbar/pull/1872#issuecomment-1939197680), change the default implementation of `OBSERVE_REQUEST_CALLBACK`, `observe_request()`, to always return `True`.

* Based on #1886, deprecate `OBSERVE_REQUEST_CALLBACK`, but do not remove it yet.

# Checklist:

- [X] I have added the relevant tests for this change.
- [X] I have added an item to the Pending section of ``docs/changes.rst``.
