### PR TITLE
Persist the credentials because coverage_comment needs them.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,7 +290,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          # Persist the credentials because coverage_comment needs them too.
+          persist-credentials: true
 
       - uses: actions/download-artifact@v4
         id: download


### PR DESCRIPTION
#### Description

This is a follow-up to #2245

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
