### PR TITLE
Enforce toolbar vs panel organization of configs.

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -23,11 +23,16 @@ CONFIG_DEFAULTS = {
         "debug_toolbar.panels.redirects.RedirectsPanel",
     },
     "INSERT_BEFORE": "</body>",
+    "IS_RUNNING_TESTS": _is_running_tests(),
+    "OBSERVE_REQUEST_CALLBACK": "debug_toolbar.toolbar.observe_request",
     "RENDER_PANELS": None,
     "RESULTS_CACHE_SIZE": 25,
     "ROOT_TAG_EXTRA_ATTRS": "",
     "SHOW_COLLAPSED": False,
     "SHOW_TOOLBAR_CALLBACK": "debug_toolbar.middleware.show_toolbar",
+    "TOOLBAR_LANGUAGE": None,
+    "TOOLBAR_STORE_CLASS": "debug_toolbar.store.MemoryStore",
+    "UPDATE_ON_FETCH": False,
     # Panel options
     "EXTRA_SIGNALS": [],
     "ENABLE_STACKTRACES": True,
@@ -52,11 +57,6 @@ CONFIG_DEFAULTS = {
     "SKIP_TEMPLATE_PREFIXES": ("django/forms/widgets/", "admin/widgets/"),
     "SKIP_TOOLBAR_QUERIES": True,
     "SQL_WARNING_THRESHOLD": 500,  # milliseconds
-    "OBSERVE_REQUEST_CALLBACK": "debug_toolbar.toolbar.observe_request",
-    "TOOLBAR_LANGUAGE": None,
-    "TOOLBAR_STORE_CLASS": "debug_toolbar.store.MemoryStore",
-    "IS_RUNNING_TESTS": _is_running_tests(),
-    "UPDATE_ON_FETCH": False,
 }
 
 


### PR DESCRIPTION

#### Description

This enforces our organization of toolbar configs first and the panel specific configs second.

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
