### PR TITLE
Restore monospace font for templates and stacktraces

### DIFF
--- a/debug_toolbar/static/debug_toolbar/css/toolbar.css
+++ b/debug_toolbar/static/debug_toolbar/css/toolbar.css
@@ -325,6 +325,10 @@
     margin-bottom: 3px;
 }
 
+#djDebug pre span {
+    font-family: var(--djdt-font-family-monospace);
+}
+
 #djDebug .djdt-panelContent {
     position: fixed;
     margin: 0;

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -14,6 +14,7 @@ Pending
 * Dropped support for the Python 3.9, it has reached its end of life date.
 * Toggle tracking the toolbar's queries when using
   ``debug_toolbar.store.DatabaseStore`` with ``SKIP_TOOLBAR_QUERIES``.
+* Fixed font family for code blocks and stack traces in the toolbar.
 
 6.1.0 (2025-10-30)
 ------------------


### PR DESCRIPTION
#### Stacktraces:

<img width="1291" height="231" alt="Captura de pantalla 2025-11-21 a la(s) 8 54 28 a  m" src="https://github.com/user-attachments/assets/ea8910f6-6fc2-47a8-b7f7-0f7a6da84324" />

<hr>

#### Template code:

<img width="1291" height="300" alt="Captura de pantalla 2025-11-21 a la(s) 8 54 39 a  m" src="https://github.com/user-attachments/assets/fbd5a290-cb1b-42f1-a7e5-219912f53f5e" />


#### Description

The font-family declared for span tags was overriding the monospace font defined for text inside pre tags.

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

