### PR TITLE
Fix overriding font-family for both light and dark themes

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -1,6 +1,5 @@
 /* Variable definitions */
-:root,
-#djDebug[data-theme="light"] {
+:root {
     /* Font families are the same as in Django admin/css/base.css */
     --djdt-font-family-primary: "Segoe UI", system-ui, Roboto, "Helvetica Neue",
         Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
@@ -10,7 +9,10 @@
         "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New",
         monospace, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
         "Noto Color Emoji";
+}
 
+:root,
+#djDebug[data-theme="light"] {
     --djdt-font-color: black;
     --djdt-background-color: white;
     --djdt-panel-content-background-color: #eee;

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Change log
 Pending
 -------
 
+* Fix overriding font-family for both light and dark themes.
+
 4.4.2 (2024-05-27)
 ------------------
 


### PR DESCRIPTION
The [docs](https://django-debug-toolbar.readthedocs.io/en/latest/configuration.html#theming-support) mention that the toolbar can be customized by overriding the --djdt-* variables defined in :root, like this:
```css
:root {
    --djdt-font-family-primary: 'Roboto', sans-serif;
}
```

But with the implementation of dark theme support these same variables [are also defined](https://github.com/jazzband/django-debug-toolbar/blob/d4811824f971eb79a72091b26119439915647949/debug_toolbar/static/debug_toolbar/css/toolbar.css#L2-L3) in #djDebug[data-theme="light"] with a higher specificity, so in reality you will need to match the specificity of that rule to override the variables.

This moves the font-family declarations to root so changes to the font-family on :root apply to both light and dark themes.