### PR TITLE
Fixed #1682 -- alert user when using file field without proper encoding

### DIFF
--- a/debug_toolbar/panels/alerts.py
+++ b/debug_toolbar/panels/alerts.py
@@ -1,0 +1,95 @@
+from html.parser import HTMLParser
+
+from django.utils.translation import gettext_lazy as _
+
+from debug_toolbar.panels import Panel
+
+
+class FormParser(HTMLParser):
+    """
+    HTML form parser, used to check for invalid configurations of forms that
+    take file inputs.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.in_form = False
+        self.current_form = {}
+        self.forms = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == "form":
+            self.in_form = True
+            self.current_form = {
+                "file_form": False,
+                "form_attrs": attrs,
+                "submit_element_attrs": [],
+            }
+        elif self.in_form and tag == "input" and attrs.get("type") == "file":
+            self.current_form["file_form"] = True
+        elif self.in_form and (
+            (tag == "input" and attrs.get("type") in {"submit", "image"})
+            or tag == "button"
+        ):
+            self.current_form["submit_element_attrs"].append(attrs)
+
+    def handle_endtag(self, tag):
+        if tag == "form" and self.in_form:
+            self.forms.append(self.current_form)
+            self.in_form = False
+
+
+class AlertsPanel(Panel):
+    """
+    A panel to alert users to issues.
+    """
+
+    title = _("Alerts")
+
+    template = "debug_toolbar/panels/alerts.html"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.issues = []
+
+    @property
+    def nav_subtitle(self):
+        if self.issues:
+            issue_text = "issue" if len(self.issues) == 1 else "issues"
+            return f"{len(self.issues)} {issue_text} found"
+        else:
+            return ""
+
+    def add_issue(self, issue):
+        self.issues.append(issue)
+
+    def check_invalid_file_form_configuration(self, html_content):
+        parser = FormParser()
+        parser.feed(html_content)
+
+        for form in parser.forms:
+            if (
+                form["file_form"]
+                and form["form_attrs"].get("enctype") != "multipart/form-data"
+                and not any(
+                    elem.get("formenctype") == "multipart/form-data"
+                    for elem in form["submit_element_attrs"]
+                )
+            ):
+                form_id = form["form_attrs"].get("id", "no form id")
+                issue = (
+                    f'Form with id "{form_id}" contains file input but '
+                    "does not have multipart/form-data encoding."
+                )
+                self.add_issue({"issue": issue})
+        return self.issues
+
+    def generate_stats(self, request, response):
+        html_content = response.content.decode(response.charset)
+        self.check_invalid_file_form_configuration(html_content)
+
+        # Further issue checks can go here
+
+        # Write all issues to record_stats
+        self.record_stats({"issues": self.issues})

--- a/debug_toolbar/panels/alerts.py
+++ b/debug_toolbar/panels/alerts.py
@@ -51,20 +51,26 @@ class AlertsPanel(Panel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.issues = []
+        self.alerts = []
 
     @property
     def nav_subtitle(self):
-        if self.issues:
-            issue_text = "issue" if len(self.issues) == 1 else "issues"
-            return f"{len(self.issues)} {issue_text} found"
+        alerts = self.get_stats()["alerts"]
+        if alerts:
+            alert_text = "alert" if len(alerts) == 1 else "alerts"
+            return f"{len(alerts)} {alert_text}"
         else:
             return ""
 
-    def add_issue(self, issue):
-        self.issues.append(issue)
+    def add_alert(self, alert):
+        self.alerts.append(alert)
 
     def check_invalid_file_form_configuration(self, html_content):
+        """
+        Inspects HTML content for a form that includes a file input but does
+        not have the encoding type set to multipart/form-data, and warns the
+        user if so.
+        """
         parser = FormParser()
         parser.feed(html_content)
 
@@ -78,18 +84,18 @@ class AlertsPanel(Panel):
                 )
             ):
                 form_id = form["form_attrs"].get("id", "no form id")
-                issue = (
+                alert = (
                     f'Form with id "{form_id}" contains file input but '
                     "does not have multipart/form-data encoding."
                 )
-                self.add_issue({"issue": issue})
-        return self.issues
+                self.add_alert({"alert": alert})
+        return self.alerts
 
     def generate_stats(self, request, response):
         html_content = response.content.decode(response.charset)
         self.check_invalid_file_form_configuration(html_content)
 
-        # Further issue checks can go here
+        # Further alert checks can go here
 
-        # Write all issues to record_stats
-        self.record_stats({"issues": self.issues})
+        # Write all alerts to record_stats
+        self.record_stats({"alerts": self.alerts})

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -58,6 +58,7 @@ def get_config():
 
 
 PANELS_DEFAULTS = [
+    "debug_toolbar.panels.alerts.AlertsPanel",
     "debug_toolbar.panels.history.HistoryPanel",
     "debug_toolbar.panels.versions.VersionsPanel",
     "debug_toolbar.panels.timer.TimerPanel",

--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -58,7 +58,6 @@ def get_config():
 
 
 PANELS_DEFAULTS = [
-    "debug_toolbar.panels.alerts.AlertsPanel",
     "debug_toolbar.panels.history.HistoryPanel",
     "debug_toolbar.panels.versions.VersionsPanel",
     "debug_toolbar.panels.timer.TimerPanel",
@@ -68,6 +67,7 @@ PANELS_DEFAULTS = [
     "debug_toolbar.panels.sql.SQLPanel",
     "debug_toolbar.panels.staticfiles.StaticFilesPanel",
     "debug_toolbar.panels.templates.TemplatesPanel",
+    "debug_toolbar.panels.alerts.AlertsPanel",
     "debug_toolbar.panels.cache.CachePanel",
     "debug_toolbar.panels.signals.SignalsPanel",
     "debug_toolbar.panels.redirects.RedirectsPanel",

--- a/debug_toolbar/templates/debug_toolbar/panels/alerts.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/alerts.html
@@ -1,12 +1,12 @@
 {% load i18n %}
 
-{% if issues %}
-  <h4>{% trans "Issues found" %}</h4>
-  {% for issue in issues %}
+{% if alerts %}
+  <h4>{% trans "alerts found" %}</h4>
+  {% for alert in alerts %}
     <ul>
-      <li>{{ issue.issue }}</li>
+      <li>{{ alert.alert }}</li>
     </ul>
   {% endfor %}
 {% else %}
-  <p>No issues found.</p>
+  <p>No alerts found.</p>
 {% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/alerts.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/alerts.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+
+{% if issues %}
+  <h4>{% trans "Issues found" %}</h4>
+  {% for issue in issues %}
+    <ul>
+      <li>{{ issue.issue }}</li>
+    </ul>
+  {% endfor %}
+{% else %}
+  <p>No issues found.</p>
+{% endif %}

--- a/debug_toolbar/templates/debug_toolbar/panels/alerts.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/alerts.html
@@ -1,12 +1,12 @@
 {% load i18n %}
 
 {% if alerts %}
-  <h4>{% trans "alerts found" %}</h4>
+  <h4>{% trans "Alerts found" %}</h4>
   {% for alert in alerts %}
     <ul>
       <li>{{ alert.alert }}</li>
     </ul>
   {% endfor %}
 {% else %}
-  <p>No alerts found.</p>
+  <h4>{% trans "No alerts found" %}</h4>
 {% endif %}

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Change log
 Pending
 -------
 
+* Added alert panel with warning when form is using file fields
+  without proper encoding type.
 * Fixed overriding font-family for both light and dark themes.
 * Restored compatibility with ``iptools.IpRangeList``.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,7 +20,6 @@ included in the toolbar. It works like Django's ``MIDDLEWARE`` setting. The
 default value is::
 
     DEBUG_TOOLBAR_PANELS = [
-        'debug_toolbar.panels.alerts.AlertsPanel',
         'debug_toolbar.panels.history.HistoryPanel',
         'debug_toolbar.panels.versions.VersionsPanel',
         'debug_toolbar.panels.timer.TimerPanel',
@@ -30,6 +29,7 @@ default value is::
         'debug_toolbar.panels.sql.SQLPanel',
         'debug_toolbar.panels.staticfiles.StaticFilesPanel',
         'debug_toolbar.panels.templates.TemplatesPanel',
+        'debug_toolbar.panels.alerts.AlertsPanel',
         'debug_toolbar.panels.cache.CachePanel',
         'debug_toolbar.panels.signals.SignalsPanel',
         'debug_toolbar.panels.redirects.RedirectsPanel',

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,6 +20,7 @@ included in the toolbar. It works like Django's ``MIDDLEWARE`` setting. The
 default value is::
 
     DEBUG_TOOLBAR_PANELS = [
+        'debug_toolbar.panels.alerts.AlertsPanel',
         'debug_toolbar.panels.history.HistoryPanel',
         'debug_toolbar.panels.versions.VersionsPanel',
         'debug_toolbar.panels.timer.TimerPanel',

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -18,7 +18,7 @@ This panel shows alerts for a set of pre-defined cases:
 
 - Alerts when the response has a form without the
   ``enctype="multipart/form-data"`` attribute and the form contains
-  a file input
+  a file input.
 
 History
 ~~~~~~~

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -14,9 +14,11 @@ Alerts
 
 .. class:: debug_toolbar.panels.alerts.AlertsPanel
 
-This panel shows alerts for a set of pre-defined issues. Currently, the only
-issue it checks for is the encoding of a form that takes a file input not
-being set to ``multipart/form-data``.
+This panel shows alerts for a set of pre-defined cases:
+
+- Alerts when the response has a form without the
+  ``enctype="multipart/form-data"`` attribute and the form contains
+  a file input
 
 History
 ~~~~~~~

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -9,6 +9,15 @@ Default built-in panels
 
 The following panels are enabled by default.
 
+Alerts
+~~~~~~~
+
+.. class:: debug_toolbar.panels.alerts.AlertsPanel
+
+This panel shows alerts for a set of pre-defined issues. Currently, the only
+issue it checks for is the encoding of a form that takes a file input not
+being set to ``multipart/form-data``.
+
 History
 ~~~~~~~
 

--- a/example/templates/bad_form.html
+++ b/example/templates/bad_form.html
@@ -1,0 +1,14 @@
+{% load cache %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Bad form</title>
+  </head>
+  <body>
+    <h1>Bad form test</h1>
+    <form>
+      <input type="file" name="file" />
+    </form>
+  </body>
+</html>

--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -14,6 +14,7 @@
         <li><a href="/prototype/">Prototype 1.7.3.0</a></li>
         <li><a href="{% url 'turbo' %}">Hotwire Turbo</a></li>
         <li><a href="{% url 'htmx' %}">htmx</a></li>
+        <li><a href="{% url 'bad_form' %}">Bad form</a></li>
       </ul>
       <p><a href="/admin/">Django Admin</a></p>
     {% endcache %}

--- a/example/urls.py
+++ b/example/urls.py
@@ -7,6 +7,11 @@ from example.views import increment
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="index.html"), name="home"),
+    path(
+        "bad-form/",
+        TemplateView.as_view(template_name="bad_form.html"),
+        name="bad_form",
+    ),
     path("jquery/", TemplateView.as_view(template_name="jquery/index.html")),
     path("mootools/", TemplateView.as_view(template_name="mootools/index.html")),
     path("prototype/", TemplateView.as_view(template_name="prototype/index.html")),

--- a/tests/panels/test_alerts.py
+++ b/tests/panels/test_alerts.py
@@ -40,6 +40,35 @@ class AlertsPanelTestCase(BaseTestCase):
 
         self.assertEqual(len(result), 0)
 
+    def test_file_form_with_enctype_multipart_form_data_in_button(self):
+        test_form = """<form id="test-form">
+        <input type="file">
+        <input type="submit" formenctype="multipart/form-data">
+        </form>"""
+        result = self.panel.check_invalid_file_form_configuration(test_form)
+
+        self.assertEqual(len(result), 0)
+
+    def test_referenced_file_input_without_enctype_multipart_form_data(self):
+        test_file_input = """<form id="test-form"></form>
+        <input type="file" form = "test-form">"""
+        result = self.panel.check_invalid_file_form_configuration(test_file_input)
+
+        expected_error = (
+            'Input element references form with id "test-form" '
+            "but the form does not have multipart/form-data encoding."
+        )
+        self.assertEqual(result[0]["alert"], expected_error)
+        self.assertEqual(len(result), 1)
+
+    def test_referenced_file_input_with_enctype_multipart_form_data(self):
+        test_file_input = """<form id="test-form" enctype="multipart/form-data">
+        </form>
+        <input type="file" form = "test-form">"""
+        result = self.panel.check_invalid_file_form_configuration(test_file_input)
+
+        self.assertEqual(len(result), 0)
+
     def test_integration_file_form_without_enctype_multipart_form_data(self):
         t = Template('<form id="test-form"><input type="file"></form>')
         c = Context({})

--- a/tests/panels/test_alerts.py
+++ b/tests/panels/test_alerts.py
@@ -26,8 +26,24 @@ class AlertsPanelTestCase(BaseTestCase):
         test_form = '<form id="test-form"><input type="file"></form>'
         result = self.panel.check_invalid_file_form_configuration(test_form)
         expected_error = (
-            'Form with id "test-form" contains file input '
-            "but does not have multipart/form-data encoding."
+            'Form with id "test-form" contains file input, '
+            'but does not have the attribute enctype="multipart/form-data".'
+        )
+        self.assertEqual(result[0]["alert"], expected_error)
+        self.assertEqual(len(result), 1)
+
+    def test_file_form_no_id_without_enctype_multipart_form_data(self):
+        """
+        Test that the panel displays a form invalid message when there is
+        a file input but encoding not set to multipart/form-data.
+
+        This should use the message when the form has no id.
+        """
+        test_form = '<form><input type="file"></form>'
+        result = self.panel.check_invalid_file_form_configuration(test_form)
+        expected_error = (
+            "Form contains file input, but does not have "
+            'the attribute enctype="multipart/form-data".'
         )
         self.assertEqual(result[0]["alert"], expected_error)
         self.assertEqual(len(result), 1)
@@ -55,8 +71,8 @@ class AlertsPanelTestCase(BaseTestCase):
         result = self.panel.check_invalid_file_form_configuration(test_file_input)
 
         expected_error = (
-            'Input element references form with id "test-form" '
-            "but the form does not have multipart/form-data encoding."
+            'Input element references form with id "test-form", '
+            'but the form does not have the attribute enctype="multipart/form-data".'
         )
         self.assertEqual(result[0]["alert"], expected_error)
         self.assertEqual(len(result), 1)
@@ -79,7 +95,7 @@ class AlertsPanelTestCase(BaseTestCase):
 
         self.assertIn("1 alert", self.panel.nav_subtitle)
         self.assertIn(
-            "Form with id &quot;test-form&quot; contains file input "
-            "but does not have multipart/form-data encoding.",
+            "Form with id &quot;test-form&quot; contains file input, "
+            "but does not have the attribute enctype=&quot;multipart/form-data&quot;.",
             self.panel.content,
         )

--- a/tests/panels/test_alerts.py
+++ b/tests/panels/test_alerts.py
@@ -1,0 +1,57 @@
+from django.http import HttpResponse
+from django.template import Context, Template
+
+from ..base import BaseTestCase
+
+
+class AlertsPanelTestCase(BaseTestCase):
+    panel_id = "AlertsPanel"
+
+    def test_issue_warning_display(self):
+        """
+        Test that the panel (does not) display[s] a warning when there are
+        (no) issues.
+        """
+        self.panel.issues = 0
+        nav_subtitle = self.panel.nav_subtitle
+        self.assertNotIn("issues found", nav_subtitle)
+
+        self.panel.issues = ["Issue 1", "Issue 2"]
+        nav_subtitle = self.panel.nav_subtitle
+        self.assertIn("2 issues found", nav_subtitle)
+
+    def test_file_form_without_enctype_multipart_form_data(self):
+        """
+        Test that the panel displays a form invalid message when there is
+        a file input but encoding not set to multipart/form-data.
+        """
+        test_form = '<form id="test-form"><input type="file"></form>'
+        result = self.panel.check_invalid_file_form_configuration(test_form)
+        expected_error = (
+            'Form with id "test-form" contains file input '
+            "but does not have multipart/form-data encoding."
+        )
+        self.assertEqual(result[0]["issue"], expected_error)
+        self.assertEqual(len(result), 1)
+
+    def test_file_form_with_enctype_multipart_form_data(self):
+        test_form = """<form id="test-form" enctype="multipart/form-data">
+        <input type="file">
+        </form>"""
+        result = self.panel.check_invalid_file_form_configuration(test_form)
+
+        self.assertEqual(len(result), 0)
+
+    def test_integration_file_form_without_enctype_multipart_form_data(self):
+        t = Template('<form id="test-form"><input type="file"></form>')
+        c = Context({})
+        rendered_template = t.render(c)
+        response = HttpResponse(content=rendered_template)
+
+        self.panel.generate_stats(self.request, response)
+
+        self.assertIn(
+            "Form with id &quot;test-form&quot; contains file input "
+            "but does not have multipart/form-data encoding.",
+            self.panel.content,
+        )

--- a/tests/panels/test_alerts.py
+++ b/tests/panels/test_alerts.py
@@ -7,18 +7,16 @@ from ..base import BaseTestCase
 class AlertsPanelTestCase(BaseTestCase):
     panel_id = "AlertsPanel"
 
-    def test_issue_warning_display(self):
+    def test_alert_warning_display(self):
         """
