### PR TITLE
Issue 1682

### DIFF
--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -130,9 +130,23 @@ class TemplatesPanel(Panel):
 
     @property
     def nav_subtitle(self):
+        subtitle_parts = []
         if self.templates:
-            return self.templates[0]["template"].name
-        return ""
+            template_name = self.templates[0]["template"].name or "No template name"
+            subtitle_parts.append(template_name)
+        if self.invalid_file_form_configs_count:
+            # Add warning for user indicating file form configuration issue
+            issue_text = (
+                "issue" if self.invalid_file_form_configs_count == 1 else "issues"
+            )
+            subtitle_parts.append(
+                f"{self.invalid_file_form_configs_count} file form configuration "
+                f"{issue_text} found"
+            )
+        if len(subtitle_parts) > 1:
+            return " - ".join(subtitle_parts)
+        else:
+            return subtitle_parts[0] if subtitle_parts else ""
 
     template = "debug_toolbar/panels/templates.html"
 
@@ -260,6 +274,7 @@ class TemplatesPanel(Panel):
         invalid_file_form_configs = self.check_invalid_file_form_configuration(
             html_content
         )
+        self.invalid_file_form_configs_count = len(invalid_file_form_configs)
 
         self.record_stats(
             {

--- a/debug_toolbar/templates/debug_toolbar/panels/templates.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/templates.html
@@ -46,3 +46,12 @@
 {% else %}
   <p>{% trans "None" %}</p>
 {% endif %}
+
+{% if invalid_file_form_configs %}
+  <h4>{% blocktrans count invalid_file_form_configs|length as invalid_file_form_configs_count %}Invalid file form configuration{% plural %}Invalid file form configurations{% endblocktrans %}</h4>
+  <dl>
+    {% for invalid_file_form_config in invalid_file_form_configs %}
+      <dt>{{ invalid_file_form_config | escape }}</dt>
+    {% endfor %}
+  </dl>
+{% endif %}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,7 @@ Change log
 Pending
 -------
 
+* Added warning when form is using file fields without proper enctype.
 * Fixed overriding font-family for both light and dark themes.
 * Restored compatibility with ``iptools.IpRangeList``.
 

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -81,6 +81,7 @@ class TemplatesPanelTestCase(BaseTestCase):
             'but missing enctype="multipart/form-data".'
         )
         self.assertEqual(result[0]["error_message"], expected_error)
+        self.assertEqual(len(result), 1)
 
     def test_file_form_with_enctype_multipart_form_data(self):
         test_form = """<form id="test-form" enctype="multipart/form-data">
@@ -89,6 +90,21 @@ class TemplatesPanelTestCase(BaseTestCase):
         result = self.panel.check_invalid_file_form_configuration(test_form)
 
         self.assertEqual(len(result), 0)
+
+    def test_file_form_configuration_warning_display(self):
+        """
+        Test that the panel (does not) display[s] a warning when there are (no)
+        forms with file input types but encoding not set to multipart/form-data.
+        """
+        # Should not show issue in subtitle when no invalid configurations
+        self.panel.invalid_file_form_configs_count = 0
+        nav_subtitle = self.panel.nav_subtitle
+        self.assertNotIn("file form configuration issue", nav_subtitle)
+
+        # Should show issue in subtitle when invalid configurations
+        self.panel.invalid_file_form_configs_count = 2
+        nav_subtitle = self.panel.nav_subtitle
+        self.assertIn("2 file form configuration issues found", nav_subtitle)
 
     def test_insert_content(self):
         """

--- a/tests/panels/test_template.py
+++ b/tests/panels/test_template.py
@@ -68,6 +68,28 @@ class TemplatesPanelTestCase(BaseTestCase):
         self.panel.generate_stats(self.request, response)
         self.assertIn("nôt åscíì", self.panel.content)
 
+    def test_file_form_without_enctype_multipart_form_data(self):
+        """
+        Test that the panel displays a form invalid message when there is
+        a file input but encoding not set to multipart/form-data.
+        """
+        test_form = '<form id="test-form"><input type="file"></form>'
+        result = self.panel.check_invalid_file_form_configuration(test_form)
+
+        expected_error = (
+            'Form with id "test-form" contains file input '
+            'but missing enctype="multipart/form-data".'
+        )
+        self.assertEqual(result[0]["error_message"], expected_error)
+
+    def test_file_form_with_enctype_multipart_form_data(self):
+        test_form = """<form id="test-form" enctype="multipart/form-data">
+        <input type="file">
+        </form>"""
+        result = self.panel.check_invalid_file_form_configuration(test_form)
+
+        self.assertEqual(len(result), 0)
+
     def test_insert_content(self):
         """
         Test that the panel only inserts content after generate_stats and


### PR DESCRIPTION
# Description

Added functionality where the toolbar inspects the loaded HTML content for a form that includes a file input but does not have the encoding type set to `multipart/form-data`, and warns the user if so.

Subclassed Python's HTML parser and added a function called `check_invalid_file_form_configuration` in `panels/templates/panel.py`. The function checks all forms for a file input type and, if it exists, checks if the form has encoding type multipart/form-data. If it does not, the error message is shown in the Templates panel by passing it to `record_stats`. It also amends the `nav_subtitle` property of the panel to notify the user that there is an issue with their template. Added three tests and checked that the test suite passes for all compatible versions of Django and Python through Tox.

Fixes #1682

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
