### PR TITLE
Remove Django 5.0 to save some CI resources

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,7 +7,8 @@ Pending
 * Deprecated ``RedirectsPanel`` in favor of ``HistoryPanel`` for viewing
   toolbar data from redirected requests.
 * Fixed support for generating code coverage comments in PRs.
-* Added Django 6.0 to the testing matrix.
+* Added Django 6.0 to the testing matrix. Removed Django 5.0 to save CI
+  resources.
 * Show the cache backend alias and cache backend class name instead of
   the cache instance in the cache panel.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Environment :: Web Environment",
   "Framework :: Django",
   "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
   "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,14 @@ envlist =
     docs
     packaging
     py{39,310,311,312}-dj{42}-{sqlite,postgresql,postgis,mysql}
-    py{310,311}-dj{42,50,51,52}-{sqlite,postgresql,psycopg3,postgis,mysql}
-    py{312}-dj{42,50,51,52,60}-{sqlite,postgresql,psycopg3,postgis,mysql}
+    py{310,311}-dj{42,51,52}-{sqlite,postgresql,psycopg3,postgis,mysql}
+    py{312}-dj{42,51,52,60}-{sqlite,postgresql,psycopg3,postgis,mysql}
     py{313}-dj{51,52,60,main}-{sqlite,psycopg3,postgis3,mysql}
     py{314}-dj{52,60,main}-{sqlite,psycopg3,postgis3,mysql}
 
 [testenv]
 deps =
     dj42: django~=4.2.1
-    dj50: django~=5.0.2
     dj51: django~=5.1.0
     dj52: django~=5.2.0a1
     dj60: django~=6.0a1
@@ -56,28 +55,28 @@ pip_pre = True
 commands = python -b -W always -m coverage run -m django test -v2 {posargs:tests}
 
 
-[testenv:py{39,310,311,312,313,314}-dj{42,50,51,52,60,main}-{postgresql,psycopg3}]
+[testenv:py{39,310,311,312,313,314}-dj{42,51,52,60,main}-{postgresql,psycopg3}]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgresql
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{39,310,311,312,313,314}-dj{42,50,51,52,60,main}-{postgis,postgis3}]
+[testenv:py{39,310,311,312,313,314}-dj{42,51,52,60,main}-{postgis,postgis3}]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = postgis
     DB_PORT = {env:DB_PORT:5432}
 
 
-[testenv:py{39,310,311,312,313,314}-dj{42,50,51,52,60,main}-mysql]
+[testenv:py{39,310,311,312,313,314}-dj{42,51,52,60,main}-mysql]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = mysql
     DB_PORT = {env:DB_PORT:3306}
 
 
-[testenv:py{39,310,311,312,313,314}-dj{42,50,51,52,60,main}-sqlite]
+[testenv:py{39,310,311,312,313,314}-dj{42,51,52,60,main}-sqlite]
 setenv =
     {[testenv]setenv}
     DB_BACKEND = sqlite3


### PR DESCRIPTION
We have now added Django 6.0 to the CI. Let's remove 5.0, it's not maintained anymore.