-        Test that the panel (does not) display[s] a warning when there are
-        (no) issues.
+        Test that the panel (does not) display[s] an alert when there are
+        (no) problems.
         """
-        self.panel.issues = 0
-        nav_subtitle = self.panel.nav_subtitle
-        self.assertNotIn("issues found", nav_subtitle)
+        self.panel.record_stats({"alerts": []})
+        self.assertNotIn("alerts", self.panel.nav_subtitle)
 
-        self.panel.issues = ["Issue 1", "Issue 2"]
-        nav_subtitle = self.panel.nav_subtitle
-        self.assertIn("2 issues found", nav_subtitle)
+        self.panel.record_stats({"alerts": ["Alert 1", "Alert 2"]})
+        self.assertIn("2 alerts", self.panel.nav_subtitle)
 
     def test_file_form_without_enctype_multipart_form_data(self):
         """
@@ -31,7 +29,7 @@ class AlertsPanelTestCase(BaseTestCase):
             'Form with id "test-form" contains file input '
             "but does not have multipart/form-data encoding."
         )
-        self.assertEqual(result[0]["issue"], expected_error)
+        self.assertEqual(result[0]["alert"], expected_error)
         self.assertEqual(len(result), 1)
 
     def test_file_form_with_enctype_multipart_form_data(self):
