### PR TITLE
Modernize Python type hints and string formatting

### DIFF
--- a/debug_toolbar/_stubs.py
+++ b/debug_toolbar/_stubs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, List, NamedTuple, Optional, Tuple
 
 from django import template as dj_template

--- a/debug_toolbar/panels/profiling.py
+++ b/debug_toolbar/panels/profiling.py
@@ -59,7 +59,7 @@ class FunctionCall:
             # special case for built-in functions
             name = func_name[2]
             if name.startswith("<") and name.endswith(">"):
-                return "{%s}" % name[1:-1]
+                return f"{{{name[1:-1]}}}"
             else:
                 return name
         else:

--- a/debug_toolbar/panels/sql/forms.py
+++ b/debug_toolbar/panels/sql/forms.py
@@ -44,7 +44,7 @@ class SQLSelectForm(forms.Form):
         value = self.cleaned_data["alias"]
 
         if value not in connections:
-            raise ValidationError("Database alias '%s' not found" % value)
+            raise ValidationError(f"Database alias '{value}' not found")
 
         return value
 

--- a/debug_toolbar/panels/versions.py
+++ b/debug_toolbar/panels/versions.py
@@ -16,7 +16,7 @@ class VersionsPanel(Panel):
 
     @property
     def nav_subtitle(self):
-        return "Django %s" % django.get_version()
+        return f"Django {django.get_version()}"
 
     title = _("Versions")
 

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -218,7 +218,7 @@ def debug_toolbar_urls(prefix="__debug__"):
         return []
     return [
         re_path(
-            r"^%s/" % re.escape(prefix.lstrip("/")),
+            r"^{}/".format(re.escape(prefix.lstrip("/"))),
             include("debug_toolbar.urls"),
         ),
     ]

--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import linecache
 import os.path
@@ -17,7 +19,7 @@ from debug_toolbar import _stubs as stubs, settings as dt_settings
 _local_data = Local()
 
 
-def _is_excluded_frame(frame: Any, excluded_modules: Optional[Sequence[str]]) -> bool:
+def _is_excluded_frame(frame: Any, excluded_modules: Sequence[str] | None) -> bool:
     if not excluded_modules:
         return False
     frame_module = frame.f_globals.get("__name__")
@@ -39,7 +41,7 @@ def _stack_trace_deprecation_warning() -> None:
     )
 
 
-def tidy_stacktrace(stack: List[stubs.InspectStack]) -> stubs.TidyStackTrace:
+def tidy_stacktrace(stack: list[stubs.InspectStack]) -> stubs.TidyStackTrace:
     """
     Clean up stacktrace and remove all entries that are excluded by the
     HIDE_IN_STACKTRACES setting.
@@ -99,7 +101,7 @@ def render_stacktrace(trace: stubs.TidyStackTrace) -> SafeString:
     return mark_safe(html)
 
 
-def get_template_info() -> Optional[Dict[str, Any]]:
+def get_template_info() -> dict[str, Any] | None:
     template_info = None
     cur_frame = sys._getframe().f_back
     try:
@@ -129,7 +131,7 @@ def get_template_info() -> Optional[Dict[str, Any]]:
 
 def get_template_context(
     node: Node, context: stubs.RequestContext, context_lines: int = 3
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     line, source_lines, name = get_template_source_from_exception_info(node, context)
     debug_context = []
     start = max(1, line - context_lines)
@@ -146,7 +148,7 @@ def get_template_context(
 
 def get_template_source_from_exception_info(
     node: Node, context: stubs.RequestContext
-) -> Tuple[int, List[Tuple[int, str]], str]:
+) -> tuple[int, list[tuple[int, str]], str]:
     if context.template.origin == node.origin:
         exception_info = context.template.get_exception_info(
             Exception("DDT"), node.token
@@ -213,8 +215,8 @@ def getframeinfo(frame: Any, context: int = 1) -> inspect.Traceback:
 
 
 def get_sorted_request_variable(
-    variable: Union[Dict[str, Any], QueryDict],
-) -> Dict[str, Union[List[Tuple[str, Any]], Any]]:
+    variable: dict[str, Any] | QueryDict,
+) -> dict[str, list[tuple[str, Any]] | Any]:
     """
     Get a data structure for showing a sorted list of variables from the
     request data.
