### PR TITLE
Make toolbar compatible with `FORCE_SCRIPT_NAME`

### DIFF
--- a/debug_toolbar/panels/request.py
+++ b/debug_toolbar/panels/request.py
@@ -41,7 +41,7 @@ class RequestPanel(Panel):
             "view_urlname": "None",
         }
         try:
-            match = resolve(request.path)
+            match = resolve(request.path_info)
             func, args, kwargs = match
             view_info["view_func"] = get_name_from_obj(func)
             view_info["view_args"] = args

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.dispatch import Signal
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
-from django.urls import get_script_prefix, include, path, re_path, resolve
+from django.urls import include, path, re_path, resolve
 from django.urls.exceptions import Resolver404
 from django.utils.module_loading import import_string
 from django.utils.translation import get_language, override as lang_override
@@ -165,8 +165,7 @@ class DebugToolbar:
         # not have resolver_match set.
         try:
             resolver_match = request.resolver_match or resolve(
-                request.path.replace(get_script_prefix(), "/", 1),
-                getattr(request, "urlconf", None),
+                request.path_info, getattr(request, "urlconf", None)
             )
         except Resolver404:
             return False

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.dispatch import Signal
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
-from django.urls import include, path, re_path, resolve
+from django.urls import get_script_prefix, include, path, re_path, resolve
 from django.urls.exceptions import Resolver404
 from django.utils.module_loading import import_string
 from django.utils.translation import get_language, override as lang_override
@@ -165,7 +165,8 @@ class DebugToolbar:
         # not have resolver_match set.
         try:
             resolver_match = request.resolver_match or resolve(
-                request.path, getattr(request, "urlconf", None)
+                request.path.replace(get_script_prefix(), "/", 1),
+                getattr(request, "urlconf", None),
             )
         except Resolver404:
             return False

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,9 @@ Change log
 Pending
 -------
 
+* Fixed internal toolbar requests being instrumented if the Django setting
+  ``FORCE_SCRIPT_NAME`` was set.
+
 4.4.6 (2024-07-10)
 ------------------
 

--- a/tests/panels/test_request.py
+++ b/tests/panels/test_request.py
@@ -1,6 +1,9 @@
 from django.http import QueryDict
+from django.test import RequestFactory
 
 from ..base import BaseTestCase
+
+rf = RequestFactory()
 
 
 class RequestPanelTestCase(BaseTestCase):
@@ -13,9 +16,9 @@ class RequestPanelTestCase(BaseTestCase):
         self.assertIn("où", self.panel.content)
 
     def test_object_with_non_ascii_repr_in_request_params(self):
-        self.request.path = "/non_ascii_request/"
-        response = self.panel.process_request(self.request)
-        self.panel.generate_stats(self.request, response)
+        request = rf.get("/non_ascii_request/")
+        response = self.panel.process_request(request)
+        self.panel.generate_stats(request, response)
         self.assertIn("nôt åscíì", self.panel.content)
 
     def test_insert_content(self):
@@ -23,11 +26,11 @@ class RequestPanelTestCase(BaseTestCase):
         Test that the panel only inserts content after generate_stats and
         not the process_request.
         """
-        self.request.path = "/non_ascii_request/"
-        response = self.panel.process_request(self.request)
+        request = rf.get("/non_ascii_request/")
+        response = self.panel.process_request(request)
         # ensure the panel does not have content yet.
         self.assertNotIn("nôt åscíì", self.panel.content)
-        self.panel.generate_stats(self.request, response)
+        self.panel.generate_stats(request, response)
         # ensure the panel renders correctly.
         content = self.panel.content
         self.assertIn("nôt åscíì", content)
@@ -99,9 +102,9 @@ class RequestPanelTestCase(BaseTestCase):
         self.assertIn("[{&#x27;a&#x27;: 1}, {&#x27;b&#x27;: 2}]", content)
 
     def test_namespaced_url(self):
-        self.request.path = "/admin/login/"
-        response = self.panel.process_request(self.request)
-        self.panel.generate_stats(self.request, response)
+        request = rf.get("/admin/login/")
+        response = self.panel.process_request(request)
+        self.panel.generate_stats(request, response)
         panel_stats = self.panel.get_stats()
         self.assertEqual(panel_stats["view_urlname"], "admin:login")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -244,6 +244,23 @@ class DebugToolbarTestCase(BaseTestCase):
         self.request.path = "/__debug__/render_panel/"
         self.assertTrue(self.toolbar.is_toolbar_request(self.request))
 
+    @patch("debug_toolbar.toolbar.get_script_prefix", return_value="/path/")
+    def test_is_toolbar_request_with_script_prefix(self, mocked_get_script_prefix):
+        """
+        Test cases when Django is running under a path prefix, such as via the
+        FORCE_SCRIPT_NAME setting.
+        """
+        self.request.path = "/path/__debug__/render_panel/"
+        self.assertTrue(self.toolbar.is_toolbar_request(self.request))
+
+        self.request.path = "/path/invalid/__debug__/render_panel/"
+        self.assertFalse(self.toolbar.is_toolbar_request(self.request))
+
+        self.request.path = "/path/render_panel/"
+        self.assertFalse(self.toolbar.is_toolbar_request(self.request))
+
+        self.assertEqual(mocked_get_script_prefix.call_count, 3)
+
     def test_data_gone(self):
         response = self.client.get(
             "/__debug__/render_panel/?store_id=GONE&panel_id=RequestPanel"


### PR DESCRIPTION
# Description

Previously, if a project used the [`FORCE_SCRIPT_NAME`](https://docs.djangoproject.com/en/5.0/ref/settings/#force-script-name) setting (such as when [hosting a Django application under a subdirectory path via a reverse proxy](https://stackoverflow.com/a/28407366/1508246)), `is_toolbar_request()` would always return False.

This is because `request.resolver_match` is not yet available in the middleware context, so `django.urls.resolve()` is [called instead](https://github.com/jazzband/django-debug-toolbar/blob/f2e389cdbef0a214f51f3c49a35b32e4295dd9c9/debug_toolbar/toolbar.py#L167-L169). `resolve()` then raised `Resolver404`, because it [does not take `FORCE_SCRIPT_NAME` into account](https://code.djangoproject.com/ticket/31724).

This caused internal toolbar URLs to be inspected, leading to a request loop when refreshing the history panel.

This PR makes calls to `django.urls.resolve()` take [`request.path_info`](https://docs.djangoproject.com/en/5.0/ref/request-response/#django.http.HttpRequest.path_info) rather than `request.path`. This effectively strips the request's leading `SCRIPT_NAME` if one is present.

Fixes #1961 

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
