### PR TITLE
Add Django 6.0 to testing matrix

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,4 +1,4 @@
-import asyncio
+import sys
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
@@ -6,6 +6,11 @@ from django.http import HttpResponse
 from django.test import AsyncRequestFactory, RequestFactory, TestCase, override_settings
 
 from debug_toolbar.middleware import DebugToolbarMiddleware
+
+if sys.version_info >= (3, 12):
+    from inspect import iscoroutinefunction
+else:
+    from asyncio import iscoroutinefunction
 
 
 def show_toolbar_if_staff(request):
@@ -35,7 +40,7 @@ class MiddlewareSyncAsyncCompatibilityTestCase(TestCase):
             lambda x: HttpResponse("<html><body>Test app</body></html>")
         )
 
-        self.assertFalse(asyncio.iscoroutinefunction(middleware))
+        self.assertFalse(iscoroutinefunction(middleware))
 
         response = middleware(request)
         self.assertEqual(response.status_code, 200)
@@ -54,7 +59,7 @@ class MiddlewareSyncAsyncCompatibilityTestCase(TestCase):
         middleware = DebugToolbarMiddleware(get_response)
         request = self.async_factory.get("/")
 
-        self.assertTrue(asyncio.iscoroutinefunction(middleware))
+        self.assertTrue(iscoroutinefunction(middleware))
 
         response = await middleware(request)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
#### Description

Fix these warnings seen in the Python 3.14 test run:

```
test middleware switches to async (__acall__) based on get_response type ... /home/runner/work/django-debug-toolbar/django-debug-toolbar/tests/test_middleware.py:57: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
  self.assertTrue(asyncio.iscoroutinefunction(middleware))

test middleware switches to sync (__call__) based on get_response type ... /home/runner/work/django-debug-toolbar/django-debug-toolbar/tests/test_middleware.py:38: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
  self.assertFalse(asyncio.iscoroutinefunction(middleware))
```

[`inspect.iscoroutinefunction()`](https://docs.python.org/3/library/inspect.html#inspect.iscoroutinefunction) has always been the public API, since Python 3.5, though we need `markcoroutine()` support, which was added in Python 3.12.

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