@@ -228,7 +230,7 @@ def get_sorted_request_variable(
         return {"raw": variable}
 
 
-def get_stack(context=1) -> List[stubs.InspectStack]:
+def get_stack(context=1) -> list[stubs.InspectStack]:
     """
     Get a list of records for a frame and all higher (calling) frames.
 
@@ -286,7 +288,7 @@ class _StackTraceRecorder:
     def get_stack_trace(
         self,
         *,
-        excluded_modules: Optional[Sequence[str]] = None,
+        excluded_modules: Sequence[str] | None = None,
         include_locals: bool = False,
         skip: int = 0,
     ):

--- a/debug_toolbar/utils.py
+++ b/debug_toolbar/utils.py
@@ -6,7 +6,7 @@ import os.path
 import sys
 import warnings
 from pprint import PrettyPrinter, pformat
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Sequence
 
 from asgiref.local import Local
 from django.http import QueryDict

--- a/debug_toolbar/views.py
+++ b/debug_toolbar/views.py
@@ -18,7 +18,7 @@ def render_panel(request):
             "Data for this panel isn't available anymore. "
             "Please reload the page and retry."
         )
-        content = "<p>%s</p>" % escape(content)
+        content = f"<p>{escape(content)}</p>"
         scripts = []
     else:
         panel = toolbar.get_panel_by_id(request.GET["panel_id"])

--- a/tests/base.py
+++ b/tests/base.py
@@ -107,8 +107,8 @@ class BaseMixin:
             msg_parts = ["Invalid HTML:"]
             lines = content.split("\n")
             for position, errorcode, datavars in parser.errors:
-                msg_parts.append("  %s" % html5lib.constants.E[errorcode] % datavars)
-                msg_parts.append("    %s" % lines[position[0] - 1])
+                msg_parts.append(f"  {html5lib.constants.E[errorcode]}" % datavars)
+                msg_parts.append(f"    {lines[position[0] - 1]}")
             raise self.failureException("\n".join(msg_parts))
 
 

--- a/tests/test_csp_rendering.py
+++ b/tests/test_csp_rendering.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, cast
 from xml.etree.ElementTree import Element
 
@@ -12,7 +14,7 @@ from debug_toolbar.toolbar import DebugToolbar
 from .base import IntegrationTestCase
 
 
-def get_namespaces(element: Element) -> Dict[str, str]:
+def get_namespaces(element: Element) -> dict[str, str]:
     """
     Return the default `xmlns`. See
     https://docs.python.org/3/library/xml.etree.elementtree.html#parsing-xml-with-namespaces
@@ -31,7 +33,7 @@ class CspRenderingTestCase(IntegrationTestCase):
         self.parser = HTMLParser()
 
     def _fail_if_missing(
-        self, root: Element, path: str, namespaces: Dict[str, str], nonce: str
+        self, root: Element, path: str, namespaces: dict[str, str], nonce: str
     ):
         """
         Search elements, fail if a `nonce` attribute is missing on them.
@@ -41,7 +43,7 @@ class CspRenderingTestCase(IntegrationTestCase):
             if item.attrib.get("nonce") != nonce:
                 raise self.failureException(f"{item} has no nonce attribute.")
 
-    def _fail_if_found(self, root: Element, path: str, namespaces: Dict[str, str]):
+    def _fail_if_found(self, root: Element, path: str, namespaces: dict[str, str]):
         """
         Search elements, fail if a `nonce` attribute is found on them.
         """
@@ -56,8 +58,8 @@ class CspRenderingTestCase(IntegrationTestCase):
             default_msg = ["Content is invalid HTML:"]
             lines = content.split(b"\n")
             for position, error_code, data_vars in parser.errors:
-                default_msg.append("  %s" % E[error_code] % data_vars)
-                default_msg.append("    %r" % lines[position[0] - 1])
+                default_msg.append(f"  {E[error_code]}" % data_vars)
+                default_msg.append(f"    {lines[position[0] - 1]!r}")
             msg = self._formatMessage(None, "\n".join(default_msg))
             raise self.failureException(msg)
 

--- a/tests/test_csp_rendering.py
+++ b/tests/test_csp_rendering.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, cast
+from typing import cast
 from xml.etree.ElementTree import Element
 
 from django.conf import settings

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -324,8 +324,8 @@ class DebugToolbarIntegrationTestCase(IntegrationTestCase):
             default_msg = ["Content is invalid HTML:"]
             lines = content.split(b"\n")
             for position, errorcode, datavars in parser.errors:
-                default_msg.append("  %s" % html5lib.constants.E[errorcode] % datavars)
-                default_msg.append("    %r" % lines[position[0] - 1])
+                default_msg.append(f"  {html5lib.constants.E[errorcode]}" % datavars)
+                default_msg.append(f"    {lines[position[0] - 1]!r}")
             msg = self._formatMessage(None, "\n".join(default_msg))
             raise self.failureException(msg)
 

--- a/tests/test_integration_async.py
+++ b/tests/test_integration_async.py
@@ -247,8 +247,8 @@ class DebugToolbarIntegrationTestCase(IntegrationTestCase):
             default_msg = ["Content is invalid HTML:"]
             lines = content.split(b"\n")
             for position, errorcode, datavars in parser.errors:
-                default_msg.append("  %s" % html5lib.constants.E[errorcode] % datavars)
-                default_msg.append("    %r" % lines[position[0] - 1])
+                default_msg.append(f"  {html5lib.constants.E[errorcode]}" % datavars)
+                default_msg.append(f"    {lines[position[0] - 1]!r}")
             msg = self._formatMessage(None, "\n".join(default_msg))
             raise self.failureException(msg)
 


### PR DESCRIPTION
#### Description

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. Your commit message should include
this information as well.

Fixes # (issue)

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.

Fixed 19 errors:
- debug_toolbar/utils.py:
    11 × UP006 (non-pep585-annotation)
     5 × UP007 (non-pep604-annotation)
- tests/test_csp_rendering.py:
     3 × UP006 (non-pep585-annotation)

Fixed 25 errors:
- debug_toolbar/panels/profiling.py:
    1 × UP031 (printf-string-formatting)
    1 × UP032 (f-string)
- debug_toolbar/panels/sql/forms.py:
    1 × UP031 (printf-string-formatting)
    1 × UP032 (f-string)
- debug_toolbar/panels/versions.py:
    1 × UP031 (printf-string-formatting)
    1 × UP032 (f-string)
- debug_toolbar/toolbar.py:
    1 × UP031 (printf-string-formatting)
- debug_toolbar/views.py:
    1 × UP031 (printf-string-formatting)
    1 × UP032 (f-string)
- tests/base.py:
    2 × UP031 (printf-string-formatting)
    2 × UP032 (f-string)
- tests/test_csp_rendering.py:
    2 × UP031 (printf-string-formatting)
    2 × UP032 (f-string)
- tests/test_integration.py:
    2 × UP031 (printf-string-formatting)
    2 × UP032 (f-string)
- tests/test_integration_async.py:
    2 × UP031 (printf-string-formatting)
    2 × UP032 (f-string)
