### PR TITLE
README: Fix Django compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ In addition to the built-in panels, a number of third-party panels are
 contributed by the community.
 
 The current stable version of the Debug Toolbar is 4.3.0. It works on
-Django ≥ 4.2.0.
+Django ≥ 5.0.0. If you uses Django 4, please install 4.2.0 version.
 
 The Debug Toolbar does not currently support `Django's asynchronous views
 <https://docs.djangoproject.com/en/dev/topics/async/>`_.


### PR DESCRIPTION
HI,
[Semantic versioning ](https://semver.org/) says to not introduce breaking change without releasing a new `major` version.

> Given a version number MAJOR.MINOR.PATCH, increment the:
> 
> MAJOR version when you make incompatible API changes
> MINOR version when you add functionality in a backward compatible manner
> PATCH version when you make backward compatible bug fixes
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.

Drop Django 4 support in 4.3.0 is a breaking change.

In the future,  please change the `major` version and not the `minor` version.