@@ -50,6 +48,7 @@ class AlertsPanelTestCase(BaseTestCase):
 
         self.panel.generate_stats(self.request, response)
 
+        self.assertIn("1 alert", self.panel.nav_subtitle)
         self.assertIn(
             "Form with id &quot;test-form&quot; contains file input "
             "but does not have multipart/form-data encoding.",

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -67,7 +67,6 @@ class HistoryPanelTestCase(BaseTestCase):
 @override_settings(DEBUG=True)
 class HistoryViewsTestCase(IntegrationTestCase):
     PANEL_KEYS = {
-        "AlertsPanel",
         "VersionsPanel",
         "TimerPanel",
         "SettingsPanel",
@@ -76,6 +75,7 @@ class HistoryViewsTestCase(IntegrationTestCase):
         "SQLPanel",
         "StaticFilesPanel",
         "TemplatesPanel",
+        "AlertsPanel",
         "CachePanel",
         "SignalsPanel",
         "ProfilingPanel",

--- a/tests/panels/test_history.py
+++ b/tests/panels/test_history.py
@@ -67,6 +67,7 @@ class HistoryPanelTestCase(BaseTestCase):
 @override_settings(DEBUG=True)
 class HistoryViewsTestCase(IntegrationTestCase):
     PANEL_KEYS = {
+        "AlertsPanel",
         "VersionsPanel",
         "TimerPanel",
         "SettingsPanel",


### PR DESCRIPTION
# Description

Added functionality where the toolbar inspects the loaded HTML content for a form that includes a file input but does not have the encoding type set to `multipart/form-data`, and warns the user if so. This is implemented in a separate alerts panel, as discussed. The alerts panel is placed at the top of the toolbar, to ensure that it receives appropriate attention when issues arise. My one concern with this implementation is that panel may cause people to expect that the toolbar checks for a wide range of issues, whereas it currently just checks for a single one.

What I did specifically is subclass Python's HTML parser and added a function called `check_invalid_file_form_configuration` in `panels/templates/panel.py`. The function checks all forms for a file input type and, if it exists, checks if the form has encoding type multipart/form-data. If it does not, the error message is shown in the alerts panel by passing it to `record_stats`. It also amends the `nav_subtitle` property of the panel to notify the user that there is an issue. Added four tests and checked that the test suite passes for all compatible versions of Django and Python through Tox.

Fixes #1682

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
