### PR TITLE
Fix string representation of values in settings panel

### DIFF
--- a/debug_toolbar/panels/settings.py
+++ b/debug_toolbar/panels/settings.py
@@ -1,10 +1,18 @@
+from pprint import pformat
+
 from django.utils.translation import gettext_lazy as _
 from django.views.debug import get_default_exception_reporter_filter
 
 from debug_toolbar.panels import Panel
-from debug_toolbar.sanitize import force_str
 
 get_safe_settings = get_default_exception_reporter_filter().get_safe_settings
+
+
+def safe_pformat(obj):
+    try:
+        return pformat(obj)
+    except Exception as e:
+        return f"<unformattable {type(obj).__name__}: {e!r}>"
 
 
 class SettingsPanel(Panel):
@@ -27,7 +35,7 @@ class SettingsPanel(Panel):
         self.record_stats(
             {
                 "settings": {
-                    key: force_str(value)
+                    key: safe_pformat(value)
                     for key, value in sorted(get_safe_settings().items())
                 }
             }

--- a/debug_toolbar/templates/debug_toolbar/panels/settings.html
+++ b/debug_toolbar/templates/debug_toolbar/panels/settings.html
@@ -10,7 +10,7 @@
     {% for name, value in settings.items %}
       <tr>
         <td>{{ name }}</td>
-        <td><code>{{ value|pprint }}</code></td>
+        <td><code>{{ value }}</code></td>
       </tr>
     {% endfor %}
   </tbody>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,7 @@ Pending
   ``debug_toolbar.store.DatabaseStore`` with ``SKIP_TOOLBAR_QUERIES``.
 * Fixed font family for code blocks and stack traces in the toolbar.
 * Added test to confirm Django's ``TestCase.assertNumQueries`` works.
+* Fixed string representation of values in settings panel.
 
 6.1.0 (2025-10-30)
 ------------------

--- a/tests/panels/test_settings.py
+++ b/tests/panels/test_settings.py
@@ -1,6 +1,25 @@
-from django.test import override_settings
+from django.test import RequestFactory, override_settings
 
-from ..base import IntegrationTestCase
+from debug_toolbar.panels.settings import SettingsPanel
+
+from ..base import BaseTestCase, IntegrationTestCase
+
+rf = RequestFactory()
+
+
+class SettingsPanelTestCase(BaseTestCase):
+    panel_id = SettingsPanel.panel_id
+
+    def test_panel_recording(self):
+        self.request = rf.post("/", data={"foo": "bar"})
+        response = self.panel.process_request(self.request)
+        self.panel.generate_stats(self.request, response)
+
+        settings = self.panel.get_stats()["settings"]
+        self.assertEqual(settings["USE_THOUSAND_SEPARATOR"], "False")
+        self.assertEqual(settings["ABSOLUTE_URL_OVERRIDES"], "{}")
+        self.assertEqual(settings["EMAIL_HOST"], "'localhost'")
+        self.assertEqual(settings["EMAIL_PORT"], "25")
 
 
 @override_settings(DEBUG=True)


### PR DESCRIPTION
#### Description

There was some weird double quoting going on in the settings panel values column. This fixes the formatting so it's more consistent and clearly distinguishes string from non-string values. Added some tests for the new behavior.

#### Before

<img width="1292" height="860" alt="Captura de pantalla 2025-11-21 a la(s) 9 07 48 p  m" src="https://github.com/user-attachments/assets/2b3f5cbf-266a-40c1-a540-b0e1a74048b1" />

#### After

<img width="1290" height="858" alt="Captura de pantalla 2025-11-21 a la(s) 8 43 21 p  m" src="https://github.com/user-attachments/assets/358af44a-7440-4516-8aab-972c147d6c2c" />

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
