### PR TITLE
Async compatible `HistoryPanel`

### DIFF
--- a/debug_toolbar/panels/history/panel.py
+++ b/debug_toolbar/panels/history/panel.py
@@ -16,6 +16,7 @@ from debug_toolbar.panels.history.forms import HistoryStoreForm
 class HistoryPanel(Panel):
     """A panel to display History"""
 
+    is_async = True
     title = _("History")
     nav_title = _("History")
     template = "debug_toolbar/panels/history.html"

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -12,6 +12,7 @@ from typing import OrderedDict
 from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.core.handlers.asgi import ASGIRequest
 from django.dispatch import Signal
 from django.template import TemplateSyntaxError
 from django.template.loader import render_to_string
@@ -106,7 +107,10 @@ class DebugToolbar:
             # incompatible with the toolbar until
             # https://github.com/jazzband/django-debug-toolbar/issues/1430
             # is resolved.
-            render_panels = self.request.META.get("wsgi.multiprocess", True)
+            if isinstance(self.request, ASGIRequest):
+                render_panels = False
+            else:
+                render_panels = self.request.META.get("wsgi.multiprocess", True)
         return render_panels
 
     # Handle storing toolbars in memory and fetching them later on

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -109,6 +109,10 @@ class DebugToolbar:
             if isinstance(self.request, ASGIRequest):
                 render_panels = False
             else:
+                # The wsgi.multiprocess case of being True isn't supported until the 
+                # toolbar has resolved the following issue:
+                # This type of set up is most likely
+                # https://github.com/jazzband/django-debug-toolbar/issues/1430
                 render_panels = self.request.META.get("wsgi.multiprocess", True)
         return render_panels
 

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -109,7 +109,7 @@ class DebugToolbar:
             if isinstance(self.request, ASGIRequest):
                 render_panels = False
             else:
-                # The wsgi.multiprocess case of being True isn't supported until the 
+                # The wsgi.multiprocess case of being True isn't supported until the
                 # toolbar has resolved the following issue:
                 # This type of set up is most likely
                 # https://github.com/jazzband/django-debug-toolbar/issues/1430

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -82,7 +82,7 @@ Problematic Parts
 - Support for async and multi-threading: ``debug_toolbar.middleware.DebugToolbarMiddleware``
   is now async compatible and can process async requests. However certain
   panels such as ``SQLPanel``, ``TimerPanel``,  ``StaticFilesPanel``,
-  ``RequestPanel``, ``HistoryPanel`` and ``ProfilingPanel`` aren't fully
+  ``RequestPanel`` and ``ProfilingPanel`` aren't fully
   compatible and currently being worked on. For now, these panels
   are disabled by default when running in async environment.
   follow the progress of this issue in `Async compatible toolbar project <https://github.com/orgs/jazzband/projects/9>`_.


### PR DESCRIPTION
# Description

adding a special check  on `should_render_panel` method in `DebugToolbar` that bypasses `request.multiprocess` check and  allows rendering at async true

Relevant issues: https://github.com/jazzband/django-debug-toolbar/issues/1413

# Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
