### PR TITLE
Add `CacheStore`, a store that uses Django's cache framework

### DIFF
--- a/debug_toolbar/settings.py
+++ b/debug_toolbar/settings.py
@@ -18,6 +18,8 @@ def _is_running_tests():
 
 CONFIG_DEFAULTS = {
     # Toolbar options
+    "CACHE_BACKEND": "default",
+    "CACHE_KEY_PREFIX": "djdt:",
     "DISABLE_PANELS": {
         "debug_toolbar.panels.profiling.ProfilingPanel",
         "debug_toolbar.panels.redirects.RedirectsPanel",

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -68,9 +68,13 @@ the store ID. This is so that the toolbar can load the collected metrics
 for that particular request.
 
 The history panel allows a user to view the metrics for any request since
-the application was started. The toolbar maintains its state entirely in
-memory for the process running ``runserver``. If the application is
-restarted the toolbar will lose its state.
+the application was started. By default, the toolbar maintains its state
+entirely in memory (``MemoryStore``) for the process running ``runserver``.
+If the application is restarted the toolbar will lose its state. To persist
+data across restarts, configure ``TOOLBAR_STORE_CLASS`` to use
+``DatabaseStore`` or ``CacheStore``. See the
+:ref:`TOOLBAR_STORE_CLASS <TOOLBAR_STORE_CLASS>` configuration option for
+details.
 
 Problematic Parts
 -----------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,12 @@ Pending
   ensure the latest static assets are used.
 * Fixed bug with ``CachePanel`` so the cache patching is only applied
   once.
+* Added ``debug_toolbar.store.CacheStore`` for storing toolbar data using
+  Django's cache framework. This provides persistence without requiring
+  database migrations, and works with any cache backend (Memcached, Redis,
+  database, file-based, etc.).
+* Added ``CACHE_BACKEND`` and ``CACHE_KEY_PREFIX`` settings to configure the
+  ``CacheStore``.
 
 6.2.0 (2026-01-20)
 ------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -53,6 +53,43 @@ toolbar itself, others are specific to some panels.
 Toolbar options
 ~~~~~~~~~~~~~~~
 
+* ``CACHE_BACKEND``
+
+  Default: ``"default"``
+
+  The alias of the Django cache backend to use when
+  :ref:`TOOLBAR_STORE_CLASS <TOOLBAR_STORE_CLASS>` is set to
+  ``debug_toolbar.store.CacheStore``. This should match one of the keys in
+  your :setting:`CACHES` setting.
+
+  Using a dedicated cache backend for the toolbar is recommended in
+  production-like environments to avoid evicting application cache entries:
+
+  .. code-block:: python
+
+      CACHES = {
+          "default": {
+              "BACKEND": "django.core.cache.backends.redis.RedisCache",
+              "LOCATION": "redis://127.0.0.1:6379",
+          },
+          "debug-toolbar": {
+              "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+          },
+      }
+
+      DEBUG_TOOLBAR_CONFIG = {
+          "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+          "CACHE_BACKEND": "debug-toolbar",
+      }
+
+* ``CACHE_KEY_PREFIX``
+
+  Default: ``"djdt:"``
+
+  A prefix applied to all cache keys used by the ``CacheStore``. This
+  prevents collisions with other cache entries when sharing a cache
+  backend with the rest of your application.
+
 * ``DISABLE_PANELS``
 
   Default:
@@ -190,22 +227,30 @@ Toolbar options
 
   Available store classes:
 
-  * ``debug_toolbar.store.MemoryStore`` - Stores data in memory
-  * ``debug_toolbar.store.DatabaseStore`` - Stores data in the database
+  * ``debug_toolbar.store.MemoryStore`` - Stores data in memory. This is the
+    default and requires no additional configuration. Data is lost when the
+    server restarts.
+  * ``debug_toolbar.store.DatabaseStore`` - Stores data in the database.
+    Requires running migrations (see below).
+  * ``debug_toolbar.store.CacheStore`` - Stores data using Django's cache
+    framework. Works with any cache backend (Memcached, Redis, database,
+    file-based, etc.). See ``CACHE_BACKEND`` and ``CACHE_KEY_PREFIX`` below
+    for configuration options.
 
-  The DatabaseStore provides persistence and automatically cleans up old
-  entries based on the ``RESULTS_CACHE_SIZE`` setting.
+  The ``DatabaseStore`` and ``CacheStore`` both provide persistence across
+  server restarts and automatically clean up old entries based on the
+  ``RESULTS_CACHE_SIZE`` setting.
 
-  Note: When using ``DatabaseStore`` migrations are required for
+  Note: When using ``DatabaseStore``, migrations are required for
   the ``debug_toolbar`` app:
 
   .. code-block:: bash
 
       python manage.py migrate debug_toolbar
 
-  For the ``DatabaseStore`` to work properly, you need to run migrations for the
-  ``debug_toolbar`` app. The migrations create the necessary database table to store
-  toolbar data.
+  The toolbar's own cache and SQL operations are automatically hidden from
+  the cache and SQL panels when using ``CacheStore``, so you won't see the
+  toolbar's internal bookkeeping in the collected metrics.
 
 .. _TOOLBAR_LANGUAGE:
 
@@ -418,12 +463,20 @@ Here's what a slightly customized toolbar configuration might look like::
         'SQL_WARNING_THRESHOLD': 100,   # milliseconds
     }
 
-Here's an example of using a persistent store to keep debug data between server
+Here's an example of using the database store to keep debug data between server
 restarts::
 
     DEBUG_TOOLBAR_CONFIG = {
-        'TOOLBAR_STORE_CLASS': 'debug_toolbar.store.DatabaseStore',
-        'RESULTS_CACHE_SIZE': 100,  # Store up to 100 requests
+        "TOOLBAR_STORE_CLASS": "debug_toolbar.store.DatabaseStore",
+        "RESULTS_CACHE_SIZE": 100,  # Store up to 100 requests
+    }
+
+Here's an example of using the cache store, which provides persistence without
+requiring migrations::
+
+    DEBUG_TOOLBAR_CONFIG = {
+        "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+        "CACHE_BACKEND": "default",  # Or a dedicated cache alias
     }
 
 Theming support

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,10 +1,14 @@
 import uuid
 
-from django.test import TestCase
-from django.test.utils import override_settings
+from django.core.management import call_command
+from django.db import connection
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils.safestring import SafeData, mark_safe
 
 from debug_toolbar import store
+from debug_toolbar.toolbar import DebugToolbar
 
 
 class SerializationTestCase(TestCase):
@@ -50,59 +54,102 @@ class BaseStoreTestCase(TestCase):
             store.BaseStore.panel("", "")
 
 
-class MemoryStoreTestCase(TestCase):
+class CommonStoreTestsMixin:
+    """
+    Mixin class with common tests that apply to all store implementations.
+    Subclasses must set self.store to the appropriate store class.
+    Subclasses can override _get_request_id() to provide appropriate ID types.
+    """
+
+    def _get_request_id(self, name: str) -> str:
+        """
+        Generate a request ID for testing.
+        """
+        return name
+
+    def test_ids(self):
+        foo_id = self._get_request_id("foo")
+        bar_id = self._get_request_id("bar")
+        self.store.set(foo_id)
+        self.store.set(bar_id)
+        request_ids = {str(id) for id in self.store.request_ids()}
+        self.assertEqual(request_ids, {str(foo_id), str(bar_id)})
+
+    def test_exists(self):
+        missing_id = self._get_request_id("missing")
+        exists_id = self._get_request_id("exists")
+        self.assertFalse(self.store.exists(missing_id))
+        self.store.set(exists_id)
+        self.assertTrue(self.store.exists(exists_id))
+
+    def test_set(self):
+        foo_id = self._get_request_id("foo")
+        self.store.set(foo_id)
+        self.assertTrue(self.store.exists(foo_id))
+
+    def test_set_max_size(self):
+        foo_id = self._get_request_id("foo")
+        bar_id = self._get_request_id("bar")
+        with self.settings(DEBUG_TOOLBAR_CONFIG={"RESULTS_CACHE_SIZE": 1}):
+            self.store.save_panel(foo_id, "foo.panel", "foo.value")
+            self.store.save_panel(bar_id, "bar.panel", {"a": 1})
+            request_ids = [str(id) for id in self.store.request_ids()]
+            self.assertEqual(len(request_ids), 1)
+            self.assertIn(str(bar_id), request_ids)
+            self.assertEqual(self.store.panel(foo_id, "foo.panel"), {})
+            self.assertEqual(self.store.panel(bar_id, "bar.panel"), {"a": 1})
+
+    def test_clear(self):
+        bar_id = self._get_request_id("bar")
+        self.store.save_panel(bar_id, "bar.panel", {"a": 1})
+        self.store.clear()
+        self.assertEqual(list(self.store.request_ids()), [])
+        self.assertEqual(self.store.panel(bar_id, "bar.panel"), {})
+
+    def test_delete(self):
+        bar_id = self._get_request_id("bar")
+        self.store.save_panel(bar_id, "bar.panel", {"a": 1})
+        self.store.delete(bar_id)
+        self.assertEqual(list(self.store.request_ids()), [])
+        self.assertEqual(self.store.panel(bar_id, "bar.panel"), {})
+        # Make sure it doesn't error
+        self.store.delete(bar_id)
+
+    def test_save_panel(self):
+        bar_id = self._get_request_id("bar")
+        self.store.save_panel(bar_id, "bar.panel", {"a": 1})
+        self.assertTrue(self.store.exists(bar_id))
+        self.assertEqual(self.store.panel(bar_id, "bar.panel"), {"a": 1})
+
+    def test_panel(self):
+        missing_id = self._get_request_id("missing")
+        bar_id = self._get_request_id("bar")
+        self.assertEqual(self.store.panel(missing_id, "missing"), {})
+        self.store.save_panel(bar_id, "bar.panel", {"a": 1})
+        self.assertEqual(self.store.panel(bar_id, "bar.panel"), {"a": 1})
+
+    def test_panels(self):
+        bar_id = self._get_request_id("bar")
+        self.store.save_panel(bar_id, "panel1", {"a": 1})
+        self.store.save_panel(bar_id, "panel2", {"b": 2})
+        panels = dict(self.store.panels(bar_id))
+        self.assertEqual(len(panels), 2)
+        self.assertEqual(panels["panel1"], {"a": 1})
+        self.assertEqual(panels["panel2"], {"b": 2})
+
+    def test_panels_nonexistent_request(self):
+        missing_id = self._get_request_id("missing")
+        panels = dict(self.store.panels(missing_id))
+        self.assertEqual(panels, {})
+
+
+class MemoryStoreTestCase(CommonStoreTestsMixin, TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.store = store.MemoryStore
 
     def tearDown(self) -> None:
         self.store.clear()
-
-    def test_ids(self):
-        self.store.set("foo")
-        self.store.set("bar")
-        self.assertEqual(list(self.store.request_ids()), ["foo", "bar"])
-
-    def test_exists(self):
-        self.assertFalse(self.store.exists("missing"))
-        self.store.set("exists")
-        self.assertTrue(self.store.exists("exists"))
-
-    def test_set(self):
-        self.store.set("foo")
-        self.assertEqual(list(self.store.request_ids()), ["foo"])
-
-    def test_set_max_size(self):
-        with self.settings(DEBUG_TOOLBAR_CONFIG={"RESULTS_CACHE_SIZE": 1}):
-            self.store.save_panel("foo", "foo.panel", "foo.value")
-            self.store.save_panel("bar", "bar.panel", {"a": 1})
-            self.assertEqual(list(self.store.request_ids()), ["bar"])
-            self.assertEqual(self.store.panel("foo", "foo.panel"), {})
-            self.assertEqual(self.store.panel("bar", "bar.panel"), {"a": 1})
-
-    def test_clear(self):
-        self.store.save_panel("bar", "bar.panel", {"a": 1})
-        self.store.clear()
-        self.assertEqual(list(self.store.request_ids()), [])
-        self.assertEqual(self.store.panel("bar", "bar.panel"), {})
-
-    def test_delete(self):
-        self.store.save_panel("bar", "bar.panel", {"a": 1})
-        self.store.delete("bar")
-        self.assertEqual(list(self.store.request_ids()), [])
-        self.assertEqual(self.store.panel("bar", "bar.panel"), {})
-        # Make sure it doesn't error
-        self.store.delete("bar")
-
-    def test_save_panel(self):
-        self.store.save_panel("bar", "bar.panel", {"a": 1})
-        self.assertEqual(list(self.store.request_ids()), ["bar"])
-        self.assertEqual(self.store.panel("bar", "bar.panel"), {"a": 1})
-
-    def test_panel(self):
-        self.assertEqual(self.store.panel("missing", "missing"), {})
-        self.store.save_panel("bar", "bar.panel", {"a": 1})
-        self.assertEqual(self.store.panel("bar", "bar.panel"), {"a": 1})
 
     def test_serialize_safestring(self):
         before = {"string": mark_safe("safe")}
@@ -135,36 +182,29 @@ class GetStoreTestCase(TestCase):
 @override_settings(
     DEBUG_TOOLBAR_CONFIG={"TOOLBAR_STORE_CLASS": "debug_toolbar.store.DatabaseStore"}
 )
-class DatabaseStoreTestCase(TestCase):
+class DatabaseStoreTestCase(CommonStoreTestsMixin, TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.store = store.DatabaseStore
 
+    def setUp(self) -> None:
+        # Cache UUIDs so the same name returns the same UUID within a test
+        self._uuid_cache = {}
+
     def tearDown(self) -> None:
         self.store.clear()
 
-    def test_ids(self):
-        id1 = str(uuid.uuid4())
-        id2 = str(uuid.uuid4())
-        self.store.set(id1)
-        self.store.set(id2)
-        # Convert the UUIDs to strings for comparison
-        request_ids = {str(id) for id in self.store.request_ids()}
-        self.assertEqual(request_ids, {id1, id2})
-
-    def test_exists(self):
-        missing_id = str(uuid.uuid4())
-        self.assertFalse(self.store.exists(missing_id))
-        id1 = str(uuid.uuid4())
-        self.store.set(id1)
-        self.assertTrue(self.store.exists(id1))
-
-    def test_set(self):
-        id1 = str(uuid.uuid4())
-        self.store.set(id1)
-        self.assertTrue(self.store.exists(id1))
+    def _get_request_id(self, name: str) -> str:
+        """Generate a UUID for DatabaseStore tests, cached by name."""
+        if name not in self._uuid_cache:
+            self._uuid_cache[name] = str(uuid.uuid4())
+        return self._uuid_cache[name]
 
     def test_set_max_size(self):
+        """
+        DatabaseStore test for max size using set() instead of save_panel().
+        The cleanup logic is triggered by set(), not save_panel().
+        """
         with self.settings(DEBUG_TOOLBAR_CONFIG={"RESULTS_CACHE_SIZE": 1}):
             # Clear any existing entries first
             self.store.clear()
@@ -180,33 +220,10 @@ class DatabaseStoreTestCase(TestCase):
             id2 = str(uuid.uuid4())
             self.store.set(id2)
 
-            # Verify only the bar entry exists now
-            # Convert the UUIDs to strings for comparison
+            # Verify only the second entry exists now
             request_ids = {str(id) for id in self.store.request_ids()}
             self.assertEqual(request_ids, {id2})
             self.assertFalse(self.store.exists(id1))
-
-    def test_clear(self):
-        id1 = str(uuid.uuid4())
-        self.store.save_panel(id1, "bar.panel", {"a": 1})
-        self.store.clear()
-        self.assertEqual(list(self.store.request_ids()), [])
-        self.assertEqual(self.store.panel(id1, "bar.panel"), {})
-
-    def test_delete(self):
-        id1 = str(uuid.uuid4())
-        self.store.save_panel(id1, "bar.panel", {"a": 1})
-        self.store.delete(id1)
-        self.assertEqual(list(self.store.request_ids()), [])
-        self.assertEqual(self.store.panel(id1, "bar.panel"), {})
-        # Make sure it doesn't error
-        self.store.delete(id1)
-
-    def test_save_panel(self):
-        id1 = str(uuid.uuid4())
-        self.store.save_panel(id1, "bar.panel", {"a": 1})
-        self.assertTrue(self.store.exists(id1))
-        self.assertEqual(self.store.panel(id1, "bar.panel"), {"a": 1})
 
     def test_update_panel(self):
         id1 = str(uuid.uuid4())
@@ -216,27 +233,6 @@ class DatabaseStoreTestCase(TestCase):
         # Update the panel
         self.store.save_panel(id1, "test.panel", {"updated": True})
         self.assertEqual(self.store.panel(id1, "test.panel"), {"updated": True})
-
-    def test_panels_nonexistent_request(self):
-        missing_id = str(uuid.uuid4())
-        panels = dict(self.store.panels(missing_id))
-        self.assertEqual(panels, {})
-
-    def test_panel(self):
-        id1 = str(uuid.uuid4())
-        missing_id = str(uuid.uuid4())
-        self.assertEqual(self.store.panel(missing_id, "missing"), {})
-        self.store.save_panel(id1, "bar.panel", {"a": 1})
-        self.assertEqual(self.store.panel(id1, "bar.panel"), {"a": 1})
-
-    def test_panels(self):
-        id1 = str(uuid.uuid4())
-        self.store.save_panel(id1, "panel1", {"a": 1})
-        self.store.save_panel(id1, "panel2", {"b": 2})
-        panels = dict(self.store.panels(id1))
-        self.assertEqual(len(panels), 2)
-        self.assertEqual(panels["panel1"], {"a": 1})
-        self.assertEqual(panels["panel2"], {"b": 2})
 
     def test_cleanup_old_entries(self):
         # Create multiple entries
@@ -251,3 +247,242 @@ class DatabaseStoreTestCase(TestCase):
 
             # Check that only the most recent 2 entries remain
             self.assertEqual(len(list(self.store.request_ids())), 2)
+
+    def test_database_queries_are_efficient(self):
+        """Verify that DatabaseStore uses efficient database queries."""
+        id1 = str(uuid.uuid4())
+
+        # Test that panel retrieval uses a single query
+        self.store.save_panel(id1, "test.panel", {"data": "value"})
+        with CaptureQueriesContext(connection) as context:
+            self.store.panel(id1, "test.panel")
+        self.assertEqual(len(context.captured_queries), 1)
+
+        # Test that panels() uses a single query
+        self.store.save_panel(id1, "panel2", {"data": "value2"})
+        with CaptureQueriesContext(connection) as context:
+            list(self.store.panels(id1))
+        self.assertEqual(len(context.captured_queries), 1)
+
+        # Test that exists() uses a single query
+        with CaptureQueriesContext(connection) as context:
+            self.store.exists(id1)
+        self.assertEqual(len(context.captured_queries), 1)
+
+
+@override_settings(
+    DEBUG_TOOLBAR_CONFIG={
+        "CACHES": {
+            "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        },
+        "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+    }
+)
+class CacheStoreWithMemoryBackendTestCase(CommonStoreTestsMixin, TestCase):
+    """
+    Test CacheStore with LocMemCache backend (in-memory caching).
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.store = store.CacheStore
+
+    def tearDown(self) -> None:
+        self.store.clear()
+
+    def test_custom_cache_backend(self):
+        with self.settings(
+            DEBUG_TOOLBAR_CONFIG={
+                "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+                "CACHE_BACKEND": "default",
+            }
+        ):
+            self.store.save_panel("test", "test.panel", {"value": 123})
+            self.assertEqual(self.store.panel("test", "test.panel"), {"value": 123})
+
+    def test_custom_key_prefix(self):
+        with self.settings(
+            DEBUG_TOOLBAR_CONFIG={
+                "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+                "CACHE_KEY_PREFIX": "custom:",
+            }
+        ):
+            # Verify the key prefix is used
+            self.assertEqual(self.store._key_prefix(), "custom:")
+            self.assertEqual(self.store._request_ids_key(), "custom:request_ids")
+            self.assertEqual(self.store._request_key("test"), "custom:req:test")
+
+    def test_cache_store_operations_not_tracked_by_cache_panel(self):
+        """Verify that CacheStore operations don't appear in CachePanel data."""
+        # Set up a toolbar with CachePanel
+        request = RequestFactory().get("/")
+        toolbar = DebugToolbar(request, lambda req: HttpResponse())
+        panel = toolbar.get_panel_by_id("CachePanel")
+        panel.enable_instrumentation()
+
+        try:
+            # Record the initial number of cache calls
+            initial_call_count = len(panel.calls)
+
+            # Perform various CacheStore operations
+            self.store.set("test_req")
+            self.store.save_panel("test_req", "test.panel", {"data": "value"})
+            self.store.exists("test_req")
+            self.store.panel("test_req", "test.panel")
+            self.store.panels("test_req")
+            self.store.delete("test_req")
+
+            # Verify that no cache operations were recorded
+            # All CacheStore operations should be invisible to the CachePanel
+            self.assertEqual(
+                len(panel.calls),
+                initial_call_count,
+                "CacheStore operations should not be tracked by CachePanel",
+            )
+        finally:
+            panel.disable_instrumentation()
+
+
+@override_settings(
+    DEBUG_TOOLBAR_CONFIG={
+        "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+        "CACHE_BACKEND": "ddt_db_cache",
+    },
+    CACHES={
+        "ddt_db_cache": {
+            "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+            "LOCATION": "test_cache_store_table",
+        }
+    },
+)
+class CacheStoreWithDatabaseBackendTestCase(CommonStoreTestsMixin, TestCase):
+    """
+    Test CacheStore with DatabaseCache backend.
+    This ensures CacheStore works correctly when using database-backed caching.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create the database cache table
+        call_command("createcachetable", "test_cache_store_table", verbosity=0)
+        cls.store = store.CacheStore
+
+    @classmethod
+    def tearDownClass(cls):
+        # Drop the cache table
+        with connection.cursor() as cursor:
+            cursor.execute("DROP TABLE IF EXISTS test_cache_store_table")
+        super().tearDownClass()
+
+    def tearDown(self) -> None:
+        self.store.clear()
+
+    def test_set_max_size(self):
+        """Override to preserve cache backend settings."""
+        foo_id = self._get_request_id("foo")
+        bar_id = self._get_request_id("bar")
+        with self.settings(
+            DEBUG_TOOLBAR_CONFIG={
+                "RESULTS_CACHE_SIZE": 1,
+                "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+                "CACHE_BACKEND": "ddt_db_cache",
+            }
+        ):
+            self.store.save_panel(foo_id, "foo.panel", "foo.value")
+            self.store.save_panel(bar_id, "bar.panel", {"a": 1})
+            request_ids = [str(id) for id in self.store.request_ids()]
+            self.assertEqual(len(request_ids), 1)
+            self.assertIn(str(bar_id), request_ids)
+            self.assertEqual(self.store.panel(foo_id, "foo.panel"), {})
+            self.assertEqual(self.store.panel(bar_id, "bar.panel"), {"a": 1})
+
+    def test_database_backend_not_tracked_by_sql_panel(self):
+        """
+        Verify that CacheStore operations using DatabaseCache backend
+        don't appear in SQLPanel data.
+
+        The _UntrackedCache wrapper prevents CachePanel tracking by setting
+        cache._djdt_panel = None. Additionally, SQL queries to the cache table
+        are filtered out because the cache table is dynamically added to
+        DDT_MODELS when CacheStore is configured with DatabaseCache.
+        """
+        # Set up a toolbar with SQLPanel
+        request = RequestFactory().get("/")
+        toolbar = DebugToolbar(request, lambda req: HttpResponse())
+        sql_panel = toolbar.get_panel_by_id("SQLPanel")
+        sql_panel.enable_instrumentation()
+
+        try:
+            # Record the initial number of SQL queries
+            initial_query_count = len(sql_panel._queries)
+
+            # Perform various CacheStore operations that will trigger DatabaseCache SQL queries
+            self.store.set("test_req")
+            self.store.save_panel("test_req", "test.panel", {"data": "value"})
+            self.store.exists("test_req")
+            self.store.panel("test_req", "test.panel")
+            self.store.panels("test_req")
+            self.store.delete("test_req")
+
+            # Verify that no SQL queries to the cache table were recorded
+            # All CacheStore DatabaseCache operations should be invisible to the SQLPanel
+            cache_queries = [
+                q
+                for q in sql_panel._queries[initial_query_count:]
+                if "test_cache_store_table" in q.get("sql", "").lower()
+            ]
+
+            self.assertEqual(
+                len(cache_queries),
+                0,
+                f"CacheStore DatabaseCache operations should not be tracked by SQLPanel, "
+                f"but found {len(cache_queries)} queries to 'test_cache_store_table' table",
+            )
+        finally:
+            sql_panel.disable_instrumentation()
+
+    @override_settings(
+        DEBUG_TOOLBAR_CONFIG={
+            "TOOLBAR_STORE_CLASS": "debug_toolbar.store.CacheStore",
+            "CACHE_BACKEND": "ddt_db_cache",
+            "SKIP_TOOLBAR_QUERIES": False,
+        },
+    )
+    def test_database_backend_can_be_tracked_by_sql_panel(self):
+        """
+        Verify that CacheStore operations using DatabaseCache backend
+        can appear in SQLPanel data.
+
+        When SKIP_TOOLBAR_QUERIES is False, the SqlPanel should show the
+        queries being made to the cache table.
+        """
+        # Set up a toolbar with SQLPanel
+        request = RequestFactory().get("/")
+        toolbar = DebugToolbar(request, lambda req: HttpResponse())
+        sql_panel = toolbar.get_panel_by_id("SQLPanel")
+        sql_panel.enable_instrumentation()
+
+        try:
+            # Record the initial number of SQL queries
+            initial_query_count = len(sql_panel._queries)
+
+            # Perform various CacheStore operations that will trigger DatabaseCache SQL queries
+            self.store.set("test_req")
+
+            # Verify that no SQL queries to the cache table were recorded
+            # All CacheStore DatabaseCache operations should be invisible to the SQLPanel
+            cache_queries = [
+                q
+                for q in sql_panel._queries[initial_query_count:]
+                if "test_cache_store_table" in q.get("sql", "").lower()
+            ]
+
+            self.assertEqual(
+                len(cache_queries),
+                4,
+                f"CacheStore DatabaseCache operations be tracked by SQLPanel, "
+                f"but found {len(cache_queries)} queries to 'test_cache_store_table' table",
+            )
+        finally:
+            sql_panel.disable_instrumentation()


### PR DESCRIPTION
Summary

- Adds a new `CacheStore` that uses Django's cache framework to persist toolbar data
- Adds `CACHE_BACKEND` and `CACHE_KEY_PREFIX` settings to configure which cache and key prefix to use
- Toolbar's own cache operations are excluded from the cache panel via an `_UntrackedCache` proxy

Motivation

By using Django's cache framework, users can choose any configured cache backend for toolbar storage. The interesting thing about this is that the `LocMemCache` backend can effectively act like the `MemoryStore`, and the `DatabaseCache` backend can effectively act like the `DatabaseStore`.

Notes

* I haven't tested all the backends (e.g. `FileBasedCache`)
* I haven't tested this on a real project with real database usage patterns


#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [x] This PR includes code generated with the help of an AI/LLM
- [x] I have reviewed / edited this code thoroughly
