### PR TITLE
Make Panels non async  by default

### DIFF
--- a/debug_toolbar/panels/__init__.py
+++ b/debug_toolbar/panels/__init__.py
@@ -10,7 +10,7 @@ class Panel:
     Base class for panels.
     """
 
-    is_async = True
+    is_async = False
 
     def __init__(self, toolbar, get_response):
         self.toolbar = toolbar

--- a/debug_toolbar/panels/alerts.py
+++ b/debug_toolbar/panels/alerts.py
@@ -76,6 +76,8 @@ class AlertsPanel(Panel):
 
     title = _("Alerts")
 
+    is_async = True
+
     template = "debug_toolbar/panels/alerts.html"
 
     def __init__(self, *args, **kwargs):

--- a/debug_toolbar/panels/cache.py
+++ b/debug_toolbar/panels/cache.py
@@ -58,6 +58,8 @@ class CachePanel(Panel):
 
     template = "debug_toolbar/panels/cache.html"
 
+    is_async = True
+
     _context_locals = Local()
 
     def __init__(self, *args, **kwargs):

--- a/debug_toolbar/panels/headers.py
+++ b/debug_toolbar/panels/headers.py
@@ -30,6 +30,8 @@ class HeadersPanel(Panel):
 
     title = _("Headers")
 
+    is_async = True
+
     template = "debug_toolbar/panels/headers.html"
 
     def process_request(self, request):

--- a/debug_toolbar/panels/redirects.py
+++ b/debug_toolbar/panels/redirects.py
@@ -11,8 +11,9 @@ class RedirectsPanel(Panel):
     Panel that intercepts redirects and displays a page with debug info.
     """
 
-    is_async = True
     has_content = False
+
+    is_async = True
 
     nav_title = _("Intercept redirects")
 

--- a/debug_toolbar/panels/request.py
+++ b/debug_toolbar/panels/request.py
@@ -15,8 +15,6 @@ class RequestPanel(Panel):
 
     title = _("Request")
 
-    is_async = False
-
     @property
     def nav_subtitle(self):
         """

--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -14,6 +14,8 @@ class SettingsPanel(Panel):
 
     template = "debug_toolbar/panels/settings.html"
 
+    is_async = True
+
     nav_title = _("Settings")
 
     def title(self):

--- a/debug_toolbar/panels/signals.py
+++ b/debug_toolbar/panels/signals.py
@@ -28,6 +28,8 @@ from debug_toolbar.panels import Panel
 class SignalsPanel(Panel):
     template = "debug_toolbar/panels/signals.html"
 
+    is_async = True
+
     SIGNALS = {
         "request_started": request_started,
         "request_finished": request_finished,

--- a/debug_toolbar/panels/staticfiles.py
+++ b/debug_toolbar/panels/staticfiles.py
@@ -73,7 +73,6 @@ class StaticFilesPanel(panels.Panel):
     A panel to display the found staticfiles.
     """
 
-    is_async = False
     name = "Static files"
     template = "debug_toolbar/panels/staticfiles.html"
 

--- a/debug_toolbar/panels/templates/panel.py
+++ b/debug_toolbar/panels/templates/panel.py
@@ -68,6 +68,8 @@ class TemplatesPanel(Panel):
     A panel that lists all templates used during processing of a response.
     """
 
+    is_async = True
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.templates = []

--- a/debug_toolbar/panels/timer.py
+++ b/debug_toolbar/panels/timer.py
@@ -17,8 +17,6 @@ class TimerPanel(Panel):
     Panel that displays the time a response took in milliseconds.
     """
 
-    is_async = False
-
     def nav_subtitle(self):
         stats = self.get_stats()
         if hasattr(self, "_start_rusage"):

--- a/debug_toolbar/panels/versions.py
+++ b/debug_toolbar/panels/versions.py
@@ -12,6 +12,8 @@ class VersionsPanel(Panel):
     Shows versions of Python, Django, and installed apps if possible.
     """
 
+    is_async = True
+
     @property
     def nav_subtitle(self):
         return "Django %s" % django.get_version()

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -82,7 +82,7 @@ Problematic Parts
 - Support for async and multi-threading: ``debug_toolbar.middleware.DebugToolbarMiddleware``
   is now async compatible and can process async requests. However certain
   panels such as ``SQLPanel``, ``TimerPanel``,  ``StaticFilesPanel``,
-  ``RequestPanel`` and ``ProfilingPanel`` aren't fully
+  ``RequestPanel``, ``HistoryPanel`` and ``ProfilingPanel`` aren't fully
   compatible and currently being worked on. For now, these panels
   are disabled by default when running in async environment.
   follow the progress of this issue in `Async compatible toolbar project <https://github.com/orgs/jazzband/projects/9>`_.


### PR DESCRIPTION
# Description

Reverting back to logic where we keep `Panel`  `is_async = False` by default.


# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
