### PR TITLE
Dark mode text needs higher contrast

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -61,6 +61,7 @@
     --djdt-font-color: #8393a7;
     --djdt-background-color: #1e293bff;
     --djdt-panel-content-background-color: #0f1729ff;
+    --djdt-panel-content-table-background-color: var(--djdt-background-color);
     --djdt-panel-title-background-color: #242432;
     --djdt-djdt-panel-content-table-strip-background-color: #324154ff;
     --djdt--highlighted-background-color: #2c2a7dff;

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Pending
   ``FORCE_SCRIPT_NAME`` was set.
 * Increase opacity of show Debug Toolbar handle to improve accessibility.
 * Changed the ``RedirectsPanel`` to be async compatible.
+* Fixed the Dark mode text needs higher contrast.
 
 4.4.6 (2024-07-10)
 ------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,7 +9,7 @@ Pending
   ``FORCE_SCRIPT_NAME`` was set.
 * Increase opacity of show Debug Toolbar handle to improve accessibility.
 * Changed the ``RedirectsPanel`` to be async compatible.
-* Fixed the Dark mode text needs higher contrast.
+* Increased the contrast of text with dark mode enabled.
 
 4.4.6 (2024-07-10)
 ------------------


### PR DESCRIPTION
# Description

This PR addresses issue #1943 by improving the table contrast when the OS mode is set to Light, and the App mode is set to Dark.

Changes Made:
  Modified a single line in toolbar.css. This was necessary to address a missing definition when compared with the Light mode settings.
I've attached screenshots for verification of the fix.

OS mode: Light
App mode: Dark
![image](https://github.com/user-attachments/assets/57cdbdb8-7f77-4dfd-bcba-072f2ee8ee8f)

OS mode: Light
App mode: Light
![image](https://github.com/user-attachments/assets/208c2d05-bb7f-4334-9ce6-23e624705217)

OS mode: Light
App mode: Default
![image](https://github.com/user-attachments/assets/410736f4-5eb2-49a4-9e31-2d0cc5230350)

OS mode: Dark
App mode: Dark
![image](https://github.com/user-attachments/assets/e6c52887-9b22-43ad-8575-2b5ae855fd7a)

OS mode: Dark
App mode: Light
![image](https://github.com/user-attachments/assets/5d820afb-91c8-473f-8806-677b84b1cb7a)

OS mode: Dark
App mode: Default
![image](https://github.com/user-attachments/assets/f7201c33-07f2-4d9e-a877-b12aac90a567)

Fixes #1943

# Checklist:

- [*] I have added the relevant tests for this change.
   - Too minor a change for tests or changelog.
- [*] I have added an item to the Pending section of ``docs/changes.rst``.
