### PR TITLE
Fix #2292: Gracefully handle SQLParseError in SQL formatting

### DIFF
--- a/debug_toolbar/panels/sql/utils.py
+++ b/debug_toolbar/panels/sql/utils.py
@@ -5,7 +5,7 @@ from itertools import cycle
 import sqlparse
 from django.dispatch import receiver
 from django.test.signals import setting_changed
-from sqlparse import tokens as T, exceptions as sqlparse_exceptions
+from sqlparse import tokens as T
 
 from debug_toolbar import settings as dt_settings
 
@@ -94,24 +94,25 @@ def is_select_query(sql):
 
 def reformat_sql(sql, *, with_toggle=False):
     import logging
+
     logger = logging.getLogger(__name__)
-    
+
     # Try to format the full SQL
     try:
         formatted = parse_sql(sql)
     except (sqlparse.exceptions.SQLParseError, RecursionError) as e:
         logger.warning(f"Failed to format SQL query: {e}")
         formatted = f"-- SQL formatting failed (query too large)\n{sql}"
-    
+
     if not with_toggle:
         return formatted
-    
+
     try:
         simplified = parse_sql(sql, simplify=True)
     except (sqlparse.exceptions.SQLParseError, RecursionError) as e:
         logger.warning(f"Failed to simplify SQL query: {e}")
         simplified = f"-- Simplified formatting failed\n{sql}"
-    
+
     uncollapsed = f'<span class="djDebugUncollapsed">{simplified}</span>'
     collapsed = f'<span class="djDebugCollapsed djdt-hidden">{formatted}</span>'
     return collapsed + uncollapsed

--- a/tests/test_sql_large_query.py
+++ b/tests/test_sql_large_query.py
@@ -1,12 +1,14 @@
 import pytest
+
 from debug_toolbar.panels.sql.utils import reformat_sql
+
 
 def test_reformat_sql_with_huge_in_clause():
     """Test that huge IN clauses don't cause crashes"""
     # Create a SQL with a huge IN clause (5000 items)
     items = [f"'{i}'" for i in range(5000)]
     sql = f"SELECT * FROM table WHERE id IN ({','.join(items)})"
-    
+
     # This should not raise an exception
     try:
         result = reformat_sql(sql, with_toggle=False)
@@ -15,23 +17,25 @@ def test_reformat_sql_with_huge_in_clause():
     except Exception as e:
         pytest.fail(f"reformat_sql raised {type(e).__name__}: {e}")
 
+
 def test_reformat_sql_with_toggle_and_huge_in_clause():
     """Test with_toggle=True with huge IN clause"""
     items = [f"'{i}'" for i in range(5000)]
     sql = f"SELECT * FROM table WHERE id IN ({','.join(items)})"
-    
+
     try:
         result = reformat_sql(sql, with_toggle=True)
         assert isinstance(result, str)
-        assert 'djDebugUncollapsed' in result
-        assert 'djDebugCollapsed' in result
+        assert "djDebugUncollapsed" in result
+        assert "djDebugCollapsed" in result
     except Exception as e:
         pytest.fail(f"reformat_sql (with_toggle) raised {type(e).__name__}: {e}")
+
 
 def test_reformat_sql_with_invalid_sql():
     """Test that invalid SQL is handled gracefully"""
     sql = "SELECT * FROM WHERE"  # Invalid SQL
-    
+
     result = reformat_sql(sql, with_toggle=False)
     assert isinstance(result, str)
     # Should either contain the SQL or an error message


### PR DESCRIPTION
#### Description

This PR adds graceful error handling to SQL formatting when queries contain large IN clauses (5000+ items). 

When formatting SQL queries with huge IN clauses:
- **sqlparse >= 0.5.5**: Raises `SQLParseError` → SQL panel crashes with 500 error
- **sqlparse < 0.5.5**: Causes 10-18 second freeze → poor UX

The solution wraps `parse_sql()` calls in try/except blocks, catches `SQLParseError` and `RecursionError`, and returns a user-friendly message with the original SQL when formatting fails.

Fixes #2292

#### Checklist:

- [x] I have added the relevant tests for this change.
- [ ] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
