### PR TITLE
Prevent check from erroring when `ROOT_URLCONF` is not defined

### DIFF
--- a/debug_toolbar/apps.py
+++ b/debug_toolbar/apps.py
@@ -249,12 +249,17 @@ def debug_toolbar_installed_when_running_tests_check(app_configs, **kwargs):
         dt_settings.get_config()["SHOW_TOOLBAR_CALLBACK"]
         != CONFIG_DEFAULTS["SHOW_TOOLBAR_CALLBACK"]
     )
-    try:
-        # Check if the toolbar's urls are installed
-        reverse(f"{APP_NAME}:render_panel")
-        toolbar_urls_installed = True
-    except NoReverseMatch:
+
+    if not hasattr(settings, "ROOT_URLCONF"):
+        # reverse will raise AttributeError if ROOT_URLCONF is not defined
         toolbar_urls_installed = False
+    else:
+        try:
+            # Check if the toolbar's urls are installed
+            reverse(f"{APP_NAME}:render_panel")
+            toolbar_urls_installed = True
+        except NoReverseMatch:
+            toolbar_urls_installed = False
 
     # If the user is using the default SHOW_TOOLBAR_CALLBACK,
     # then the middleware will respect the change to settings.DEBUG.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,7 @@ Change log
 
 Pending
 -------
+* Prevent check from failing when ``ROOT_URLCONF`` is not defined.
 
 6.3.0 (2026-04-01)
 ------------------


### PR DESCRIPTION
#### Description

The check `debug_toolbar_installed_when_running_tests_check` checks if the toolbar's URLs are installed by calling `reverse`. This can cause issues when `ROOT_URLCONF` is not defined. In this case, `reverse` will throw an `AttributeError`. The check should ignore this error, since if there is no `ROOT_URLCONF` then it means `toolbar_urls_installed` should be false.

This comes into play when you're using separate settings files for things like management commands, where it's not necessary to define a `ROOT_URLCONF`.

For reference, the exception in Django gets raised from [this line](https://github.com/django/django/blob/6f030e8e5d13ee94bf45d4322c17ca7c2d8aaffb/django/urls/resolvers.py#L110).

#### Checklist:

- [x] I have added the relevant tests for this change.
- [x] I have added an item to the Pending section of ``docs/changes.rst``.

#### AI/LLM Usage
- [ ] This PR includes code generated with the help of an AI/LLM
