### PR TITLE
Version 5.0.0-alpha

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Here's a screenshot of the toolbar in action:
 In addition to the built-in panels, a number of third-party panels are
 contributed by the community.
 
-The current stable version of the Debug Toolbar is 4.4.6. It works on
+The current stable version of the Debug Toolbar is 5.0.0-alpha. It works on
 Django ≥ 4.2.0.
 
 The Debug Toolbar does not currently support `Django's asynchronous views

--- a/debug_toolbar/__init__.py
+++ b/debug_toolbar/__init__.py
@@ -4,7 +4,7 @@ APP_NAME = "djdt"
 
 # Do not use pkg_resources to find the version but set it here directly!
 # see issue #1446
-VERSION = "4.4.6"
+VERSION = "5.0.0-alpha"
 
 # Code that discovers files or modules in INSTALLED_APPS imports this module.
 urls = "debug_toolbar.urls", APP_NAME

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,12 @@ Change log
 Pending
 -------
 
+5.0.0-alpha (2024-09-01)
+------------------------
+
+* Support async applications, but not concurrent requests from
+  `Google Summer of Code Project 2024
+  <https://summerofcode.withgoogle.com/programs/2024/projects/iXVvyGYp>`__.
 * Added Django 5.1 to the CI matrix.
 * Support select and explain buttons for ``UNION`` queries on PostgreSQL.
 * Fixed internal toolbar requests being instrumented if the Django setting

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,7 +7,7 @@ Pending
 5.0.0-alpha (2024-09-01)
 ------------------------
 
-* Support async applications, but not concurrent requests from
+* Support async applications and ASGI from
   `Google Summer of Code Project 2024
   <https://summerofcode.withgoogle.com/programs/2024/projects/iXVvyGYp>`__.
 * Added Django 5.1 to the CI matrix.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = "{}, Django Debug Toolbar developers and contributors"
 copyright = copyright.format(datetime.date.today().year)
 
 # The full version, including alpha/beta/rc tags
-release = "4.4.6"
+release = "5.0.0-alpha"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
# Description

Bump to version 5.0.0-alpha

Use an alpha version because it's quite the leap to start supporting async. However, there aren't any planned backwards incompatibilities.

# Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
