### PR TITLE
Slightly increase opacity of debug toolbar button

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -301,7 +301,7 @@
     font-size: 22px;
     font-weight: bold;
     background: #000;
-    opacity: 0.5;
+    opacity: 0.6;
 }
 
 #djDebug #djShowToolBarButton:hover {

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,10 +3,11 @@ Change log
 
 Pending
 -------
-* Support select and explain buttons for ``UNION`` queries on PostgreSQL.
 
+* Support select and explain buttons for ``UNION`` queries on PostgreSQL.
 * Fixed internal toolbar requests being instrumented if the Django setting
   ``FORCE_SCRIPT_NAME`` was set.
+* Increase opacity of show Debug Toolbar handle to improve accessibility.
 
 4.4.6 (2024-07-10)
 ------------------


### PR DESCRIPTION
# Description

Avoids an accessibility issue (low-contrast text) when the page behind the button is white.

Fixes #1981

# Checklist:

Too minor a change for tests or changelog.