### PR TITLE
Update the transifex link for the project.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -155,7 +155,7 @@ Translations
 ------------
 
 Translation efforts are coordinated on `Transifex
-<https://www.transifex.com/projects/p/django-debug-toolbar/>`_.
+<https://explore.transifex.com/django-debug-toolbar/django-debug-toolbar/>`_.
 
 Help translate the Debug Toolbar in your language!
 


### PR DESCRIPTION
Transifex is used for translations. At some point they changed their URL structure and we missed it.

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
