### PR TITLE
Add a paragraph describing our stance on Python typing

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -112,10 +112,10 @@ For MySQL/MariaDB in a ``mysql`` shell::
 Style
 -----
 
-The Django Debug Toolbar uses `black <https://github.com/psf/black>`__ to
-format code and additionally uses ruff. The toolbar uses
-`pre-commit <https://pre-commit.com>`__ to automatically apply our style
-guidelines when a commit is made. Set up pre-commit before committing with::
+The Django Debug Toolbar uses `ruff <https://github.com/astral-sh/ruff/>`__ to
+format and lint Python code. The toolbar uses `pre-commit
+<https://pre-commit.com>`__ to automatically apply our style guidelines when a
+commit is made. Set up pre-commit before committing with::
 
     $ pre-commit install
 
@@ -128,6 +128,18 @@ Note that it runs on CI.
 To reformat the code manually use::
 
     $ pre-commit run --all-files
+
+
+Typing
+------
+
+The Debug Toolbar has been accepting patches which add type hints to the code
+base, as long as the types themselves do not cause any problems or obfuscate
+the intent.
+
+The maintainers are not committed to adding type hints and are not requiring
+new code to have type hints at this time. This may change in the future.
+
 
 Patches
 -------


### PR DESCRIPTION
I think we should an official paragraph to the contributing docs regarding our stance on typing. I tried describing what we're doing currently since I think it makes sense, but I'm definitely open to changing this. I don't think we should open a big round of discussions on this though.