### PR TITLE
Limit the cases for E001 to likely scenarios

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,10 @@ Change log
 Pending
 -------
 
+* Limit ``E001`` check to likely error cases when the
+  ``SHOW_TOOLBAR_CALLBACK`` has changed, but the toolbar's URL
+  paths aren't installed.
+
 4.4.2 (2024-05-27)
 ------------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -152,6 +152,16 @@ Toolbar options
      implication is that it is possible to execute arbitrary SQL through the
      SQL panel when the ``SECRET_KEY`` value is leaked somehow.
 
+  .. warning::
+
+     Do not use
+     ``DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG}``
+     in your project's settings.py file. The toolbar expects to use
+     ``django.conf.settings.DEBUG``. Using your project's setting's ``DEBUG``
+     is likely to cause unexpected when running your tests. This is because
+     Django automatically sets ``settings.DEBUG = False``, but your project's
+     setting's ``DEBUG`` will still be set to ``True``.
+
 .. _OBSERVE_REQUEST_CALLBACK:
 
 * ``OBSERVE_REQUEST_CALLBACK``

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -158,7 +158,7 @@ Toolbar options
      ``DEBUG_TOOLBAR_CONFIG = {"SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG}``
      in your project's settings.py file. The toolbar expects to use
      ``django.conf.settings.DEBUG``. Using your project's setting's ``DEBUG``
-     is likely to cause unexpected when running your tests. This is because
+     is likely to cause unexpected results when running your tests. This is because
      Django automatically sets ``settings.DEBUG = False``, but your project's
      setting's ``DEBUG`` will still be set to ``True``.
 


### PR DESCRIPTION
# Description 

Only when the user is customizing both the show toolbar callback setting and the URLs aren't installed will the underlying NoReverseMatch error occur.


Fixes #1920

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
