### PR TITLE
Use double-quotes for GITHUB_REF_NAME shell variable.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: >-
         gh release create
-        '${GITHUB_REF_NAME}'
+        "${GITHUB_REF_NAME}"
         --repo '${{ github.repository }}'
         --notes ""
     - name: Upload artifact signatures to GitHub Release
@@ -94,7 +94,7 @@ jobs:
       # sigstore-produced signatures and certificates.
       run: >-
         gh release upload
-        '${GITHUB_REF_NAME}' dist/**
+        "${GITHUB_REF_NAME}" dist/**
         --repo '${{ github.repository }}'
 
   publish-to-testpypi:


### PR DESCRIPTION
This properly expands it.

#### Description

Follow-up to #2201

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
