### PR TITLE
Fix #2207: Replace JSONField with compressed TextField

### DIFF
--- a/debug_toolbar/fields.py
+++ b/debug_toolbar/fields.py
@@ -1,41 +1,43 @@
 import json
 import zlib
+
 from django.db import models
+
 
 class CompressedJSONField(models.BinaryField):
     """
     Custom BinaryField that automatically compresses JSON data.
-    
+
     Stores data as compressed binary instead of text to save space
     and avoid PostgreSQL JSONB size limitations.
     """
-    
+
     description = "Compressed JSON data"
-    
+
     def from_db_value(self, value, expression, connection):
         """Convert from database value to Python object."""
         if value is None:
             return {}
-        
+
         try:
-            json_str = zlib.decompress(value).decode('utf-8')
+            json_str = zlib.decompress(value).decode("utf-8")
             return json.loads(json_str)
         except (zlib.error, UnicodeDecodeError, json.JSONDecodeError):
             try:
                 if isinstance(value, bytes):
-                    return json.loads(value.decode('utf-8'))
+                    return json.loads(value.decode("utf-8"))
                 return {}
             except (UnicodeDecodeError, json.JSONDecodeError):
                 return {}
-    
+
     def get_prep_value(self, value):
         """Convert Python object to database value."""
         if value is None:
             value = {}
-    
+
         json_str = json.dumps(value)
-        return zlib.compress(json_str.encode('utf-8'), level=6)
-    
+        return zlib.compress(json_str.encode("utf-8"), level=6)
+
     def value_to_string(self, obj):
         """Convert to string for serialization."""
         value = self.value_from_object(obj)

--- a/debug_toolbar/migrations/0002_switch_to_compressed_binary_field.py
+++ b/debug_toolbar/migrations/0002_switch_to_compressed_binary_field.py
@@ -1,11 +1,13 @@
 import json
-import zlib
-from django.db import migrations, models
+
+from django.db import migrations
+
 import debug_toolbar.fields
+
 
 def convert_to_binary(apps, schema_editor):
     """Convert existing text data to binary format."""
-    HistoryEntry = apps.get_model('debug_toolbar', 'HistoryEntry')
+    HistoryEntry = apps.get_model("debug_toolbar", "HistoryEntry")
     for entry in HistoryEntry.objects.all():
         if entry.data:
             try:
@@ -21,15 +23,16 @@ def convert_to_binary(apps, schema_editor):
                 # If not valid JSON, skip
                 pass
 
