### PR TITLE
fix Exception while resolving variable 'toolbar' in template

### DIFF
--- a/debug_toolbar/panels/history/views.py
+++ b/debug_toolbar/panels/history/views.py
@@ -24,7 +24,7 @@ def history_sidebar(request):
         for panel in toolbar.panels:
             if exclude_history and not panel.is_historical:
                 continue
-            panel_context = {"panel": panel}
+            panel_context = {"panel": panel, "toolbar": toolbar}
             context[panel.panel_id] = {
                 "button": render_to_string(
                     "debug_toolbar/includes/panel_button.html", panel_context


### PR DESCRIPTION
# Description

When sending a request using ajax, toolbar.js will send a request at the same time:
`GET /__debug__/history_sidebar/?store_id=<id> HTTP/1.1`

This request will throw the following exception when rendering the template.
It seems because toolbar is not passed in panel_context.

Fixes # (#1905 )

1. add `toolbar` into `panel_context`.

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
