### PR TITLE
Remove unnecessary GitHub Graph info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 import sys
 
-from setuptools import setup
 
 sys.stderr.write(
     """\
@@ -14,10 +13,3 @@ Please use `python -m pip install .` instead.
 """
 )
 sys.exit(1)
-
-# The code below will never execute, however is required to
-# display the "Used by" section on the GitHub repository.
-#
-# See: https://github.com/github/feedback/discussions/6456
-
-setup(name="django-debug-toolbar")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 import sys
 
-
 sys.stderr.write(
     """\
 ===============================


### PR DESCRIPTION
This code is no longer needed now that the GitHub dependency graph shipped support for `pyproject.toml`: https://github.com/orgs/community/discussions/6456#discussioncomment-5244057

I didn't include a changelog mention as this is not a user-facing change.