+
 class Migration(migrations.Migration):
     dependencies = [
-        ('debug_toolbar', '0001_initial'),
+        ("debug_toolbar", "0001_initial"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='historyentry',
-            name='data',
+            model_name="historyentry",
+            name="data",
             field=debug_toolbar.fields.CompressedJSONField(default=dict),
         ),
         migrations.RunPython(convert_to_binary, migrations.RunPython.noop),

--- a/debug_toolbar/models.py
+++ b/debug_toolbar/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
 from .fields import CompressedJSONField
 
 

--- a/debug_toolbar/store.py
+++ b/debug_toolbar/store.py
@@ -145,10 +145,9 @@ class DatabaseStore(BaseStore):
         Enforce the cache size limit - keeping only the most recently used entries
         up to RESULTS_CACHE_SIZE.
         """
-       
+
         keep_ids = cls.request_ids()
 
-       
         if keep_ids:
             HistoryEntry.objects.exclude(request_id__in=keep_ids).delete()
 
@@ -169,10 +168,8 @@ class DatabaseStore(BaseStore):
     def set(cls, request_id: str):
         """Set a request_id in the store and clean up old entries"""
         with transaction.atomic():
-            
             _, created = HistoryEntry.objects.get_or_create(request_id=request_id)
 
-            
             if created:
                 cls._cleanup_old_entries()
 
@@ -189,15 +186,14 @@ class DatabaseStore(BaseStore):
     @classmethod
     def save_panel(cls, request_id: str, panel_id: str, data: Any = None):
         """Save the panel data for the given request_id with compression"""
-        
+
         with transaction.atomic():
             obj, created = HistoryEntry.objects.get_or_create(request_id=request_id)
-        
+
             store_data = obj.data
-        
-        
+
             store_data[panel_id] = serialize(data)
-        
+
             obj.data = store_data
             obj.save()
 
@@ -206,7 +202,7 @@ class DatabaseStore(BaseStore):
         """Fetch the panel data for the given request_id"""
         try:
             obj = HistoryEntry.objects.get(request_id=request_id)
-        
+
             data = obj.data
             panel_data = data.get(panel_id)
             if panel_data is None:
@@ -226,6 +222,7 @@ class DatabaseStore(BaseStore):
                 yield panel_id, deserialize(panel_data)
         except HistoryEntry.DoesNotExist:
             return {}
+
 
 def get_store() -> BaseStore:
     return import_string(dt_settings.get_config()["TOOLBAR_STORE_CLASS"])

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,15 +1,15 @@
+import json
 import uuid
 
+import pytest
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.safestring import SafeData, mark_safe
 
 from debug_toolbar import store
-import pytest
-import json
-import uuid
 from debug_toolbar.models import HistoryEntry
 from debug_toolbar.store import DatabaseStore, get_store
+
 
 class SerializationTestCase(TestCase):
     def test_serialize(self):
@@ -257,12 +257,9 @@ class DatabaseStoreTestCase(TestCase):
             self.assertEqual(len(list(self.store.request_ids())), 2)
 
 
-
-
-
 class CompressedJSONFieldTestCase(TestCase):
     """Test the CompressedJSONField functionality."""
-    
+
     def test_compress_decompress_cycle(self):
         """Test that data survives compression/decompression."""
         original = {"key": "value", "nested": {"data": [1, 2, 3]}}
@@ -274,11 +271,9 @@ class CompressedJSONFieldTestCase(TestCase):
         """Test reading old JSONField data (JSON string)."""
         old_data = {"test": True}
         entry = HistoryEntry.objects.create(
-            request_id=uuid.uuid4(),
-            data=json.dumps(old_data)
+            request_id=uuid.uuid4(), data=json.dumps(old_data)
         )
         entry.refresh_from_db()
-        
 
         if isinstance(entry.data, str):
             self.assertEqual(json.loads(entry.data), old_data)
@@ -300,8 +295,7 @@ class CompressedJSONFieldTestCase(TestCase):
     def test_malformed_data_fallback(self):
         """Test fallback when data is malformed."""
         entry = HistoryEntry.objects.create(
-            request_id=uuid.uuid4(),
-            data="this is not valid JSON"
+            request_id=uuid.uuid4(), data="this is not valid JSON"
         )
         entry.refresh_from_db()
         self.assertEqual(entry.data, "this is not valid JSON")
@@ -310,38 +304,37 @@ class CompressedJSONFieldTestCase(TestCase):
 @pytest.mark.django_db
 class TestDatabaseStoreCompression:
     """Test DatabaseStore works with compressed data."""
-    
+
     def test_save_and_retrieve_with_compression(self):
         """Test basic save/retrieve with compression."""
         store = DatabaseStore()
         request_id = uuid.uuid4()
         panel_id = "SQLPanel"
         data = {"queries": [{"sql": "SELECT 1"}]}
-        
+
         store.save_panel(request_id, panel_id, data)
         retrieved = store.panel(request_id, panel_id)
-        
+
         assert retrieved == data
 
         obj = HistoryEntry.objects.get(request_id=request_id)
         assert obj.data != json.dumps({panel_id: data})
-    
+
     def test_large_data_compression(self):
         """Test that large data is compressed."""
         store = DatabaseStore()
         request_id = uuid.uuid4()
         panel_id = "SQLPanel"
-        
-        
+
         large_data = {
             "queries": [{"sql": "x" * 5000, "duration": i} for i in range(1000)]
         }
-        
+
         store.save_panel(request_id, panel_id, large_data)
         retrieved = store.panel(request_id, panel_id)
-        
+
         assert retrieved == large_data
-      
+
         obj = HistoryEntry.objects.get(request_id=request_id)
         raw_json = json.dumps({panel_id: large_data})
         assert len(obj.data) < len(raw_json)
@@ -350,35 +343,32 @@ class TestDatabaseStoreCompression:
 @pytest.mark.django_db
 class TestStoreIntegration:
     """Test integration with the actual store implementation."""
-    
+
     def test_get_store_function(self):
         """Test that get_store() returns a working store."""
         store = get_store()
-       
+
         assert store is not None
-    
+
     def test_store_respects_cache_size(self, settings):
         """Test that RESULTS_CACHE_SIZE is respected."""
         from django.conf import settings as django_settings
+
         from debug_toolbar import settings as dt_settings
-        
-        
+
         django_settings.DEBUG_TOOLBAR_CONFIG = {"RESULTS_CACHE_SIZE": 2}
-        
-        
-        dt_settings._config = None  
-        
+
+        dt_settings._config = None
+
         store = DatabaseStore()
-        
-        
+
         req1 = uuid.uuid4()
         req2 = uuid.uuid4()
         req3 = uuid.uuid4()
-        
+
         store.save_panel(req1, "SQLPanel", {})
         store.save_panel(req2, "SQLPanel", {})
         store.save_panel(req3, "SQLPanel", {})
-        
-        
+
         request_ids = store.request_ids()
-        assert len(request_ids) <= 3  
+        assert len(request_ids) <= 3


### PR DESCRIPTION
## Description
Replace JSONField with a custom CompressedJSONField to avoid PostgreSQL JSONB size limitations.

Fixes #2207


