### PR TITLE
Adding in support for Python 3.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,7 @@ jobs:
             - python-version: '3.12'
               database: psycopg3
             - python-version: '3.13'
-              # psycopg installs version 3+; psycopg3 not found via pip in python 3.13
-              database: psycopg
+              database: psycopg3
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     services:
       mariadb:
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         database: [postgresql, postgis]
         # Add psycopg3 to our matrix for modern python versions
         include:
@@ -148,7 +148,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Get pip cache dir
       id: pip-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,8 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        # Skip 3.13 here, it needs the psycopg3 / postgis3 database
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         database: [postgresql, postgis]
         # Add psycopg3 to our matrix for modern python versions
         include:
@@ -85,6 +86,8 @@ jobs:
               database: psycopg3
             - python-version: '3.13'
               database: psycopg3
+            - python-version: '3.13'
+              database: postgis3
 
     services:
       postgres:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     services:
       mariadb:
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         database: [postgresql, postgis]
         # Add psycopg3 to our matrix for modern python versions
         include:
@@ -83,6 +83,9 @@ jobs:
               database: psycopg3
             - python-version: '3.12'
               database: psycopg3
+            - python-version: '3.13'
+              # psycopg installs version 3+; psycopg3 not found via pip in python 3.13
+              database: psycopg
 
     services:
       postgres:
@@ -145,7 +148,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/debug_toolbar/toolbar.py
+++ b/debug_toolbar/toolbar.py
@@ -4,10 +4,8 @@ The main DebugToolbar class that loads and renders the Toolbar.
 
 import re
 import uuid
+from collections import OrderedDict
 from functools import lru_cache
-
-# Can be removed when python3.8 is dropped
-from typing import OrderedDict
 
 from django.apps import apps
 from django.conf import settings

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,6 +4,8 @@ Change log
 Pending
 -------
 
+* Added support for Python 3.13 and to the CI matrix.
+
 5.0.0-alpha (2024-09-01)
 ------------------------
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,8 @@ Change log
 Pending
 -------
 
-* Added support for Python 3.13 and to the CI matrix.
+* Added support for Python 3.13 to the CI matrix.
+* Removed support for Python 3.8 as it is end of life.
 
 5.0.0-alpha (2024-09-01)
 ------------------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,8 +4,8 @@ Change log
 Pending
 -------
 
