### PR TITLE
Override `DEBUG=True` in async middleware compatibility tests

### DIFF
--- a/tests/test_middleware_compatibility.py
+++ b/tests/test_middleware_compatibility.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from django.http import HttpResponse
-from django.test import AsyncRequestFactory, RequestFactory, TestCase
+from django.test import AsyncRequestFactory, RequestFactory, TestCase, override_settings
 
 from debug_toolbar.middleware import DebugToolbarMiddleware
 
@@ -11,6 +11,7 @@ class MiddlewareSyncAsyncCompatibilityTestCase(TestCase):
         self.factory = RequestFactory()
         self.async_factory = AsyncRequestFactory()
 
+    @override_settings(DEBUG=True)
     def test_sync_mode(self):
         """
         test middlware switches to sync (__call__) based on get_response type
@@ -26,6 +27,7 @@ class MiddlewareSyncAsyncCompatibilityTestCase(TestCase):
         response = middleware(request)
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(DEBUG=True)
     async def test_async_mode(self):
         """
         test middlware switches to async (__acall__) based on get_response type


### PR DESCRIPTION
# Description

Toggle `DEBUG=True` with `override_settings` in `test_middleware_compatibility` in order to let `DebugToolbarMiddleware` make a complete run through panels.
 

Fixes https://github.com/jazzband/django-debug-toolbar/pull/1938

# Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
