### PR TITLE
Remove comment for clarity in `DebugToolbarMiddleware` call method

### DIFF
--- a/debug_toolbar/middleware.py
+++ b/debug_toolbar/middleware.py
@@ -126,9 +126,9 @@ class DebugToolbarMiddleware:
             markcoroutinefunction(self)
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
-        # Decide whether the toolbar is active for this request.
         if self.async_mode:
             return self.__acall__(request)
+
         # Decide whether the toolbar is active for this request.
         show_toolbar = get_show_toolbar(async_mode=self.async_mode)
 


### PR DESCRIPTION
#### Description

Based on how the discussion in the issue unfolds, I decided to propose a trivial change to remove single line of comment inside `DebugToolbarMiddleware.__call__`.

I've also added a space on the branching between `__acall__` and `get_show_toolbar` call.

Fixes #2281 

#### Checklist:

- [ ] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.

_(I don't think this change need tests nor an extra item in the Pending listing)_