### PR TITLE
Limit metadata version for Jazzband's release process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,14 @@ dependencies = [
 Download = "https://pypi.org/project/django-debug-toolbar/"
 Homepage = "https://github.com/jazzband/django-debug-toolbar"
 
+[tool.hatch.build.targets.sdist]
+# Jazzband's release process is limited to 2.2 metadata
+core-metadata-version = "2.2"
+
 [tool.hatch.build.targets.wheel]
 packages = ["debug_toolbar"]
+# Jazzband's release process is limited to 2.2 metadata
+core-metadata-version = "2.2"
 
 [tool.hatch.version]
 path = "debug_toolbar/__init__.py"


### PR DESCRIPTION
Attempting to release with 2.3 caused the following:

```
Uploading distributions to https://upload.pypi.org/legacy/ [31mERROR [0m InvalidDistribution: Metadata is missing required fields: Name, Version. Make sure the distribution includes the files where those fields are specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2.
```

This is related to https://github.com/jazzband/help/issues/360
# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
