### PR TITLE
Check for for StreamingHttpResponse when generating stats in Alert

### DIFF
--- a/debug_toolbar/panels/alerts.py
+++ b/debug_toolbar/panels/alerts.py
@@ -139,6 +139,11 @@ class AlertsPanel(Panel):
         return self.alerts
 
     def generate_stats(self, request, response):
+
+        # check if streaming response
+        if getattr(response, "streaming", True):
+            return
+
         html_content = response.content.decode(response.charset)
         self.check_invalid_file_form_configuration(html_content)
 

--- a/debug_toolbar/panels/alerts.py
+++ b/debug_toolbar/panels/alerts.py
@@ -139,7 +139,6 @@ class AlertsPanel(Panel):
         return self.alerts
 
     def generate_stats(self, request, response):
-
         # check if streaming response
         if getattr(response, "streaming", True):
             return

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,11 @@ Change log
 Pending
 -------
 
+4.4.3 (2024-07-05)
+------------------
+
+* Added check for StreamingHttpResponse in Alert Panel
+
 4.4.3 (2024-07-04)
 ------------------
 

--- a/tests/panels/test_alerts.py
+++ b/tests/panels/test_alerts.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, StreamingHttpResponse
 from django.template import Context, Template
 
 from ..base import BaseTestCase
@@ -99,3 +99,14 @@ class AlertsPanelTestCase(BaseTestCase):
             "but does not have the attribute enctype=&quot;multipart/form-data&quot;.",
             self.panel.content,
         )
+
+    def test_streaming_response(self):
+        """Test to check for a streaming response."""
+
+        def _render():
+            yield "ok"
+
+        response = StreamingHttpResponse(_render())
+
+        self.panel.generate_stats(self.request, response)
+        self.assertEqual(self.panel.get_stats(), {})


### PR DESCRIPTION
# Description

Adds check for `StreamingHttpResponse`  when generating stats for Alert Pane.

Fixes #1945

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
