### PR TITLE
Optimize CI with concurrency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
     # Run weekly on Saturday
     - cron: '37 3 * * SAT'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION

I added a concurrency group to the `test.yml` workflow to make it more efficient.

-It ensures that only the latest commit on a branch is running. 
-If a new push is made while an old one is still going, the old run will automatically cancel. 
-This helps us save GitHub Actions minutes and keeps our PRs clean.