### PR TITLE
Set a dependabot cooldown.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
#### Description

From Zizmor docs:
> By default, Dependabot does not perform any cooldown on dependency updates. In other words, a regularly scheduled Dependabot run may perform an update on a dependency that was just released moments before the run began. This presents both stability and supply-chain security risks

Source: https://docs.zizmor.sh/audits/#dependabot-cooldown

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.
