### PR TITLE
Docs > Add a note on the profiling panel doc

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,7 +20,8 @@ Pending
 * Deprecated the ``OBSERVE_REQUEST_CALLBACK`` setting and added check
   ``debug_toolbar.W008`` to warn when it is present in
   ``DEBUG_TOOLBAR_SETTINGS``.
-* Add a note on the profiling panel document about python 3.12 and after.
+* Add a note on the profiling panel about using Python 3.12 and later 
+  about needing ``--nothreading``
 
 4.3.0 (2024-02-01)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,7 +20,7 @@ Pending
 * Deprecated the ``OBSERVE_REQUEST_CALLBACK`` setting and added check
   ``debug_toolbar.W008`` to warn when it is present in
   ``DEBUG_TOOLBAR_SETTINGS``.
-* Add a note on the profiling panel about using Python 3.12 and later 
+* Add a note on the profiling panel about using Python 3.12 and later
   about needing ``--nothreading``
 
 4.3.0 (2024-02-01)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,7 @@ Pending
 * Deprecated the ``OBSERVE_REQUEST_CALLBACK`` setting and added check
   ``debug_toolbar.W008`` to warn when it is present in
   ``DEBUG_TOOLBAR_SETTINGS``.
+* Add a note on the profiling panel document about python 3.12 and after.
 
 4.3.0 (2024-02-01)
 ------------------

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -123,8 +123,9 @@ Profiling information for the processing of the request.
 This panel is included but inactive by default. You can activate it by default
 with the ``DISABLE_PANELS`` configuration option.
 
-For version of python 3.12 and after you need to add --nothreading
-to the runserver. Concurrent requests don't work with the profiling.
+For version of Python 3.12 and later you need to use
+``python -m manage runserver --nothreading``
+Concurrent requests don't work with the profiling panel.
 
 The panel will include all function calls made by your project if you're using
 the setting ``settings.BASE_DIR`` to point to your project's root directory.

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -123,6 +123,9 @@ Profiling information for the processing of the request.
 This panel is included but inactive by default. You can activate it by default
 with the ``DISABLE_PANELS`` configuration option.
 
+For version of python 3.12 and after you need to add --nothreading to the runserver.
+Concurrent requests don't work with the profiling.
+
 The panel will include all function calls made by your project if you're using
 the setting ``settings.BASE_DIR`` to point to your project's root directory.
 If a function is in a file within that directory and does not include

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -123,8 +123,8 @@ Profiling information for the processing of the request.
 This panel is included but inactive by default. You can activate it by default
 with the ``DISABLE_PANELS`` configuration option.
 
-For version of python 3.12 and after you need to add --nothreading to the runserver.
-Concurrent requests don't work with the profiling.
+For version of python 3.12 and after you need to add --nothreading
+to the runserver. Concurrent requests don't work with the profiling.
 
 The panel will include all function calls made by your project if you're using
 the setting ``settings.BASE_DIR`` to point to your project's root directory.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -36,6 +36,7 @@ mousedown
 mouseup
 multi
 neo
+nothreading
 paddings
 pre
 profiler
@@ -47,6 +48,7 @@ pyupgrade
 querysets
 refactoring
 resizing
+runserver
 spellchecking
 spooler
 stacktrace


### PR DESCRIPTION
# Description

Add a note on the profiling panel documentation about the necessity to put --nothreading on runserver for using the panel on python 3.12

Fixes # (issue)

# Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
