### PR TITLE
Declare support for Django 6.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,7 @@ Pending
 * Fixed font family for code blocks and stack traces in the toolbar.
 * Added test to confirm Django's ``TestCase.assertNumQueries`` works.
 * Fixed string representation of values in settings panel.
+* Declared support for Django 6.0.
 
 6.1.0 (2025-10-30)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     dj42: django~=4.2.1
     dj51: django~=5.1.0
     dj52: django~=5.2.0a1
-    dj60: django~=6.0a1
+    dj60: django~=6.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     postgresql: psycopg2-binary
     psycopg3: psycopg[binary]


### PR DESCRIPTION
#### Description

https://www.djangoproject.com/weblog/2025/dec/03/django-60-released/ 🎈 

Follows up:
- https://github.com/django-commons/django-debug-toolbar/pull/2249
- https://github.com/django-commons/django-debug-toolbar/pull/2251

Declare Django 6.0 support

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.
