### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: file-contents-sorter
         files: docs/spelling_wordlist.txt
 -   repo: https://github.com/pycqa/doc8
-    rev: v1.1.2
+    rev: v2.0.0
     hooks:
     -   id: doc8
 -   repo: https://github.com/adamchainz/django-upgrade
@@ -29,12 +29,12 @@ repos:
     -   id: rst-backticks
     -   id: rst-directive-colons
 -   repo: https://github.com/biomejs/pre-commit
-    rev: v2.0.0-beta.5
+    rev: v2.0.6
     hooks:
       - id: biome-check
         verbose: true
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.11.12'
+    rev: 'v0.12.2'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.0.0-beta.5/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
     "formatter": {
         "enabled": true,
         "useEditorconfig": true
@@ -15,34 +15,8 @@
         "enabled": true,
         "rules": {
             "recommended": true,
-            "style": {
-                "useLiteralEnumMembers": "error",
-                "noCommaOperator": "error",
-                "useNodejsImportProtocol": "error",
-                "useAsConstAssertion": "error",
-                "useEnumInitializers": "error",
-                "useSelfClosingElements": "error",
-                "useConst": "error",
-                "useSingleVarDeclarator": "error",
-                "noUnusedTemplateLiteral": "error",
-                "useNumberNamespace": "error",
-                "noInferrableTypes": "error",
-                "useExponentiationOperator": "error",
-                "useTemplate": "error",
-                "noParameterAssign": "error",
-                "noNonNullAssertion": "error",
-                "useDefaultParameterLast": "error",
-                "noArguments": "error",
-                "useImportType": "error",
-                "useExportType": "error",
-                "noUselessElse": "error",
-                "useShorthandFunctionType": "error"
-            },
             "suspicious": {
                 "noDocumentCookie": "off"
-            },
-            "complexity": {
-                "useNumericLiterals": "error"
             }
         }
     },

--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -1,9 +1,10 @@
 /* Variable definitions */
 :root {
     /* Font families are the same as in Django admin/css/base.css */
-    --djdt-font-family-primary: "Segoe UI", system-ui, Roboto, "Helvetica Neue",
-        Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-        "Segoe UI Symbol", "Noto Color Emoji";
+    --djdt-font-family-primary:
+        "Segoe UI", system-ui, Roboto, "Helvetica Neue", Arial, sans-serif,
+        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+        "Noto Color Emoji";
     --djdt-font-family-monospace:
         ui-monospace, Menlo, Monaco, "Cascadia Mono",
         "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace",


### PR DESCRIPTION
Also, go back to the recommended ruleset of biome instead of raising the level of rules; those were all introduced by automatically migrating the biome configuration, not by explicit choice.