-* Added support for Python 3.13 to the CI matrix.
-* Removed support for Python 3.8 as it is end of life.
+* Added Python 3.13 to the CI matrix.
+* Removed support for Python 3.8 as it has reached end of life.
 
 5.0.0-alpha (2024-09-01)
 ------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "BSD-3-Clause" }
 authors = [
   { name = "Rob Hudson" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
@@ -25,7 +25,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dynamic = [

--- a/tox.ini
+++ b/tox.ini
@@ -51,56 +51,28 @@ pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
 
-[testenv:py{39,310,311,312}-dj{42,50,51,main}-{postgresql,psycopg3}]
+[testenv:py{39,310,311,312,313}-dj{42,50,51,main}-{postgresql,psycopg3}]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{39,310,311,312}-dj{42,50,51,main}-postgis]
+[testenv:py{39,310,311,312,313}-dj{42,50,51,main}-{postgis,postgis3}]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgis
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{39,310,311,312}-dj{42,50,51,main}-mysql]
+[testenv:py{39,310,311,312,313}-dj{42,50,51,main}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
     DB_PORT = {env:DB_PORT:3306}
 
 
-[testenv:py{39,310,311,312}-dj{42,50,51,main}-sqlite]
-setenv =
-    {[testenv]setenv}
-    DB_BACKEND = sqlite3
-    DB_NAME = ":memory:"
-
-
-[testenv:py313-dj{51,main}-psycopg3]
-setenv =
-    {[testenv]setenv}
-    DB_BACKEND = postgresql
-    DB_PORT = {env:DB_PORT:5432}
-
-
-[testenv:py313-dj{51,main}-postgis3]
-setenv =
-    {[testenv]setenv}
-    DB_BACKEND = postgis
-    DB_PORT = {env:DB_PORT:5432}
-
-
-[testenv:py313-dj{51,main}-mysql]
-setenv =
-    {[testenv]setenv}
-    DB_BACKEND = mysql
-    DB_PORT = {env:DB_PORT:3306}
-
-
-[testenv:py313-dj{51,main}-sqlite]
+[testenv:py{39,310,311,312,313}-dj{42,50,51,main}-sqlite]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ isolated_build = true
 envlist =
     docs
     packaging
-    py{38,39,310,311,312,313}-dj{42}-{sqlite,postgresql,postgis,mysql}
-    py{310,311,312,313}-dj{42,50,51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
+    py{39,310,311,312}-dj{42}-{sqlite,postgresql,postgis,mysql}
+    py{310,311,312}-dj{42,50,51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
+    py{313}-dj{51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
 
 [testenv]
 deps =
@@ -94,7 +95,6 @@ skip_install = true
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
@@ -105,6 +105,7 @@ python =
 DB_BACKEND =
     mysql: mysql
     postgresql: postgresql
+    psycopg: psycopg
     psycopg3: psycopg3
     postgis: postgis
     sqlite3: sqlite

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     packaging
     py{39,310,311,312}-dj{42}-{sqlite,postgresql,postgis,mysql}
     py{310,311,312}-dj{42,50,51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
-    py{313}-dj{51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
+    py{313}-dj{51,main}-{sqlite,psycopg3,mysql}
 
 [testenv]
 deps =
@@ -16,6 +16,7 @@ deps =
     postgresql: psycopg2-binary
     psycopg3: psycopg[binary]
     postgis: psycopg2-binary
+    postgis3: psycopg[binary]
     mysql: mysqlclient
     coverage[toml]
     Jinja2
@@ -50,32 +51,61 @@ pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
 
-[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-{postgresql,psycopg3}]
+[testenv:py{39,310,311,312}-dj{42,50,51,main}-{postgresql,psycopg3}]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-postgis]
+[testenv:py{39,310,311,312}-dj{42,50,51,main}-postgis]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgis
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-mysql]
+[testenv:py{39,310,311,312}-dj{42,50,51,main}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
     DB_PORT = {env:DB_PORT:3306}
 
 
-[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-sqlite]
+[testenv:py{39,310,311,312}-dj{42,50,51,main}-sqlite]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3
     DB_NAME = ":memory:"
+
+
+[testenv:py313-dj{51,main}-psycopg3]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = postgresql
+    DB_PORT = {env:DB_PORT:5432}
+
+
+[testenv:py313-dj{51,main}-postgis3]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = postgis
+    DB_PORT = {env:DB_PORT:5432}
+
+
+[testenv:py313-dj{51,main}-mysql]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = mysql
+    DB_PORT = {env:DB_PORT:3306}
+
+
+[testenv:py313-dj{51,main}-sqlite]
+setenv =
+    {[testenv]setenv}
+    DB_BACKEND = sqlite3
+    DB_NAME = ":memory:"
+
 
 [testenv:docs]
 commands = make -C {toxinidir}/docs {posargs:spelling}
@@ -105,7 +135,7 @@ python =
 DB_BACKEND =
     mysql: mysql
     postgresql: postgresql
-    psycopg: psycopg
     psycopg3: psycopg3
     postgis: postgis
+    postgis3: postgis3
     sqlite3: sqlite

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ isolated_build = true
 envlist =
     docs
     packaging
-    py{38,39,310,311,312}-dj{42}-{sqlite,postgresql,postgis,mysql}
-    py{310,311,312}-dj{42,50,51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
+    py{38,39,310,311,312,313}-dj{42}-{sqlite,postgresql,postgis,mysql}
+    py{310,311,312,313}-dj{42,50,51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
 
 [testenv]
 deps =
@@ -49,28 +49,28 @@ pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
 
-[testenv:py{38,39,310,311,312}-dj{42,50,51,main}-{postgresql,psycopg3}]
+[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-{postgresql,psycopg3}]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{38,39,310,311,312}-dj{42,50,51,main}-postgis]
+[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-postgis]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgis
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{38,39,310,311,312}-dj{42,50,51,main}-mysql]
+[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
     DB_PORT = {env:DB_PORT:3306}
 
 
-[testenv:py{38,39,310,311,312}-dj{42,50,51,main}-sqlite]
+[testenv:py{38,39,310,311,312,313}-dj{42,50,51,main}-sqlite]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3
@@ -99,6 +99,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DB_BACKEND =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     packaging
     py{39,310,311,312}-dj{42}-{sqlite,postgresql,postgis,mysql}
     py{310,311,312}-dj{42,50,51,main}-{sqlite,postgresql,psycopg3,postgis,mysql}
-    py{313}-dj{51,main}-{sqlite,psycopg3,mysql}
+    py{313}-dj{51,main}-{sqlite,psycopg3,postgis3,mysql}
 
 [testenv]
 deps =


### PR DESCRIPTION
#### Description

This adds support for Python 3.13. I _think_ I've got all the references, but there's probably somewhere else that I've overlooked.

Shout-out to London Django Meetup for the Hacktoberfest Hackathon inspiration. CC @adamchainz et al.

#### Testing notes

I ran this under docker (python:3.13-slim) locally and `make test` and `make coverage` passed all the tests. Would have also tried with a virtualenv but pyenv didn't have 3.13 (non-RC) at the time of testing.

#### Checklist:

- [ x ] I have added the relevant tests for this change.
- [ x ] I have added an item to the Pending section of ``docs/changes.rst``.
