### PR TITLE
Fixed order and grammatical number of panels in documentation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Change log
 Pending
 -------
 
+* Changed ordering (and grammatical number) of panels and their titles in
+  documentation to match actual panel ordering and titles.
+
 4.4.5 (2024-07-05)
 ------------------
 

--- a/docs/panels.rst
+++ b/docs/panels.rst
@@ -9,17 +9,6 @@ Default built-in panels
 
 The following panels are enabled by default.
 
-Alerts
-~~~~~~~
-
-.. class:: debug_toolbar.panels.alerts.AlertsPanel
-
-This panel shows alerts for a set of pre-defined cases:
-
-- Alerts when the response has a form without the
-  ``enctype="multipart/form-data"`` attribute and the form contains
-  a file input.
-
 History
 ~~~~~~~
 
@@ -33,8 +22,8 @@ snapshot of the toolbar to view that request's stats.
    ``True`` or if the server runs with multiple processes, the History Panel
    will be disabled.
 
-Version
-~~~~~~~
+Versions
+~~~~~~~~
 
 .. class:: debug_toolbar.panels.versions.VersionsPanel
 
@@ -80,19 +69,30 @@ SQL
 
 SQL queries including time to execute and links to EXPLAIN each query.
 
-Template
-~~~~~~~~
-
-.. class:: debug_toolbar.panels.templates.TemplatesPanel
-
-Templates and context used, and their template paths.
-
 Static files
 ~~~~~~~~~~~~
 
 .. class:: debug_toolbar.panels.staticfiles.StaticFilesPanel
 
 Used static files and their locations (via the ``staticfiles`` finders).
+
+Templates
+~~~~~~~~~
+
+.. class:: debug_toolbar.panels.templates.TemplatesPanel
+
+Templates and context used, and their template paths.
+
+Alerts
+~~~~~~~
+
+.. class:: debug_toolbar.panels.alerts.AlertsPanel
+
+This panel shows alerts for a set of pre-defined cases:
+
+- Alerts when the response has a form without the
+  ``enctype="multipart/form-data"`` attribute and the form contains
+  a file input.
 
 Cache
 ~~~~~
@@ -101,8 +101,8 @@ Cache
 
 Cache queries. Is incompatible with Django's per-site caching.
 
-Signal
-~~~~~~
+Signals
+~~~~~~~
 
 .. class:: debug_toolbar.panels.signals.SignalsPanel
 


### PR DESCRIPTION
# Description

The order of the panels in the panels documentation was not entirely consistent with the ordering of the panels themselves. Specifically, `Alerts`, `StaticFiles`, and `Templates` were out of order. Additionally, some panel titles in the panels documentation did not match the grammatical number of the panel (e.g., the title of `SignalsPanel` was Signal).

This pull request fixes these inconsistenties.

# Checklist:

~~- [ ] I have added the relevant tests for this change.~~ No relevant tests.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
