### PR TITLE
Use Heading-4 for PR template for screen-readers.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Description
+#### Description
 
 Please include a summary of the change and which issue is fixed. Please also
 include relevant motivation and context. Your commit message should include
@@ -6,7 +6,7 @@ this information as well.
 
 Fixes # (issue)
 
-# Checklist:
+#### Checklist:
 
 - [ ] I have added the relevant tests for this change.
 - [ ] I have added an item to the Pending section of ``docs/changes.rst``.


### PR DESCRIPTION
#### Description

To better integrate with GitHub's PR page, our PR template should result in h4 elements rather than h1.

See https://marijkeluttekes.dev/blog/articles/2024/08/19/quick-tip-use-h4-in-github-issue-descriptions/

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
